### PR TITLE
Now JqGrid support if you changing JqGrid default values in JavaScript.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ ipch/
 *.psess
 *.vsp
 *.vspx
+\.vs/
 
 # Guidance Automation Toolkit
 *.gpState

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JQueryUIWidgetsDefaults.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JQueryUIWidgetsDefaults.cs
@@ -1,38 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-    /// <summary>
-    /// Contains default options values for jQuery UI widgets integrations. 
-    /// </summary>
-    public static class JQueryUIWidgetsDefaults
-    {
-        /// <summary>
-        /// The icon class (form UI theme icons) for Spinner down button.
-        /// </summary>
-        public const string SpinnerDownIcon = "ui-icon-triangle-1-s";
+	/// <summary>
+	/// Contains default options values for jQuery UI widgets integrations. 
+	/// </summary>
+	public static class JQueryUIWidgetsDefaults
+	{
+		/// <summary>
+		/// The icon class (form UI theme icons) for Spinner down button.
+		/// </summary>
+		public const string SpinnerDownIcon = "ui-icon-triangle-1-s";
 
-        /// <summary>
-        /// The icon class (form UI theme icons) for Spinner up button.
-        /// </summary>
-        public const string SpinnerUpIcon = "ui-icon-triangle-1-n";
+		/// <summary>
+		/// The icon class (form UI theme icons) for Spinner up button.
+		/// </summary>
+		public const string SpinnerUpIcon = "ui-icon-triangle-1-n";
 
-        /// <summary>
-        /// The format for parsed and displayed dates in Datepicker.
-        /// </summary>
-        public const string DatepickerDateFormat = "m/d/yy";
+		/// <summary>
+		/// The format for parsed and displayed dates in Datepicker.
+		/// </summary>
+		public const string DatepickerDateFormat = "m/d/yy";
 
-        /// <summary>
-        /// The cutoff year for determining the century for a date in Datepicker.
-        /// </summary>
-        public const string DatepickerShortYearCutoff = "+10";
+		/// <summary>
+		/// The cutoff year for determining the century for a date in Datepicker.
+		/// </summary>
+		public const string DatepickerShortYearCutoff = "+10";
 
-        /// <summary>
-        /// The range of years displayed in the Datepicker year dropdown.
-        /// </summary>
-        public const string DatepickerYearRange = "c-10:c+10";
-    }
+		/// <summary>
+		/// The range of years displayed in the Datepicker year dropdown.
+		/// </summary>
+		public const string DatepickerYearRange = "c-10:c+10";
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JQueryUIWidgetsDefaults.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JQueryUIWidgetsDefaults.cs
@@ -1,33 +1,33 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-	/// <summary>
-	/// Contains default options values for jQuery UI widgets integrations. 
-	/// </summary>
-	public static class JQueryUIWidgetsDefaults
-	{
-		/// <summary>
-		/// The icon class (form UI theme icons) for Spinner down button.
-		/// </summary>
-		public const string SpinnerDownIcon = "ui-icon-triangle-1-s";
+    /// <summary>
+    /// Contains default options values for jQuery UI widgets integrations. 
+    /// </summary>
+    public static class JQueryUIWidgetsDefaults
+    {
+        /// <summary>
+        /// The icon class (form UI theme icons) for Spinner down button.
+        /// </summary>
+        public const string SpinnerDownIcon = "ui-icon-triangle-1-s";
 
-		/// <summary>
-		/// The icon class (form UI theme icons) for Spinner up button.
-		/// </summary>
-		public const string SpinnerUpIcon = "ui-icon-triangle-1-n";
+        /// <summary>
+        /// The icon class (form UI theme icons) for Spinner up button.
+        /// </summary>
+        public const string SpinnerUpIcon = "ui-icon-triangle-1-n";
 
-		/// <summary>
-		/// The format for parsed and displayed dates in Datepicker.
-		/// </summary>
-		public const string DatepickerDateFormat = "m/d/yy";
+        /// <summary>
+        /// The format for parsed and displayed dates in Datepicker.
+        /// </summary>
+        public const string DatepickerDateFormat = "m/d/yy";
 
-		/// <summary>
-		/// The cutoff year for determining the century for a date in Datepicker.
-		/// </summary>
-		public const string DatepickerShortYearCutoff = "+10";
+        /// <summary>
+        /// The cutoff year for determining the century for a date in Datepicker.
+        /// </summary>
+        public const string DatepickerShortYearCutoff = "+10";
 
-		/// <summary>
-		/// The range of years displayed in the Datepicker year dropdown.
-		/// </summary>
-		public const string DatepickerYearRange = "c-10:c+10";
-	}
+        /// <summary>
+        /// The range of years displayed in the Datepicker year dropdown.
+        /// </summary>
+        public const string DatepickerYearRange = "c-10:c+10";
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridColumnPredefinedFormatters.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridColumnPredefinedFormatters.cs
@@ -1,61 +1,61 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-	/// <summary>
-	/// Contains predefined jqGrid formatters names, delimited with ''
-	/// </summary>
-	public static class JqGridColumnPredefinedFormatters
-	{
-		/// <summary>
-		/// Predefined integer formatter.
-		/// </summary>
-		public const string Integer = "'integer'";
+    /// <summary>
+    /// Contains predefined jqGrid formatters names, delimited with ''
+    /// </summary>
+    public static class JqGridColumnPredefinedFormatters
+    {
+        /// <summary>
+        /// Predefined integer formatter.
+        /// </summary>
+        public const string Integer = "'integer'";
 
-		/// <summary>
-		/// Predefined number formatter.
-		/// </summary>
-		public const string Number = "'number'";
+        /// <summary>
+        /// Predefined number formatter.
+        /// </summary>
+        public const string Number = "'number'";
 
-		/// <summary>
-		/// Predefined currency formatter.
-		/// </summary>
-		public const string Currency = "'currency'";
+        /// <summary>
+        /// Predefined currency formatter.
+        /// </summary>
+        public const string Currency = "'currency'";
 
-		/// <summary>
-		/// Predefined date formatter.
-		/// </summary>
-		public const string Date = "'date'";
+        /// <summary>
+        /// Predefined date formatter.
+        /// </summary>
+        public const string Date = "'date'";
 
-		/// <summary>
-		/// Predefined email formatter.
-		/// </summary>
-		public const string Email = "'email'";
+        /// <summary>
+        /// Predefined email formatter.
+        /// </summary>
+        public const string Email = "'email'";
 
-		/// <summary>
-		/// Predefined link formatter.
-		/// </summary>
-		public const string Link = "'link'";
+        /// <summary>
+        /// Predefined link formatter.
+        /// </summary>
+        public const string Link = "'link'";
 
-		/// <summary>
-		/// Predefined showlink formatter.
-		/// </summary>
-		public const string ShowLink = "'showlink'";
+        /// <summary>
+        /// Predefined showlink formatter.
+        /// </summary>
+        public const string ShowLink = "'showlink'";
 
-		/// <summary>
-		/// Predefined checkbox formatter.
-		/// </summary>
-		public const string CheckBox = "'checkbox'";
+        /// <summary>
+        /// Predefined checkbox formatter.
+        /// </summary>
+        public const string CheckBox = "'checkbox'";
 
-		/// <summary>
-		/// Predefined select formatter.
-		/// </summary>
-		public const string Select = "'select'";
+        /// <summary>
+        /// Predefined select formatter.
+        /// </summary>
+        public const string Select = "'select'";
 
-		/// <summary>
-		/// Predefined jQuery UI Button formatter.
-		/// </summary>
-		/// <remarks>The column value can be accessed in function passed to OnClick property from custom attribute: $(this).attr('data-cell-value');.</remarks>
-		public const string JQueryUIButton = "'JQueryUIButton'";
+        /// <summary>
+        /// Predefined jQuery UI Button formatter.
+        /// </summary>
+        /// <remarks>The column value can be accessed in function passed to OnClick property from custom attribute: $(this).attr('data-cell-value');.</remarks>
+        public const string JQueryUIButton = "'JQueryUIButton'";
 
-		internal const string Actions = "'actions'";
-	}
+        internal const string Actions = "'actions'";
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridColumnPredefinedFormatters.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridColumnPredefinedFormatters.cs
@@ -1,66 +1,61 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-    /// <summary>
-    /// Contains predefined jqGrid formatters names, delimited with ''
-    /// </summary>
-    public static class JqGridColumnPredefinedFormatters
-    {
-        /// <summary>
-        /// Predefined integer formatter.
-        /// </summary>
-        public const string Integer = "'integer'";
+	/// <summary>
+	/// Contains predefined jqGrid formatters names, delimited with ''
+	/// </summary>
+	public static class JqGridColumnPredefinedFormatters
+	{
+		/// <summary>
+		/// Predefined integer formatter.
+		/// </summary>
+		public const string Integer = "'integer'";
 
-        /// <summary>
-        /// Predefined number formatter.
-        /// </summary>
-        public const string Number = "'number'";
+		/// <summary>
+		/// Predefined number formatter.
+		/// </summary>
+		public const string Number = "'number'";
 
-        /// <summary>
-        /// Predefined currency formatter.
-        /// </summary>
-        public const string Currency = "'currency'";
+		/// <summary>
+		/// Predefined currency formatter.
+		/// </summary>
+		public const string Currency = "'currency'";
 
-        /// <summary>
-        /// Predefined date formatter.
-        /// </summary>
-        public const string Date = "'date'";
+		/// <summary>
+		/// Predefined date formatter.
+		/// </summary>
+		public const string Date = "'date'";
 
-        /// <summary>
-        /// Predefined email formatter.
-        /// </summary>
-        public const string Email = "'email'";
+		/// <summary>
+		/// Predefined email formatter.
+		/// </summary>
+		public const string Email = "'email'";
 
-        /// <summary>
-        /// Predefined link formatter.
-        /// </summary>
-        public const string Link = "'link'";
+		/// <summary>
+		/// Predefined link formatter.
+		/// </summary>
+		public const string Link = "'link'";
 
-        /// <summary>
-        /// Predefined showlink formatter.
-        /// </summary>
-        public const string ShowLink = "'showlink'";
+		/// <summary>
+		/// Predefined showlink formatter.
+		/// </summary>
+		public const string ShowLink = "'showlink'";
 
-        /// <summary>
-        /// Predefined checkbox formatter.
-        /// </summary>
-        public const string CheckBox = "'checkbox'";
+		/// <summary>
+		/// Predefined checkbox formatter.
+		/// </summary>
+		public const string CheckBox = "'checkbox'";
 
-        /// <summary>
-        /// Predefined select formatter.
-        /// </summary>
-        public const string Select = "'select'";
+		/// <summary>
+		/// Predefined select formatter.
+		/// </summary>
+		public const string Select = "'select'";
 
-        /// <summary>
-        /// Predefined jQuery UI Button formatter.
-        /// </summary>
-        /// <remarks>The column value can be accessed in function passed to OnClick property from custom attribute: $(this).attr('data-cell-value');.</remarks>
-        public const string JQueryUIButton = "'JQueryUIButton'";
+		/// <summary>
+		/// Predefined jQuery UI Button formatter.
+		/// </summary>
+		/// <remarks>The column value can be accessed in function passed to OnClick property from custom attribute: $(this).attr('data-cell-value');.</remarks>
+		public const string JQueryUIButton = "'JQueryUIButton'";
 
-        internal const string Actions = "'actions'";
-    }
+		internal const string Actions = "'actions'";
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridFilterToolbarDefaults.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridFilterToolbarDefaults.cs
@@ -2,37 +2,37 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-	/// <summary>
-	/// Contains default values for jqGrid filter toolbar properties
-	/// </summary>
-	public static class JqGridFilterToolbarDefaults
-	{
-		/// <summary>
-		/// The tooltip for the operation button.
-		/// </summary>
-		public const string OperandToolTip = "Click to select search operation";
+    /// <summary>
+    /// Contains default values for jqGrid filter toolbar properties
+    /// </summary>
+    public static class JqGridFilterToolbarDefaults
+    {
+        /// <summary>
+        /// The tooltip for the operation button.
+        /// </summary>
+        public const string OperandToolTip = "Click to select search operation";
 
-		/// <summary>
-		/// The short texts for search operators which are dispalyed to the user when a operation button is clicked.
-		/// </summary>
-		public static readonly Dictionary<JqGridSearchOperators, string> Operands = new Dictionary<JqGridSearchOperators, string>()
-		{
-			{ JqGridSearchOperators.Eq, "==" },
-			{ JqGridSearchOperators.Ne, "!" },
-			{ JqGridSearchOperators.Lt, "<" },
-			{ JqGridSearchOperators.Le, "<=" },
-			{ JqGridSearchOperators.Gt, ">" },
-			{ JqGridSearchOperators.Ge, ">=" },
-			{ JqGridSearchOperators.Bw, "^" },
-			{ JqGridSearchOperators.Bn, "!^" },
-			{ JqGridSearchOperators.In, "=" },
-			{ JqGridSearchOperators.Ni, "!=" },
-			{ JqGridSearchOperators.Ew, "|" },
-			{ JqGridSearchOperators.En, "!@" },
-			{ JqGridSearchOperators.Cn, "~" },
-			{ JqGridSearchOperators.Nc, "!~" },
-			{ JqGridSearchOperators.Nu, "#" },
-			{ JqGridSearchOperators.Nn, "!#" }
-		};
-	}
+        /// <summary>
+        /// The short texts for search operators which are dispalyed to the user when a operation button is clicked.
+        /// </summary>
+        public static readonly Dictionary<JqGridSearchOperators, string> Operands = new Dictionary<JqGridSearchOperators, string>()
+        {
+            { JqGridSearchOperators.Eq, "==" },
+            { JqGridSearchOperators.Ne, "!" },
+            { JqGridSearchOperators.Lt, "<" },
+            { JqGridSearchOperators.Le, "<=" },
+            { JqGridSearchOperators.Gt, ">" },
+            { JqGridSearchOperators.Ge, ">=" },
+            { JqGridSearchOperators.Bw, "^" },
+            { JqGridSearchOperators.Bn, "!^" },
+            { JqGridSearchOperators.In, "=" },
+            { JqGridSearchOperators.Ni, "!=" },
+            { JqGridSearchOperators.Ew, "|" },
+            { JqGridSearchOperators.En, "!@" },
+            { JqGridSearchOperators.Cn, "~" },
+            { JqGridSearchOperators.Nc, "!~" },
+            { JqGridSearchOperators.Nu, "#" },
+            { JqGridSearchOperators.Nn, "!#" }
+        };
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridFilterToolbarDefaults.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridFilterToolbarDefaults.cs
@@ -1,41 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-    /// <summary>
-    /// Contains default values for jqGrid filter toolbar properties
-    /// </summary>
-    public static class JqGridFilterToolbarDefaults
-    {
-        /// <summary>
-        /// The tooltip for the operation button.
-        /// </summary>
-        public const string OperandToolTip = "Click to select search operation";
+	/// <summary>
+	/// Contains default values for jqGrid filter toolbar properties
+	/// </summary>
+	public static class JqGridFilterToolbarDefaults
+	{
+		/// <summary>
+		/// The tooltip for the operation button.
+		/// </summary>
+		public const string OperandToolTip = "Click to select search operation";
 
-        /// <summary>
-        /// The short texts for search operators which are dispalyed to the user when a operation button is clicked.
-        /// </summary>
-        public static readonly Dictionary<JqGridSearchOperators, string> Operands = new Dictionary<JqGridSearchOperators, string>()
-        {
-            { JqGridSearchOperators.Eq, "==" },
-            { JqGridSearchOperators.Ne, "!" },
-            { JqGridSearchOperators.Lt, "<" },
-            { JqGridSearchOperators.Le, "<=" },
-            { JqGridSearchOperators.Gt, ">" },
-            { JqGridSearchOperators.Ge, ">=" },
-            { JqGridSearchOperators.Bw, "^" },
-            { JqGridSearchOperators.Bn, "!^" },
-            { JqGridSearchOperators.In, "=" },
-            { JqGridSearchOperators.Ni, "!=" },
-            { JqGridSearchOperators.Ew, "|" },
-            { JqGridSearchOperators.En, "!@" },
-            { JqGridSearchOperators.Cn, "~" },
-            { JqGridSearchOperators.Nc, "!~" },
-            { JqGridSearchOperators.Nu, "#" },
-            { JqGridSearchOperators.Nn, "!#" }
-        };
-    }
+		/// <summary>
+		/// The short texts for search operators which are dispalyed to the user when a operation button is clicked.
+		/// </summary>
+		public static readonly Dictionary<JqGridSearchOperators, string> Operands = new Dictionary<JqGridSearchOperators, string>()
+		{
+			{ JqGridSearchOperators.Eq, "==" },
+			{ JqGridSearchOperators.Ne, "!" },
+			{ JqGridSearchOperators.Lt, "<" },
+			{ JqGridSearchOperators.Le, "<=" },
+			{ JqGridSearchOperators.Gt, ">" },
+			{ JqGridSearchOperators.Ge, ">=" },
+			{ JqGridSearchOperators.Bw, "^" },
+			{ JqGridSearchOperators.Bn, "!^" },
+			{ JqGridSearchOperators.In, "=" },
+			{ JqGridSearchOperators.Ni, "!=" },
+			{ JqGridSearchOperators.Ew, "|" },
+			{ JqGridSearchOperators.En, "!@" },
+			{ JqGridSearchOperators.Cn, "~" },
+			{ JqGridSearchOperators.Nc, "!~" },
+			{ JqGridSearchOperators.Nu, "#" },
+			{ JqGridSearchOperators.Nn, "!#" }
+		};
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridNavigatorDefaults.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridNavigatorDefaults.cs
@@ -1,128 +1,123 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-    /// <summary>
-    /// Contains default values for jqGrid Navigator properties
-    /// </summary>
-    public static class JqGridNavigatorDefaults
-    {
-        /// <summary>
-        /// The icon (form UI theme images) for add action
-        /// </summary>
-        public const string AddIcon = "ui-icon-plus";
+	/// <summary>
+	/// Contains default values for jqGrid Navigator properties
+	/// </summary>
+	public static class JqGridNavigatorDefaults
+	{
+		/// <summary>
+		/// The icon (form UI theme images) for add action
+		/// </summary>
+		public const string AddIcon = "ui-icon-plus";
 
-        /// <summary>
-        /// The tooltip for add action.
-        /// </summary>
-        public const string AddToolTip = "Add new row";
+		/// <summary>
+		/// The tooltip for add action.
+		/// </summary>
+		public const string AddToolTip = "Add new row";
 
-        /// <summary>
-        /// The caption for warning which appears when user try to edit, delete or view a row without selecting it.
-        /// </summary>
-        public const string AlertCaption = "Warning";
+		/// <summary>
+		/// The caption for warning which appears when user try to edit, delete or view a row without selecting it.
+		/// </summary>
+		public const string AlertCaption = "Warning";
 
-        /// <summary>
-        /// The text for warning which appears when user try to edit, delete or view a row without selecting it.
-        /// </summary>
-        public const string AlertText = "Please, select row";
+		/// <summary>
+		/// The text for warning which appears when user try to edit, delete or view a row without selecting it.
+		/// </summary>
+		public const string AlertText = "Please, select row";
 
-        /// <summary>
-        /// The icon (form UI theme images) for cancel action.
-        /// </summary>
-        public const string CancelIcon = "ui-icon-cancel";
+		/// <summary>
+		/// The icon (form UI theme images) for cancel action.
+		/// </summary>
+		public const string CancelIcon = "ui-icon-cancel";
 
-        /// <summary>
-        /// The tooltip for cancel action.
-        /// </summary>
-        public const string CancelToolTip = "Cancel row editing";
+		/// <summary>
+		/// The tooltip for cancel action.
+		/// </summary>
+		public const string CancelToolTip = "Cancel row editing";
 
-        /// <summary>
-        /// The icon (form UI theme images) for delete action.
-        /// </summary>
-        public const string DeleteIcon = "ui-icon-trash";
+		/// <summary>
+		/// The icon (form UI theme images) for delete action.
+		/// </summary>
+		public const string DeleteIcon = "ui-icon-trash";
 
-        /// <summary>
-        /// The tooltip for delete action.
-        /// </summary>
-        public const string DeleteToolTip = "Delete selected row";
+		/// <summary>
+		/// The tooltip for delete action.
+		/// </summary>
+		public const string DeleteToolTip = "Delete selected row";
 
-        /// <summary>
-        /// The icon (form UI theme images) for edit action.
-        /// </summary>
-        public const string EditIcon = "ui-icon-pencil";
+		/// <summary>
+		/// The icon (form UI theme images) for edit action.
+		/// </summary>
+		public const string EditIcon = "ui-icon-pencil";
 
-        /// <summary>
-        /// The tooltip for edit action.
-        /// </summary>
-        public const string EditToolTip = "Edit selected row";
+		/// <summary>
+		/// The tooltip for edit action.
+		/// </summary>
+		public const string EditToolTip = "Edit selected row";
 
-        /// <summary>
-        /// The icon (form UI theme images) for refresh action.
-        /// </summary>
-        public const string RefreshIcon = "ui-icon-refresh";
+		/// <summary>
+		/// The icon (form UI theme images) for refresh action.
+		/// </summary>
+		public const string RefreshIcon = "ui-icon-refresh";
 
-        /// <summary>
-        /// The tooltip for refresh action.
-        /// </summary>
-        public const string RefreshToolTip = "Reload Grid";
+		/// <summary>
+		/// The tooltip for refresh action.
+		/// </summary>
+		public const string RefreshToolTip = "Reload Grid";
 
-        /// <summary>
-        /// The icon (form UI theme images) for save action.
-        /// </summary>
-        public const string SaveIcon = "ui-icon-disk";
+		/// <summary>
+		/// The icon (form UI theme images) for save action.
+		/// </summary>
+		public const string SaveIcon = "ui-icon-disk";
 
-        /// <summary>
-        /// The tooltip for save action.
-        /// </summary>
-        public const string SaveToolTip = "Save row";
+		/// <summary>
+		/// The tooltip for save action.
+		/// </summary>
+		public const string SaveToolTip = "Save row";
 
-        /// <summary>
-        /// The icon (form UI theme images) for search action.
-        /// </summary>
-        public const string SearchIcon = "ui-icon-search";
+		/// <summary>
+		/// The icon (form UI theme images) for search action.
+		/// </summary>
+		public const string SearchIcon = "ui-icon-search";
 
-        /// <summary>
-        /// The tooltip for search action.
-        /// </summary>
-        public const string SearchToolTip = "Find records";
+		/// <summary>
+		/// The tooltip for search action.
+		/// </summary>
+		public const string SearchToolTip = "Find records";
 
-        /// <summary>
-        /// The icon (form UI theme images) for view action.
-        /// </summary>
-        public const string ViewIcon = "ui-icon-document";
+		/// <summary>
+		/// The icon (form UI theme images) for view action.
+		/// </summary>
+		public const string ViewIcon = "ui-icon-document";
 
-        /// <summary>
-        /// The tooltip for view action.
-        /// </summary>
-        public const string ViewToolTip = "View selected row";
+		/// <summary>
+		/// The tooltip for view action.
+		/// </summary>
+		public const string ViewToolTip = "View selected row";
 
-        /// <summary>
-        /// The caption of the button.
-        /// </summary>
-        public const string ButtonCaption = "NewButton";
+		/// <summary>
+		/// The caption of the button.
+		/// </summary>
+		public const string ButtonCaption = "NewButton";
 
-        /// <summary>
-        /// The icon (form UI theme images) of the button.
-        /// </summary>
-        public const string ButtonIcon = "ui-icon-newwin";
+		/// <summary>
+		/// The icon (form UI theme images) of the button.
+		/// </summary>
+		public const string ButtonIcon = "ui-icon-newwin";
 
-        /// <summary>
-        /// The value which determines the cursor when user mouseover the button.
-        /// </summary>
-        public const string ButtonCursor = "pointer";
+		/// <summary>
+		/// The value which determines the cursor when user mouseover the button.
+		/// </summary>
+		public const string ButtonCursor = "pointer";
 
-        /// <summary>
-        /// The class for the separator.
-        /// </summary>
-        public const string SeparatorClass = "ui-separator";
+		/// <summary>
+		/// The class for the separator.
+		/// </summary>
+		public const string SeparatorClass = "ui-separator";
 
-        /// <summary>
-        /// The row id for new row.
-        /// </summary>
-        public const string NewRowId = "new_row";
-    }
+		/// <summary>
+		/// The row id for new row.
+		/// </summary>
+		public const string NewRowId = "new_row";
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridNavigatorDefaults.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridNavigatorDefaults.cs
@@ -1,123 +1,123 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-	/// <summary>
-	/// Contains default values for jqGrid Navigator properties
-	/// </summary>
-	public static class JqGridNavigatorDefaults
-	{
-		/// <summary>
-		/// The icon (form UI theme images) for add action
-		/// </summary>
-		public const string AddIcon = "ui-icon-plus";
+    /// <summary>
+    /// Contains default values for jqGrid Navigator properties
+    /// </summary>
+    public static class JqGridNavigatorDefaults
+    {
+        /// <summary>
+        /// The icon (form UI theme images) for add action
+        /// </summary>
+        public const string AddIcon = "ui-icon-plus";
 
-		/// <summary>
-		/// The tooltip for add action.
-		/// </summary>
-		public const string AddToolTip = "Add new row";
+        /// <summary>
+        /// The tooltip for add action.
+        /// </summary>
+        public const string AddToolTip = "Add new row";
 
-		/// <summary>
-		/// The caption for warning which appears when user try to edit, delete or view a row without selecting it.
-		/// </summary>
-		public const string AlertCaption = "Warning";
+        /// <summary>
+        /// The caption for warning which appears when user try to edit, delete or view a row without selecting it.
+        /// </summary>
+        public const string AlertCaption = "Warning";
 
-		/// <summary>
-		/// The text for warning which appears when user try to edit, delete or view a row without selecting it.
-		/// </summary>
-		public const string AlertText = "Please, select row";
+        /// <summary>
+        /// The text for warning which appears when user try to edit, delete or view a row without selecting it.
+        /// </summary>
+        public const string AlertText = "Please, select row";
 
-		/// <summary>
-		/// The icon (form UI theme images) for cancel action.
-		/// </summary>
-		public const string CancelIcon = "ui-icon-cancel";
+        /// <summary>
+        /// The icon (form UI theme images) for cancel action.
+        /// </summary>
+        public const string CancelIcon = "ui-icon-cancel";
 
-		/// <summary>
-		/// The tooltip for cancel action.
-		/// </summary>
-		public const string CancelToolTip = "Cancel row editing";
+        /// <summary>
+        /// The tooltip for cancel action.
+        /// </summary>
+        public const string CancelToolTip = "Cancel row editing";
 
-		/// <summary>
-		/// The icon (form UI theme images) for delete action.
-		/// </summary>
-		public const string DeleteIcon = "ui-icon-trash";
+        /// <summary>
+        /// The icon (form UI theme images) for delete action.
+        /// </summary>
+        public const string DeleteIcon = "ui-icon-trash";
 
-		/// <summary>
-		/// The tooltip for delete action.
-		/// </summary>
-		public const string DeleteToolTip = "Delete selected row";
+        /// <summary>
+        /// The tooltip for delete action.
+        /// </summary>
+        public const string DeleteToolTip = "Delete selected row";
 
-		/// <summary>
-		/// The icon (form UI theme images) for edit action.
-		/// </summary>
-		public const string EditIcon = "ui-icon-pencil";
+        /// <summary>
+        /// The icon (form UI theme images) for edit action.
+        /// </summary>
+        public const string EditIcon = "ui-icon-pencil";
 
-		/// <summary>
-		/// The tooltip for edit action.
-		/// </summary>
-		public const string EditToolTip = "Edit selected row";
+        /// <summary>
+        /// The tooltip for edit action.
+        /// </summary>
+        public const string EditToolTip = "Edit selected row";
 
-		/// <summary>
-		/// The icon (form UI theme images) for refresh action.
-		/// </summary>
-		public const string RefreshIcon = "ui-icon-refresh";
+        /// <summary>
+        /// The icon (form UI theme images) for refresh action.
+        /// </summary>
+        public const string RefreshIcon = "ui-icon-refresh";
 
-		/// <summary>
-		/// The tooltip for refresh action.
-		/// </summary>
-		public const string RefreshToolTip = "Reload Grid";
+        /// <summary>
+        /// The tooltip for refresh action.
+        /// </summary>
+        public const string RefreshToolTip = "Reload Grid";
 
-		/// <summary>
-		/// The icon (form UI theme images) for save action.
-		/// </summary>
-		public const string SaveIcon = "ui-icon-disk";
+        /// <summary>
+        /// The icon (form UI theme images) for save action.
+        /// </summary>
+        public const string SaveIcon = "ui-icon-disk";
 
-		/// <summary>
-		/// The tooltip for save action.
-		/// </summary>
-		public const string SaveToolTip = "Save row";
+        /// <summary>
+        /// The tooltip for save action.
+        /// </summary>
+        public const string SaveToolTip = "Save row";
 
-		/// <summary>
-		/// The icon (form UI theme images) for search action.
-		/// </summary>
-		public const string SearchIcon = "ui-icon-search";
+        /// <summary>
+        /// The icon (form UI theme images) for search action.
+        /// </summary>
+        public const string SearchIcon = "ui-icon-search";
 
-		/// <summary>
-		/// The tooltip for search action.
-		/// </summary>
-		public const string SearchToolTip = "Find records";
+        /// <summary>
+        /// The tooltip for search action.
+        /// </summary>
+        public const string SearchToolTip = "Find records";
 
-		/// <summary>
-		/// The icon (form UI theme images) for view action.
-		/// </summary>
-		public const string ViewIcon = "ui-icon-document";
+        /// <summary>
+        /// The icon (form UI theme images) for view action.
+        /// </summary>
+        public const string ViewIcon = "ui-icon-document";
 
-		/// <summary>
-		/// The tooltip for view action.
-		/// </summary>
-		public const string ViewToolTip = "View selected row";
+        /// <summary>
+        /// The tooltip for view action.
+        /// </summary>
+        public const string ViewToolTip = "View selected row";
 
-		/// <summary>
-		/// The caption of the button.
-		/// </summary>
-		public const string ButtonCaption = "NewButton";
+        /// <summary>
+        /// The caption of the button.
+        /// </summary>
+        public const string ButtonCaption = "NewButton";
 
-		/// <summary>
-		/// The icon (form UI theme images) of the button.
-		/// </summary>
-		public const string ButtonIcon = "ui-icon-newwin";
+        /// <summary>
+        /// The icon (form UI theme images) of the button.
+        /// </summary>
+        public const string ButtonIcon = "ui-icon-newwin";
 
-		/// <summary>
-		/// The value which determines the cursor when user mouseover the button.
-		/// </summary>
-		public const string ButtonCursor = "pointer";
+        /// <summary>
+        /// The value which determines the cursor when user mouseover the button.
+        /// </summary>
+        public const string ButtonCursor = "pointer";
 
-		/// <summary>
-		/// The class for the separator.
-		/// </summary>
-		public const string SeparatorClass = "ui-separator";
+        /// <summary>
+        /// The class for the separator.
+        /// </summary>
+        public const string SeparatorClass = "ui-separator";
 
-		/// <summary>
-		/// The row id for new row.
-		/// </summary>
-		public const string NewRowId = "new_row";
-	}
+        /// <summary>
+        /// The row id for new row.
+        /// </summary>
+        public const string NewRowId = "new_row";
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridOptionsDefaults.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridOptionsDefaults.cs
@@ -1,178 +1,178 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-	/// <summary>
-	/// Contains default values for jqGrid options
-	/// </summary>
-	public static class JqGridOptionsDefaults
-	{
-		/// <summary>
-		/// The name of an array that contains the actual data.
-		/// </summary>
-		public const string ResponseRecords = "rows";
+    /// <summary>
+    /// Contains default values for jqGrid options
+    /// </summary>
+    public static class JqGridOptionsDefaults
+    {
+        /// <summary>
+        /// The name of an array that contains the actual data.
+        /// </summary>
+        public const string ResponseRecords = "rows";
 
-		/// <summary>
-		/// The name for page index parametr.
-		/// </summary>
-		public const string ResponsePageIndex = "page";
+        /// <summary>
+        /// The name for page index parametr.
+        /// </summary>
+        public const string ResponsePageIndex = "page";
 
-		/// <summary>
-		/// The name of a field that contains total pages count.
-		/// </summary>
-		public const string ResponseTotalPagesCount = "total";
+        /// <summary>
+        /// The name of a field that contains total pages count.
+        /// </summary>
+        public const string ResponseTotalPagesCount = "total";
 
-		/// <summary>
-		/// The name of a field that contains total records count.
-		/// </summary>
-		public const string ResponseTotalRecordsCount = "records";
+        /// <summary>
+        /// The name of a field that contains total records count.
+        /// </summary>
+        public const string ResponseTotalRecordsCount = "records";
 
-		/// <summary>
-		/// The name of an array that contains custom data.
-		/// </summary>
-		public const string ResponseUserData = "userdata";
+        /// <summary>
+        /// The name of an array that contains custom data.
+        /// </summary>
+        public const string ResponseUserData = "userdata";
 
-		/// <summary>
-		/// The name of a field that contains record identifier.
-		/// </summary>
-		public const string ResponseRecordId = "id";
+        /// <summary>
+        /// The name of a field that contains record identifier.
+        /// </summary>
+        public const string ResponseRecordId = "id";
 
-		/// <summary>
-		/// The name of an array that contains record values.
-		/// </summary>
-		public const string ResponseRecordValues = "cell";
+        /// <summary>
+        /// The name of an array that contains record values.
+        /// </summary>
+        public const string ResponseRecordValues = "cell";
 
-		/// <summary>
-		/// The name for page index parametr.
-		/// </summary>
-		public const string RequestPageIndex = "page";
+        /// <summary>
+        /// The name for page index parametr.
+        /// </summary>
+        public const string RequestPageIndex = "page";
 
-		/// <summary>
-		/// The name for records count parametr.
-		/// </summary>
-		public const string RequestRecordsCount = "rows";
+        /// <summary>
+        /// The name for records count parametr.
+        /// </summary>
+        public const string RequestRecordsCount = "rows";
 
-		/// <summary>
-		/// The name for sorting name parametr.
-		/// </summary>
-		public const string RequestSortingName = "sidx";
+        /// <summary>
+        /// The name for sorting name parametr.
+        /// </summary>
+        public const string RequestSortingName = "sidx";
 
-		/// <summary>
-		/// The name for sorting order parametr.
-		/// </summary>
-		public const string RequestSortingOrder = "sord";
+        /// <summary>
+        /// The name for sorting order parametr.
+        /// </summary>
+        public const string RequestSortingOrder = "sord";
 
-		/// <summary>
-		/// The name for searching parametr.
-		/// </summary>
-		public const string RequestSearching = "_search";
+        /// <summary>
+        /// The name for searching parametr.
+        /// </summary>
+        public const string RequestSearching = "_search";
 
-		/// <summary>
-		/// The name for id parametr.
-		/// </summary>
-		public const string RequestId = "id";
+        /// <summary>
+        /// The name for id parametr.
+        /// </summary>
+        public const string RequestId = "id";
 
-		/// <summary>
-		/// The name for operator parametr.
-		/// </summary>
-		public const string RequestOperator = "oper";
+        /// <summary>
+        /// The name for operator parametr.
+        /// </summary>
+        public const string RequestOperator = "oper";
 
-		/// <summary>
-		/// The name for edit operator parametr.
-		/// </summary>
-		public const string RequestEditOperator = "edit";
+        /// <summary>
+        /// The name for edit operator parametr.
+        /// </summary>
+        public const string RequestEditOperator = "edit";
 
-		/// <summary>
-		/// The name for add operator parametr.
-		/// </summary>
-		public const string RequestAddOperator = "add";
+        /// <summary>
+        /// The name for add operator parametr.
+        /// </summary>
+        public const string RequestAddOperator = "add";
 
-		/// <summary>
-		/// The name for delete operator parametr.
-		/// </summary>
-		public const string RequestDeleteOperator = "del";
+        /// <summary>
+        /// The name for delete operator parametr.
+        /// </summary>
+        public const string RequestDeleteOperator = "del";
 
-		/// <summary>
-		/// The name for subgrid id parametr.
-		/// </summary>
-		public const string RequestSubgridId = "id";
+        /// <summary>
+        /// The name for subgrid id parametr.
+        /// </summary>
+        public const string RequestSubgridId = "id";
 
-		/// <summary>
-		/// The name for total rows parametr.
-		/// </summary>
-		public const string RequestTotalRows = "totalrows";
+        /// <summary>
+        /// The name for total rows parametr.
+        /// </summary>
+        public const string RequestTotalRows = "totalrows";
 
-		/// <summary>
-		/// The icon (form UI theme images) that will be used if the group is collapsed.
-		/// </summary>
-		public const string GroupingPlusIcon = "ui-icon-circlesmall-plus";
+        /// <summary>
+        /// The icon (form UI theme images) that will be used if the group is collapsed.
+        /// </summary>
+        public const string GroupingPlusIcon = "ui-icon-circlesmall-plus";
 
-		/// <summary>
-		/// The icon (form UI theme images) that will be used if the group is expanded.
-		/// </summary>
-		public const string GroupingMinusIcon = "ui-icon-circlesmall-minus";
+        /// <summary>
+        /// The icon (form UI theme images) that will be used if the group is expanded.
+        /// </summary>
+        public const string GroupingMinusIcon = "ui-icon-circlesmall-minus";
 
-		/// <summary>
-		/// The decimal places for formatter.
-		/// </summary>
-		public const int FormatterDecimalPlaces = 2;
+        /// <summary>
+        /// The decimal places for formatter.
+        /// </summary>
+        public const int FormatterDecimalPlaces = 2;
 
-		/// <summary>
-		/// The decimal separator for formatter.
-		/// </summary>
-		public const string FormatterDecimalSeparator = ".";
+        /// <summary>
+        /// The decimal separator for formatter.
+        /// </summary>
+        public const string FormatterDecimalSeparator = ".";
 
-		/// <summary>
-		/// The date source format for formatter.
-		/// </summary>
-		public const string FormatterSourceFormat = "Y-m-d";
+        /// <summary>
+        /// The date source format for formatter.
+        /// </summary>
+        public const string FormatterSourceFormat = "Y-m-d";
 
-		/// <summary>
-		/// The date output format for formatter.
-		/// </summary>
-		public const string FormatterOutputFormat = "n/j/Y";
+        /// <summary>
+        /// The date output format for formatter.
+        /// </summary>
+        public const string FormatterOutputFormat = "n/j/Y";
 
-		/// <summary>
-		/// The thousands separator for formatter.
-		/// </summary>
-		public const string FormatterThousandsSeparator = " ";
+        /// <summary>
+        /// The thousands separator for formatter.
+        /// </summary>
+        public const string FormatterThousandsSeparator = " ";
 
-		/// <summary>
-		/// The first parameter that is added after the ShowAction.
-		/// </summary>
-		public const string FormatterIdName = "id";
+        /// <summary>
+        /// The first parameter that is added after the ShowAction.
+        /// </summary>
+        public const string FormatterIdName = "id";
 
-		/// <summary>
-		/// The default value for integer formatter.
-		/// </summary>
-		public const string IntegerFormatterDefaultValue = "0";
+        /// <summary>
+        /// The default value for integer formatter.
+        /// </summary>
+        public const string IntegerFormatterDefaultValue = "0";
 
-		/// <summary>
-		/// The default value for number formatter.
-		/// </summary>
-		public const string NumberFormatterDefaultValue = "0.00";
+        /// <summary>
+        /// The default value for number formatter.
+        /// </summary>
+        public const string NumberFormatterDefaultValue = "0.00";
 
-		/// <summary>
-		/// The default value for currency formatter.
-		/// </summary>
-		public const string CurrencyFormatterDefaultValue = "0.00";
+        /// <summary>
+        /// The default value for currency formatter.
+        /// </summary>
+        public const string CurrencyFormatterDefaultValue = "0.00";
 
-		/// <summary>
-		/// The class that is used for alternate rows.
-		/// </summary>
-		public const string AltClass = "ui-priority-secondary";
+        /// <summary>
+        /// The class that is used for alternate rows.
+        /// </summary>
+        public const string AltClass = "ui-priority-secondary";
 
-		/// <summary>
-		/// The padding plus border width of the cell.
-		/// </summary>
-		public const int CellLayout = 5;
+        /// <summary>
+        /// The padding plus border width of the cell.
+        /// </summary>
+        public const int CellLayout = 5;
 
-		/// <summary>
-		/// The ISO date format.
-		/// </summary>
-		public const string DateFormat = "Y-m-d";
+        /// <summary>
+        /// The ISO date format.
+        /// </summary>
+        public const string DateFormat = "Y-m-d";
 
-		/// <summary>
-		/// The information to be displayed when the returned (or the current) number of records is zero.
-		/// </summary>
-		public const string EmptyRecords = "No records to view";
-	}
+        /// <summary>
+        /// The information to be displayed when the returned (or the current) number of records is zero.
+        /// </summary>
+        public const string EmptyRecords = "No records to view";
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridOptionsDefaults.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Constants/JqGridOptionsDefaults.cs
@@ -1,183 +1,178 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid.Constants
 {
-    /// <summary>
-    /// Contains default values for jqGrid options
-    /// </summary>
-    public static class JqGridOptionsDefaults
-    {
-        /// <summary>
-        /// The name of an array that contains the actual data.
-        /// </summary>
-        public const string ResponseRecords = "rows";
+	/// <summary>
+	/// Contains default values for jqGrid options
+	/// </summary>
+	public static class JqGridOptionsDefaults
+	{
+		/// <summary>
+		/// The name of an array that contains the actual data.
+		/// </summary>
+		public const string ResponseRecords = "rows";
 
-        /// <summary>
-        /// The name for page index parametr.
-        /// </summary>
-        public const string ResponsePageIndex = "page";
+		/// <summary>
+		/// The name for page index parametr.
+		/// </summary>
+		public const string ResponsePageIndex = "page";
 
-        /// <summary>
-        /// The name of a field that contains total pages count.
-        /// </summary>
-        public const string ResponseTotalPagesCount = "total";
+		/// <summary>
+		/// The name of a field that contains total pages count.
+		/// </summary>
+		public const string ResponseTotalPagesCount = "total";
 
-        /// <summary>
-        /// The name of a field that contains total records count.
-        /// </summary>
-        public const string ResponseTotalRecordsCount = "records";
+		/// <summary>
+		/// The name of a field that contains total records count.
+		/// </summary>
+		public const string ResponseTotalRecordsCount = "records";
 
-        /// <summary>
-        /// The name of an array that contains custom data.
-        /// </summary>
-        public const string ResponseUserData = "userdata";
+		/// <summary>
+		/// The name of an array that contains custom data.
+		/// </summary>
+		public const string ResponseUserData = "userdata";
 
-        /// <summary>
-        /// The name of a field that contains record identifier.
-        /// </summary>
-        public const string ResponseRecordId = "id";
+		/// <summary>
+		/// The name of a field that contains record identifier.
+		/// </summary>
+		public const string ResponseRecordId = "id";
 
-        /// <summary>
-        /// The name of an array that contains record values.
-        /// </summary>
-        public const string ResponseRecordValues = "cell";
+		/// <summary>
+		/// The name of an array that contains record values.
+		/// </summary>
+		public const string ResponseRecordValues = "cell";
 
-        /// <summary>
-        /// The name for page index parametr.
-        /// </summary>
-        public const string RequestPageIndex = "page";
+		/// <summary>
+		/// The name for page index parametr.
+		/// </summary>
+		public const string RequestPageIndex = "page";
 
-        /// <summary>
-        /// The name for records count parametr.
-        /// </summary>
-        public const string RequestRecordsCount = "rows";
+		/// <summary>
+		/// The name for records count parametr.
+		/// </summary>
+		public const string RequestRecordsCount = "rows";
 
-        /// <summary>
-        /// The name for sorting name parametr.
-        /// </summary>
-        public const string RequestSortingName = "sidx";
+		/// <summary>
+		/// The name for sorting name parametr.
+		/// </summary>
+		public const string RequestSortingName = "sidx";
 
-        /// <summary>
-        /// The name for sorting order parametr.
-        /// </summary>
-        public const string RequestSortingOrder = "sord";
+		/// <summary>
+		/// The name for sorting order parametr.
+		/// </summary>
+		public const string RequestSortingOrder = "sord";
 
-        /// <summary>
-        /// The name for searching parametr.
-        /// </summary>
-        public const string RequestSearching = "_search";
+		/// <summary>
+		/// The name for searching parametr.
+		/// </summary>
+		public const string RequestSearching = "_search";
 
-        /// <summary>
-        /// The name for id parametr.
-        /// </summary>
-        public const string RequestId = "id";
+		/// <summary>
+		/// The name for id parametr.
+		/// </summary>
+		public const string RequestId = "id";
 
-        /// <summary>
-        /// The name for operator parametr.
-        /// </summary>
-        public const string RequestOperator = "oper";
+		/// <summary>
+		/// The name for operator parametr.
+		/// </summary>
+		public const string RequestOperator = "oper";
 
-        /// <summary>
-        /// The name for edit operator parametr.
-        /// </summary>
-        public const string RequestEditOperator = "edit";
+		/// <summary>
+		/// The name for edit operator parametr.
+		/// </summary>
+		public const string RequestEditOperator = "edit";
 
-        /// <summary>
-        /// The name for add operator parametr.
-        /// </summary>
-        public const string RequestAddOperator = "add";
+		/// <summary>
+		/// The name for add operator parametr.
+		/// </summary>
+		public const string RequestAddOperator = "add";
 
-        /// <summary>
-        /// The name for delete operator parametr.
-        /// </summary>
-        public const string RequestDeleteOperator = "del";
+		/// <summary>
+		/// The name for delete operator parametr.
+		/// </summary>
+		public const string RequestDeleteOperator = "del";
 
-        /// <summary>
-        /// The name for subgrid id parametr.
-        /// </summary>
-        public const string RequestSubgridId = "id";
+		/// <summary>
+		/// The name for subgrid id parametr.
+		/// </summary>
+		public const string RequestSubgridId = "id";
 
-        /// <summary>
-        /// The name for total rows parametr.
-        /// </summary>
-        public const string RequestTotalRows = "totalrows";
+		/// <summary>
+		/// The name for total rows parametr.
+		/// </summary>
+		public const string RequestTotalRows = "totalrows";
 
-        /// <summary>
-        /// The icon (form UI theme images) that will be used if the group is collapsed.
-        /// </summary>
-        public const string GroupingPlusIcon = "ui-icon-circlesmall-plus";
+		/// <summary>
+		/// The icon (form UI theme images) that will be used if the group is collapsed.
+		/// </summary>
+		public const string GroupingPlusIcon = "ui-icon-circlesmall-plus";
 
-        /// <summary>
-        /// The icon (form UI theme images) that will be used if the group is expanded.
-        /// </summary>
-        public const string GroupingMinusIcon = "ui-icon-circlesmall-minus";
+		/// <summary>
+		/// The icon (form UI theme images) that will be used if the group is expanded.
+		/// </summary>
+		public const string GroupingMinusIcon = "ui-icon-circlesmall-minus";
 
-        /// <summary>
-        /// The decimal places for formatter.
-        /// </summary>
-        public const int FormatterDecimalPlaces = 2;
+		/// <summary>
+		/// The decimal places for formatter.
+		/// </summary>
+		public const int FormatterDecimalPlaces = 2;
 
-        /// <summary>
-        /// The decimal separator for formatter.
-        /// </summary>
-        public const string FormatterDecimalSeparator = ".";
+		/// <summary>
+		/// The decimal separator for formatter.
+		/// </summary>
+		public const string FormatterDecimalSeparator = ".";
 
-        /// <summary>
-        /// The date source format for formatter.
-        /// </summary>
-        public const string FormatterSourceFormat = "Y-m-d";
+		/// <summary>
+		/// The date source format for formatter.
+		/// </summary>
+		public const string FormatterSourceFormat = "Y-m-d";
 
-        /// <summary>
-        /// The date output format for formatter.
-        /// </summary>
-        public const string FormatterOutputFormat = "n/j/Y";
+		/// <summary>
+		/// The date output format for formatter.
+		/// </summary>
+		public const string FormatterOutputFormat = "n/j/Y";
 
-        /// <summary>
-        /// The thousands separator for formatter.
-        /// </summary>
-        public const string FormatterThousandsSeparator = " ";
+		/// <summary>
+		/// The thousands separator for formatter.
+		/// </summary>
+		public const string FormatterThousandsSeparator = " ";
 
-        /// <summary>
-        /// The first parameter that is added after the ShowAction.
-        /// </summary>
-        public const string FormatterIdName = "id";
+		/// <summary>
+		/// The first parameter that is added after the ShowAction.
+		/// </summary>
+		public const string FormatterIdName = "id";
 
-        /// <summary>
-        /// The default value for integer formatter.
-        /// </summary>
-        public const string IntegerFormatterDefaultValue = "0";
+		/// <summary>
+		/// The default value for integer formatter.
+		/// </summary>
+		public const string IntegerFormatterDefaultValue = "0";
 
-        /// <summary>
-        /// The default value for number formatter.
-        /// </summary>
-        public const string NumberFormatterDefaultValue = "0.00";
+		/// <summary>
+		/// The default value for number formatter.
+		/// </summary>
+		public const string NumberFormatterDefaultValue = "0.00";
 
-        /// <summary>
-        /// The default value for currency formatter.
-        /// </summary>
-        public const string CurrencyFormatterDefaultValue = "0.00";
+		/// <summary>
+		/// The default value for currency formatter.
+		/// </summary>
+		public const string CurrencyFormatterDefaultValue = "0.00";
 
-        /// <summary>
-        /// The class that is used for alternate rows.
-        /// </summary>
-        public const string  AltClass = "ui-priority-secondary";
+		/// <summary>
+		/// The class that is used for alternate rows.
+		/// </summary>
+		public const string AltClass = "ui-priority-secondary";
 
-        /// <summary>
-        /// The padding plus border width of the cell.
-        /// </summary>
-        public const int CellLayout = 5;
+		/// <summary>
+		/// The padding plus border width of the cell.
+		/// </summary>
+		public const int CellLayout = 5;
 
-        /// <summary>
-        /// The ISO date format.
-        /// </summary>
-        public const string DateFormat = "Y-m-d";
+		/// <summary>
+		/// The ISO date format.
+		/// </summary>
+		public const string DateFormat = "Y-m-d";
 
-        /// <summary>
-        /// The information to be displayed when the returned (or the current) number of records is zero.
-        /// </summary>
-        public const string EmptyRecords = "No records to view";
-    }
+		/// <summary>
+		/// The information to be displayed when the returned (or the current) number of records is zero.
+		/// </summary>
+		public const string EmptyRecords = "No records to view";
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnEditableAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnEditableAttribute.cs
@@ -1,278 +1,291 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Routing;
 using System.Web.Mvc;
-using System.Web;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+using JetBrains.Annotations;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Specifies the editing options for column
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class JqGridColumnEditableAttribute : JqGridColumnElementAttribute
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the name of function which is used to create custom edit element
-        /// </summary>
-        public string CustomElementFunction
-        {
-            get { return EditOptions.CustomElementFunction; }
-            set { EditOptions.CustomElementFunction = value; }
-        }
+	/// <inheritdoc />
+	/// <summary>
+	/// Specifies the editing options for column
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	public class JqGridColumnEditableAttribute : JqGridColumnElementAttribute
+	{
+		#region Fields
+		private string _dateFormat;
 
-        /// <summary>
-        /// Gets or sets the name of function which should return the value from the custom element after the editing.
-        /// </summary>
-        public string CustomElementValueFunction
-        {
-            get { return EditOptions.CustomValueFunction; }
-            set { EditOptions.CustomValueFunction = value; }
-        }
 
-        /// <summary>
-        /// Gets or sets the expected date format for this column in case of date validation (default ISO date). 
-        /// </summary>
-        public string DateFormat { get; set; }
+		#endregion
+		#region Properties
+		/// <summary>
+		/// Gets or sets the name of function which is used to create custom edit element
+		/// </summary>
+		public string CustomElementFunction
+		{
+			get => EditOptions.CustomElementFunction;
+			set => EditOptions.CustomElementFunction = value;
+		}
 
-        /// <summary>
-        /// Gets the value defining if this column can be edited.
-        /// </summary>
-        public bool Editable { get; private set; }
+		/// <summary>
+		/// Gets or sets the name of function which should return the value from the custom element after the editing.
+		/// </summary>
+		public string CustomElementValueFunction
+		{
+			get => EditOptions.CustomValueFunction;
+			set => EditOptions.CustomValueFunction = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value which defines if hidden column can be edited in form editing.
-        /// </summary>
-        public bool EditHidden
-        {
-            get { return Rules.EditHidden; }
-            set { Rules.EditHidden = value; }
-        }
+		internal bool IsDateFormatSetted { get; set; }
+		/// <summary>
+		/// Gets or sets the expected date format for this column in case of date validation (default ISO date). 
+		/// </summary>
+		public string DateFormat
+		{
+			get => _dateFormat;
+			set
+			{
+				_dateFormat = value;
+				IsDateFormatSetted = true;
+			}
+		}
 
-        internal JqGridColumnEditOptions EditOptions
-        {
-            get { return (base.Options as JqGridColumnEditOptions); }
-            set { base.Options = value; }
-        }
+		/// <summary>
+		/// Gets the value defining if this column can be edited.
+		/// </summary>
+		public bool Editable { get; }
 
-        /// <summary>
-        /// Gets or sets the type of the editable field (default JqGridColumnEditTypes.Text).
-        /// </summary>
-        public JqGridColumnEditTypes EditType { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if hidden column can be edited in form editing.
+		/// </summary>
+		public bool EditHidden
+		{
+			get => Rules.EditHidden ?? false;
+			set => Rules.EditHidden = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the column position of the element (with the label) in form editing (one-based).
-        /// </summary>
-        public int FormColumnPosition
-        {
-            get { return FormOptions.ColumnPosition.HasValue ? FormOptions.ColumnPosition.Value : 1; }
-            set { FormOptions.ColumnPosition = value; }
-        }
+		internal JqGridColumnEditOptions EditOptions
+		{
+			get => Options as JqGridColumnEditOptions;
+			set => Options = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the text or HTML content to appear before the input element in form editing.
-        /// </summary>
-        public string FormElementPrefix
-        {
-            get { return FormOptions.ElementPrefix; }
-            set { FormOptions.ElementPrefix = value; }
-        }
+		/// <summary>
+		/// Gets or sets the type of the editable field (default JqGridColumnEditTypes.Text).
+		/// </summary>
+		public JqGridColumnEditTypes EditType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text or HTML content to appear after the input element in form editing.
-        /// </summary>
-        public string FormElementSuffix
-        {
-            get { return FormOptions.ElementSuffix; }
-            set { FormOptions.ElementSuffix = value; }
-        }
+		/// <summary>
+		/// Gets or sets the column position of the element (with the label) in form editing (one-based).
+		/// </summary>
+		public int FormColumnPosition
+		{
+			get => FormOptions.ColumnPosition ?? 1;
+			set => FormOptions.ColumnPosition = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the text which will replace the name from ColumnNames as label in form editing.
-        /// </summary>
-        public string FormLabel
-        {
-            get { return FormOptions.Label; }
-            set { FormOptions.Label = value; }
-        }
+		/// <summary>
+		/// Gets or sets the text or HTML content to appear before the input element in form editing.
+		/// </summary>
+		public string FormElementPrefix
+		{
+			get => FormOptions.ElementPrefix;
+			set => FormOptions.ElementPrefix = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the row position of the element (with the label) in form editing (one-based).
-        /// </summary>
-        public int FormRowPosition
-        {
-            get { return FormOptions.RowPosition.HasValue ? FormOptions.RowPosition.Value : 1; }
-            set { FormOptions.RowPosition = value; }
-        }
+		/// <summary>
+		/// Gets or sets the text or HTML content to appear after the input element in form editing.
+		/// </summary>
+		public string FormElementSuffix
+		{
+			get => FormOptions.ElementSuffix;
+			set => FormOptions.ElementSuffix = value;
+		}
 
-        internal JqGridColumnFormOptions FormOptions { get; private set; }
+		/// <summary>
+		/// Gets or sets the text which will replace the name from ColumnNames as label in form editing.
+		/// </summary>
+		public string FormLabel
+		{
+			get => FormOptions.Label;
+			set => FormOptions.Label = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value which defines if null value should be send to server if the field is empty.
-        /// </summary>
-        public bool NullIfEmpty
-        {
-            get { return EditOptions.NullIfEmpty; }
-            set { EditOptions.NullIfEmpty = value; }
-        }
+		/// <summary>
+		/// Gets or sets the row position of the element (with the label) in form editing (one-based).
+		/// </summary>
+		public int FormRowPosition
+		{
+			get => FormOptions.RowPosition ?? 1;
+			set => FormOptions.RowPosition = value;
+		}
 
-        /// <summary>
-        /// When overriden in delivered class, provides additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
-        /// </summary>
-        protected virtual object PostData
-        {
-            get { return null; }
-        }
+		internal JqGridColumnFormOptions FormOptions { get; }
 
-        /// <summary>
-        /// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select). This property takes precedence over PostData.
-        /// </summary>
-        public string PostDataScript
-        {
-            get { return EditOptions.PostDataScript; }
-            set { EditOptions.PostDataScript = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value which defines if null value should be send to server if the field is empty.
+		/// </summary>
+		public bool NullIfEmpty
+		{
+			get => EditOptions.NullIfEmpty ?? false;
+			set => EditOptions.NullIfEmpty = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the child property name if this element performs parent role in selects cascade.
-        /// </summary>
-        public string ChildName
-        {
-            get { return EditOptions.ChildName; }
-            set { EditOptions.ChildName = value; }
-        }
-        #endregion
+		internal bool IsPostDataDefault { get; private set; }
+		/// <summary>
+		/// When overriden in delivered class, provides additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
+		/// </summary>
+		/// <remarks>Do not call base.PostData when overriden.</remarks>
+		protected virtual object PostData
+		{
+			get
+			{
+				IsPostDataDefault = true;
+				return null;
+			}
+		}
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnEditableAttribute class.
-        /// </summary>
-        /// <param name="editable">If this column can be edited</param>
-        public JqGridColumnEditableAttribute(bool editable)
-            : base()
-        {
-            DateFormat = JqGridOptionsDefaults.DateFormat;
-            Editable = editable;
-            EditOptions = new JqGridColumnEditOptions();
-            EditType = JqGridColumnEditTypes.Text;
-            FormOptions = new JqGridColumnFormOptions();
-        }
+		/// <summary>
+		/// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select). This property takes precedence over PostData.
+		/// </summary>
+		public string PostDataScript
+		{
+			get => EditOptions.PostDataScript;
+			set => EditOptions.PostDataScript = value;
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnEditableAttribute class.
-        /// </summary>
-        /// <param name="editable">If this column can be edited</param>
-        /// <param name="dataUrlRouteName">Route name for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-        public JqGridColumnEditableAttribute(bool editable, string dataUrlRouteName)
-            : this(editable)
-        {
-            if (String.IsNullOrWhiteSpace(dataUrlRouteName))
-                throw new ArgumentNullException("dataUrlRouteName");
-            
+		/// <summary>
+		/// Gets or sets the child property name if this element performs parent role in selects cascade.
+		/// </summary>
+		public string ChildName
+		{
+			get => EditOptions.ChildName;
+			set => EditOptions.ChildName = value;
+		}
+		#endregion
 
-            DataUrlRouteName = dataUrlRouteName;
-            DataUrlRouteData = new RouteValueDictionary();
-        }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnEditableAttribute class.
+		/// </summary>
+		/// <param name="editable">If this column can be edited</param>
+		public JqGridColumnEditableAttribute(bool editable = true)
+		{
+			//DateFormat = JqGridOptionsDefaults.DateFormat;
+			Editable = editable;
+			EditOptions = new JqGridColumnEditOptions();
+			EditType = JqGridColumnEditTypes.Default;
+			FormOptions = new JqGridColumnFormOptions();
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnEditableAttribute class.
-        /// </summary>
-        /// <param name="editable">If this column can be edited</param>
-        /// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-        /// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-        public JqGridColumnEditableAttribute(bool editable, string dataUrlAction, string dataUrlController) :
-            this(editable, dataUrlAction, dataUrlController, null)
-        { }
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
+		/// </summary>
+		/// <param name="dataUrlRouteName">Route name for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+		public JqGridColumnEditableAttribute(string dataUrlRouteName)
+			: this()
+		{
+			if (string.IsNullOrWhiteSpace(dataUrlRouteName))
+				throw new ArgumentNullException(nameof(dataUrlRouteName));
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnEditableAttribute class.
-        /// </summary>
-        /// <param name="editable">If this column can be edited</param>
-        /// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-        /// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-        /// <param name="dataUrlAreaName">Area for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-        public JqGridColumnEditableAttribute(bool editable, string dataUrlAction, string dataUrlController, string dataUrlAreaName)
-            : this(editable)
-        {
-            if (String.IsNullOrWhiteSpace(dataUrlAction))
-                throw new ArgumentNullException("dataUrlAction");
-            
-            if (String.IsNullOrWhiteSpace(dataUrlController))
-                throw new ArgumentNullException("dataUrlController");
 
-            DataUrlRouteData = new RouteValueDictionary();
-            DataUrlRouteData["controller"] = dataUrlController;
-            DataUrlRouteData["action"] = dataUrlAction;
+			DataUrlRouteName = dataUrlRouteName;
+			DataUrlRouteData = new RouteValueDictionary();
+		}
 
-            if (dataUrlAreaName != null)
-                DataUrlRouteData["area"] = dataUrlAreaName;
-        }
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
+		/// </summary>
+		/// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+		/// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+		public JqGridColumnEditableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController) :
+			this(dataUrlAction, dataUrlController, null)
+		{ }
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnEditableAttribute class.
-        /// </summary>
-        /// <param name="editable">If this column can be edited</param>
-        /// <param name="valueProviderType">The type of class which contains a method which will provide data for select element (if is JqGridColumnEditTypes.Select). This class must have public parameterless constructor.</param>
-        /// <param name="valueProviderMethodName">The name of method which will provide data for select element (if is JqGridColumnEditTypes.Select). This method must return an object which implements IDictionary&lt;string, string&gt;.</param>
-        public JqGridColumnEditableAttribute(bool editable, Type valueProviderType, string valueProviderMethodName)
-            : this(editable)
-        {
-            if (valueProviderType == null)
-                throw new ArgumentNullException("valueProviderType");
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
+		/// </summary>
+		/// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+		/// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+		/// <param name="dataUrlAreaName">Area for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+		public JqGridColumnEditableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController, [AspMvcArea] string dataUrlAreaName)
+			: this()
+		{
+			if (string.IsNullOrWhiteSpace(dataUrlAction))
+				throw new ArgumentNullException(nameof(dataUrlAction));
 
-            if (String.IsNullOrWhiteSpace(valueProviderMethodName))
-                throw new ArgumentNullException("valueProviderMethodName");
+			if (string.IsNullOrWhiteSpace(dataUrlController))
+				throw new ArgumentNullException(nameof(dataUrlController));
 
-            ValueProviderType = valueProviderType;
-            ValueProviderMethodName = valueProviderMethodName;
-        }
-        #endregion
+			DataUrlRouteData = new RouteValueDictionary
+			{
+				["controller"] = dataUrlController,
+				["action"] = dataUrlAction
+			};
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        protected override void InternalOnMetadataCreated(ModelMetadata metadata)
-        {
-            EditOptions.DataEvents = DataEvents;
-            EditOptions.DataUrl = DataUrl;
-            EditOptions.HtmlAttributes = HtmlAttributes;
-            EditOptions.PostData = PostData;
-            EditOptions.ValueDictionary = ValueDictionary;
+			if (dataUrlAreaName != null)
+				DataUrlRouteData["area"] = dataUrlAreaName;
+		}
 
-            if (EditType == JqGridColumnEditTypes.JQueryUIAutocomplete)
-            {
-                EditType = JqGridColumnEditTypes.Text;
-                EditOptions.ConfigureJQueryUIAutocomplete();
-            }
-            else if (EditType == JqGridColumnEditTypes.JQueryUIDatepicker)
-            {
-                EditType = JqGridColumnEditTypes.Text;
-                EditOptions.ConfigureJQueryUIDatepicker(metadata);
-            }
-            else if (EditType == JqGridColumnEditTypes.JQueryUISpinner)
-            {
-                EditType = JqGridColumnEditTypes.Text;
-                EditOptions.ConfigureJQueryUISpinner();
-            }
-            else if (EditType == JqGridColumnEditTypes.SelectsCascadeParent)
-            {
-                EditType = JqGridColumnEditTypes.Select;
-                EditOptions.ConfigureSelectsCascadeParent();
-            }
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
+		/// </summary>
+		/// <param name="valueProviderType">The type of class which contains a method which will provide data for select element (if is JqGridColumnEditTypes.Select). This class must have public parameterless constructor.</param>
+		/// <param name="valueProviderMethodName">The name of method which will provide data for select element (if is JqGridColumnEditTypes.Select). This method must return an object which implements IDictionary&lt;string, string&gt;.</param>
+		public JqGridColumnEditableAttribute([NotNull] Type valueProviderType, string valueProviderMethodName)
+			: this()
+		{
+			if (string.IsNullOrWhiteSpace(valueProviderMethodName))
+				throw new ArgumentNullException(nameof(valueProviderMethodName));
 
-            metadata.SetColumnDateFormat(DateFormat);
-            metadata.SetColumnEditable(Editable);
-            metadata.SetColumnEditOptions(EditOptions);
-            metadata.SetColumnEditRules(Rules);
-            metadata.SetColumnEditType(EditType);
-            metadata.SetColumnFormOptions(FormOptions);
-        }
-        #endregion
-    }
+			ValueProviderType = valueProviderType ?? throw new ArgumentNullException(nameof(valueProviderType));
+			ValueProviderMethodName = valueProviderMethodName;
+		}
+		#endregion
+
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		protected override void InternalOnMetadataCreated(ModelMetadata metadata)
+		{
+			EditOptions.DataEvents = DataEvents;
+			if (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null)
+				EditOptions.DataUrl = DataUrl;
+			EditOptions.HtmlAttributes = HtmlAttributes;
+			if (!IsPostDataDefault)
+				EditOptions.PostData = PostData;
+			EditOptions.ValueDictionary = ValueDictionary;
+
+			if (EditType == JqGridColumnEditTypes.JQueryUIAutocomplete)
+			{
+				EditType = JqGridColumnEditTypes.Text;
+				EditOptions.ConfigureJQueryUIAutocomplete();
+			}
+			else if (EditType == JqGridColumnEditTypes.JQueryUIDatepicker)
+			{
+				EditType = JqGridColumnEditTypes.Text;
+				EditOptions.ConfigureJQueryUIDatepicker(metadata);
+			}
+			else if (EditType == JqGridColumnEditTypes.JQueryUISpinner)
+			{
+				EditType = JqGridColumnEditTypes.Text;
+				EditOptions.ConfigureJQueryUISpinner();
+			}
+			else if (EditType == JqGridColumnEditTypes.SelectsCascadeParent)
+			{
+				EditType = JqGridColumnEditTypes.Select;
+				EditOptions.ConfigureSelectsCascadeParent();
+			}
+
+			metadata.SetColumnDateFormat(new SettedString(IsDateFormatSetted, DateFormat));
+			metadata.SetColumnEditable(Editable);
+			metadata.SetColumnEditOptions(EditOptions);
+			metadata.SetColumnEditRules(Rules);
+			metadata.SetColumnEditType(EditType);
+			metadata.SetColumnFormOptions(FormOptions);
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnEditableAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnEditableAttribute.cs
@@ -5,287 +5,287 @@ using JetBrains.Annotations;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <inheritdoc />
-	/// <summary>
-	/// Specifies the editing options for column
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property)]
-	public class JqGridColumnEditableAttribute : JqGridColumnElementAttribute
-	{
-		#region Fields
-		private string _dateFormat;
+    /// <inheritdoc />
+    /// <summary>
+    /// Specifies the editing options for column
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class JqGridColumnEditableAttribute : JqGridColumnElementAttribute
+    {
+        #region Fields
+        private string _dateFormat;
 
 
-		#endregion
-		#region Properties
-		/// <summary>
-		/// Gets or sets the name of function which is used to create custom edit element
-		/// </summary>
-		public string CustomElementFunction
-		{
-			get => EditOptions.CustomElementFunction;
-			set => EditOptions.CustomElementFunction = value;
-		}
+        #endregion
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of function which is used to create custom edit element
+        /// </summary>
+        public string CustomElementFunction
+        {
+            get => EditOptions.CustomElementFunction;
+            set => EditOptions.CustomElementFunction = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the name of function which should return the value from the custom element after the editing.
-		/// </summary>
-		public string CustomElementValueFunction
-		{
-			get => EditOptions.CustomValueFunction;
-			set => EditOptions.CustomValueFunction = value;
-		}
+        /// <summary>
+        /// Gets or sets the name of function which should return the value from the custom element after the editing.
+        /// </summary>
+        public string CustomElementValueFunction
+        {
+            get => EditOptions.CustomValueFunction;
+            set => EditOptions.CustomValueFunction = value;
+        }
 
-		internal bool IsDateFormatSetted { get; set; }
-		/// <summary>
-		/// Gets or sets the expected date format for this column in case of date validation (default ISO date). 
-		/// </summary>
-		public string DateFormat
-		{
-			get => _dateFormat;
-			set
-			{
-				_dateFormat = value;
-				IsDateFormatSetted = true;
-			}
-		}
+        internal bool IsDateFormatSetted { get; set; }
+        /// <summary>
+        /// Gets or sets the expected date format for this column in case of date validation (default ISO date). 
+        /// </summary>
+        public string DateFormat
+        {
+            get => _dateFormat;
+            set
+            {
+                _dateFormat = value;
+                IsDateFormatSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets the value defining if this column can be edited.
-		/// </summary>
-		public bool Editable { get; }
+        /// <summary>
+        /// Gets the value defining if this column can be edited.
+        /// </summary>
+        public bool Editable { get; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if hidden column can be edited in form editing.
-		/// </summary>
-		public bool EditHidden
-		{
-			get => Rules.EditHidden ?? false;
-			set => Rules.EditHidden = value;
-		}
+        /// <summary>
+        /// Gets or sets the value which defines if hidden column can be edited in form editing.
+        /// </summary>
+        public bool EditHidden
+        {
+            get => Rules.EditHidden ?? false;
+            set => Rules.EditHidden = value;
+        }
 
-		internal JqGridColumnEditOptions EditOptions
-		{
-			get => Options as JqGridColumnEditOptions;
-			set => Options = value;
-		}
+        internal JqGridColumnEditOptions EditOptions
+        {
+            get => Options as JqGridColumnEditOptions;
+            set => Options = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the type of the editable field (default JqGridColumnEditTypes.Text).
-		/// </summary>
-		public JqGridColumnEditTypes EditType { get; set; }
+        /// <summary>
+        /// Gets or sets the type of the editable field (default JqGridColumnEditTypes.Text).
+        /// </summary>
+        public JqGridColumnEditTypes EditType { get; set; }
 
-		/// <summary>
-		/// Gets or sets the column position of the element (with the label) in form editing (one-based).
-		/// </summary>
-		public int FormColumnPosition
-		{
-			get => FormOptions.ColumnPosition ?? 1;
-			set => FormOptions.ColumnPosition = value;
-		}
+        /// <summary>
+        /// Gets or sets the column position of the element (with the label) in form editing (one-based).
+        /// </summary>
+        public int FormColumnPosition
+        {
+            get => FormOptions.ColumnPosition ?? 1;
+            set => FormOptions.ColumnPosition = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the text or HTML content to appear before the input element in form editing.
-		/// </summary>
-		public string FormElementPrefix
-		{
-			get => FormOptions.ElementPrefix;
-			set => FormOptions.ElementPrefix = value;
-		}
+        /// <summary>
+        /// Gets or sets the text or HTML content to appear before the input element in form editing.
+        /// </summary>
+        public string FormElementPrefix
+        {
+            get => FormOptions.ElementPrefix;
+            set => FormOptions.ElementPrefix = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the text or HTML content to appear after the input element in form editing.
-		/// </summary>
-		public string FormElementSuffix
-		{
-			get => FormOptions.ElementSuffix;
-			set => FormOptions.ElementSuffix = value;
-		}
+        /// <summary>
+        /// Gets or sets the text or HTML content to appear after the input element in form editing.
+        /// </summary>
+        public string FormElementSuffix
+        {
+            get => FormOptions.ElementSuffix;
+            set => FormOptions.ElementSuffix = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the text which will replace the name from ColumnNames as label in form editing.
-		/// </summary>
-		public string FormLabel
-		{
-			get => FormOptions.Label;
-			set => FormOptions.Label = value;
-		}
+        /// <summary>
+        /// Gets or sets the text which will replace the name from ColumnNames as label in form editing.
+        /// </summary>
+        public string FormLabel
+        {
+            get => FormOptions.Label;
+            set => FormOptions.Label = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the row position of the element (with the label) in form editing (one-based).
-		/// </summary>
-		public int FormRowPosition
-		{
-			get => FormOptions.RowPosition ?? 1;
-			set => FormOptions.RowPosition = value;
-		}
+        /// <summary>
+        /// Gets or sets the row position of the element (with the label) in form editing (one-based).
+        /// </summary>
+        public int FormRowPosition
+        {
+            get => FormOptions.RowPosition ?? 1;
+            set => FormOptions.RowPosition = value;
+        }
 
-		internal JqGridColumnFormOptions FormOptions { get; }
+        internal JqGridColumnFormOptions FormOptions { get; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if null value should be send to server if the field is empty.
-		/// </summary>
-		public bool NullIfEmpty
-		{
-			get => EditOptions.NullIfEmpty ?? false;
-			set => EditOptions.NullIfEmpty = value;
-		}
+        /// <summary>
+        /// Gets or sets the value which defines if null value should be send to server if the field is empty.
+        /// </summary>
+        public bool NullIfEmpty
+        {
+            get => EditOptions.NullIfEmpty ?? false;
+            set => EditOptions.NullIfEmpty = value;
+        }
 
-		internal bool IsPostDataDefault { get; private set; }
-		/// <summary>
-		/// When overriden in delivered class, provides additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
-		/// </summary>
-		/// <remarks>Do not call base.PostData when overriden.</remarks>
-		protected virtual object PostData
-		{
-			get
-			{
-				IsPostDataDefault = true;
-				return null;
-			}
-		}
+        internal bool IsPostDataDefault { get; private set; }
+        /// <summary>
+        /// When overriden in delivered class, provides additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
+        /// </summary>
+        /// <remarks>Do not call base.PostData when overriden.</remarks>
+        protected virtual object PostData
+        {
+            get
+            {
+                IsPostDataDefault = true;
+                return null;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select). This property takes precedence over PostData.
-		/// </summary>
-		public string PostDataScript
-		{
-			get => EditOptions.PostDataScript;
-			set => EditOptions.PostDataScript = value;
-		}
+        /// <summary>
+        /// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select). This property takes precedence over PostData.
+        /// </summary>
+        public string PostDataScript
+        {
+            get => EditOptions.PostDataScript;
+            set => EditOptions.PostDataScript = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the child property name if this element performs parent role in selects cascade.
-		/// </summary>
-		public string ChildName
-		{
-			get => EditOptions.ChildName;
-			set => EditOptions.ChildName = value;
-		}
-		#endregion
+        /// <summary>
+        /// Gets or sets the child property name if this element performs parent role in selects cascade.
+        /// </summary>
+        public string ChildName
+        {
+            get => EditOptions.ChildName;
+            set => EditOptions.ChildName = value;
+        }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnEditableAttribute class.
-		/// </summary>
-		/// <param name="editable">If this column can be edited</param>
-		public JqGridColumnEditableAttribute(bool editable = true)
-		{
-			//DateFormat = JqGridOptionsDefaults.DateFormat;
-			Editable = editable;
-			EditOptions = new JqGridColumnEditOptions();
-			EditType = JqGridColumnEditTypes.Default;
-			FormOptions = new JqGridColumnFormOptions();
-		}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnEditableAttribute class.
+        /// </summary>
+        /// <param name="editable">If this column can be edited</param>
+        public JqGridColumnEditableAttribute(bool editable = true)
+        {
+            //DateFormat = JqGridOptionsDefaults.DateFormat;
+            Editable = editable;
+            EditOptions = new JqGridColumnEditOptions();
+            EditType = JqGridColumnEditTypes.Default;
+            FormOptions = new JqGridColumnFormOptions();
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
-		/// </summary>
-		/// <param name="dataUrlRouteName">Route name for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-		public JqGridColumnEditableAttribute(string dataUrlRouteName)
-			: this()
-		{
-			if (string.IsNullOrWhiteSpace(dataUrlRouteName))
-				throw new ArgumentNullException(nameof(dataUrlRouteName));
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
+        /// </summary>
+        /// <param name="dataUrlRouteName">Route name for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+        public JqGridColumnEditableAttribute(string dataUrlRouteName)
+            : this()
+        {
+            if (string.IsNullOrWhiteSpace(dataUrlRouteName))
+                throw new ArgumentNullException(nameof(dataUrlRouteName));
 
 
-			DataUrlRouteName = dataUrlRouteName;
-			DataUrlRouteData = new RouteValueDictionary();
-		}
+            DataUrlRouteName = dataUrlRouteName;
+            DataUrlRouteData = new RouteValueDictionary();
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
-		/// </summary>
-		/// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-		/// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-		public JqGridColumnEditableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController) :
-			this(dataUrlAction, dataUrlController, null)
-		{ }
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
+        /// </summary>
+        /// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+        /// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+        public JqGridColumnEditableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController) :
+            this(dataUrlAction, dataUrlController, null)
+        { }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
-		/// </summary>
-		/// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-		/// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-		/// <param name="dataUrlAreaName">Area for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
-		public JqGridColumnEditableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController, [AspMvcArea] string dataUrlAreaName)
-			: this()
-		{
-			if (string.IsNullOrWhiteSpace(dataUrlAction))
-				throw new ArgumentNullException(nameof(dataUrlAction));
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
+        /// </summary>
+        /// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+        /// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+        /// <param name="dataUrlAreaName">Area for the URL to get the AJAX data for the select element (if EditType is JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if EditType is JqGridColumnEditTypes.Autocomplete).</param>
+        public JqGridColumnEditableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController, [AspMvcArea] string dataUrlAreaName)
+            : this()
+        {
+            if (string.IsNullOrWhiteSpace(dataUrlAction))
+                throw new ArgumentNullException(nameof(dataUrlAction));
 
-			if (string.IsNullOrWhiteSpace(dataUrlController))
-				throw new ArgumentNullException(nameof(dataUrlController));
+            if (string.IsNullOrWhiteSpace(dataUrlController))
+                throw new ArgumentNullException(nameof(dataUrlController));
 
-			DataUrlRouteData = new RouteValueDictionary
-			{
-				["controller"] = dataUrlController,
-				["action"] = dataUrlAction
-			};
+            DataUrlRouteData = new RouteValueDictionary
+            {
+                ["controller"] = dataUrlController,
+                ["action"] = dataUrlAction
+            };
 
-			if (dataUrlAreaName != null)
-				DataUrlRouteData["area"] = dataUrlAreaName;
-		}
+            if (dataUrlAreaName != null)
+                DataUrlRouteData["area"] = dataUrlAreaName;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
-		/// </summary>
-		/// <param name="valueProviderType">The type of class which contains a method which will provide data for select element (if is JqGridColumnEditTypes.Select). This class must have public parameterless constructor.</param>
-		/// <param name="valueProviderMethodName">The name of method which will provide data for select element (if is JqGridColumnEditTypes.Select). This method must return an object which implements IDictionary&lt;string, string&gt;.</param>
-		public JqGridColumnEditableAttribute([NotNull] Type valueProviderType, string valueProviderMethodName)
-			: this()
-		{
-			if (string.IsNullOrWhiteSpace(valueProviderMethodName))
-				throw new ArgumentNullException(nameof(valueProviderMethodName));
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnEditableAttribute class and set column as editable force.
+        /// </summary>
+        /// <param name="valueProviderType">The type of class which contains a method which will provide data for select element (if is JqGridColumnEditTypes.Select). This class must have public parameterless constructor.</param>
+        /// <param name="valueProviderMethodName">The name of method which will provide data for select element (if is JqGridColumnEditTypes.Select). This method must return an object which implements IDictionary&lt;string, string&gt;.</param>
+        public JqGridColumnEditableAttribute([NotNull] Type valueProviderType, string valueProviderMethodName)
+            : this()
+        {
+            if (string.IsNullOrWhiteSpace(valueProviderMethodName))
+                throw new ArgumentNullException(nameof(valueProviderMethodName));
 
-			ValueProviderType = valueProviderType ?? throw new ArgumentNullException(nameof(valueProviderType));
-			ValueProviderMethodName = valueProviderMethodName;
-		}
-		#endregion
+            ValueProviderType = valueProviderType ?? throw new ArgumentNullException(nameof(valueProviderType));
+            ValueProviderMethodName = valueProviderMethodName;
+        }
+        #endregion
 
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		protected override void InternalOnMetadataCreated(ModelMetadata metadata)
-		{
-			EditOptions.DataEvents = DataEvents;
-			if (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null)
-				EditOptions.DataUrl = DataUrl;
-			EditOptions.HtmlAttributes = HtmlAttributes;
-			if (!IsPostDataDefault)
-				EditOptions.PostData = PostData;
-			EditOptions.ValueDictionary = ValueDictionary;
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        protected override void InternalOnMetadataCreated(ModelMetadata metadata)
+        {
+            EditOptions.DataEvents = DataEvents;
+            if (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null)
+                EditOptions.DataUrl = DataUrl;
+            EditOptions.HtmlAttributes = HtmlAttributes;
+            if (!IsPostDataDefault)
+                EditOptions.PostData = PostData;
+            EditOptions.ValueDictionary = ValueDictionary;
 
-			if (EditType == JqGridColumnEditTypes.JQueryUIAutocomplete)
-			{
-				EditType = JqGridColumnEditTypes.Text;
-				EditOptions.ConfigureJQueryUIAutocomplete();
-			}
-			else if (EditType == JqGridColumnEditTypes.JQueryUIDatepicker)
-			{
-				EditType = JqGridColumnEditTypes.Text;
-				EditOptions.ConfigureJQueryUIDatepicker(metadata);
-			}
-			else if (EditType == JqGridColumnEditTypes.JQueryUISpinner)
-			{
-				EditType = JqGridColumnEditTypes.Text;
-				EditOptions.ConfigureJQueryUISpinner();
-			}
-			else if (EditType == JqGridColumnEditTypes.SelectsCascadeParent)
-			{
-				EditType = JqGridColumnEditTypes.Select;
-				EditOptions.ConfigureSelectsCascadeParent();
-			}
+            if (EditType == JqGridColumnEditTypes.JQueryUIAutocomplete)
+            {
+                EditType = JqGridColumnEditTypes.Text;
+                EditOptions.ConfigureJQueryUIAutocomplete();
+            }
+            else if (EditType == JqGridColumnEditTypes.JQueryUIDatepicker)
+            {
+                EditType = JqGridColumnEditTypes.Text;
+                EditOptions.ConfigureJQueryUIDatepicker(metadata);
+            }
+            else if (EditType == JqGridColumnEditTypes.JQueryUISpinner)
+            {
+                EditType = JqGridColumnEditTypes.Text;
+                EditOptions.ConfigureJQueryUISpinner();
+            }
+            else if (EditType == JqGridColumnEditTypes.SelectsCascadeParent)
+            {
+                EditType = JqGridColumnEditTypes.Select;
+                EditOptions.ConfigureSelectsCascadeParent();
+            }
 
-			metadata.SetColumnDateFormat(new SettedString(IsDateFormatSetted, DateFormat));
-			metadata.SetColumnEditable(Editable);
-			metadata.SetColumnEditOptions(EditOptions);
-			metadata.SetColumnEditRules(Rules);
-			metadata.SetColumnEditType(EditType);
-			metadata.SetColumnFormOptions(FormOptions);
-		}
-		#endregion
-	}
+            metadata.SetColumnDateFormat(new SettedString(IsDateFormatSetted, DateFormat));
+            metadata.SetColumnEditable(Editable);
+            metadata.SetColumnEditOptions(EditOptions);
+            metadata.SetColumnEditRules(Rules);
+            metadata.SetColumnEditType(EditType);
+            metadata.SetColumnFormOptions(FormOptions);
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnEditableAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnEditableAttribute.cs
@@ -254,6 +254,7 @@ namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
             if (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null)
                 EditOptions.DataUrl = DataUrl;
             EditOptions.HtmlAttributes = HtmlAttributes;
+            object testOverridePostData = PostData;
             if (!IsPostDataDefault)
                 EditOptions.PostData = PostData;
             EditOptions.ValueDictionary = ValueDictionary;

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnElementAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnElementAttribute.cs
@@ -510,6 +510,7 @@ namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
         /// <param name="metadata">The model metadata.</param>
         public void OnMetadataCreated(ModelMetadata metadata)
         {
+            string testOverrideValue = Value;
             if (!IsValueNotOveriden || IsValueSetted)
                 Options.Value = Value;
 

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnElementAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnElementAttribute.cs
@@ -1,530 +1,531 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Web.Routing;
 using System.Web.Mvc;
 using System.Web;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <summary>
-	/// Base class which specifies the options for jqGrid editable or searchable column element
-	/// </summary>
-	public abstract class JqGridColumnElementAttribute : Attribute, IMetadataAware
-	{
-		private string _value;
-
-		#region Properties
-		internal string DataUrl
-		{
-			get
-			{
-				if (HttpContext.Current != null && (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null))
-				{
-					var dataUrlRouteValueDictionary = DataUrlRouteData;
-					if (DataUrlRouteValues != null)
-					{
-						dataUrlRouteValueDictionary = new RouteValueDictionary(DataUrlRouteValues);
-						if (DataUrlRouteData != null)
-						{
-							foreach (var key in DataUrlRouteData.Keys)
-							{
-								if (dataUrlRouteValueDictionary.ContainsKey(key))
-									dataUrlRouteValueDictionary[key] = DataUrlRouteData[key];
-								else
-									dataUrlRouteValueDictionary.Add(key, DataUrlRouteData[key]);
-							}
-						}
-					}
-					var dataUrlPathData = RouteTable.Routes.GetVirtualPathForArea(HttpContext.Current.Request != null ? HttpContext.Current.Request.RequestContext : null, DataUrlRouteName, dataUrlRouteValueDictionary);
-
-					if (dataUrlPathData == null)
-						throw new InvalidOperationException("The DataUrl could not be resolved.");
-
-					return dataUrlPathData.VirtualPath;
-				}
-				return null;
-			}
-		}
-
-		internal RouteValueDictionary DataUrlRouteData { get; set; }
-
-		internal string DataUrlRouteName { get; set; }
-
-		/// <summary>
-		/// When overriden in delivered class, provides additional route values for the select element AJAX request.
-		/// </summary>
-		protected virtual object DataUrlRouteValues => null;
-
-		/// <summary>
-		/// Gets or sets the text to display after each date field (jQuery UI Datepicker widget).
-		/// </summary>
-		public string AppendText
-		{
-			get => Options.AppendText;
-			set => Options.AppendText = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the first item will automatically be focused when the menu is shown (jQuery UI Autocomplete widget).
-		/// </summary>
-		public bool AutoFocus
-		{
-			get => Options.AutoFocus;
-			set => Options.AutoFocus = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the input field should be automatically resize to accommodate dates in the current format (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool AutoSize
-		{
-			get => Options.AutoSize;
-			set => Options.AutoSize = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the function which will build the select element in case where the server response can not build it (requires DataUrl property to be set).
-		/// </summary>
-		public string BuildSelect
-		{
-			get => Options.BuildSelect;
-			set => Options.BuildSelect = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the month should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ChangeMonth
-		{
-			get => Options.ChangeMonth;
-			set => Options.ChangeMonth = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the year should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ChangeYear
-		{
-			get => Options.ChangeYear;
-			set => Options.ChangeYear = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the input field should constrained to characters allowed by the current format (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ConstrainInput
-		{
-			get => Options.ConstrainInput;
-			set => Options.ConstrainInput = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the culture to use for parsing and formatting the value when Globalize plugin is included (jQuery UI Spinner widget).
-		/// </summary>
-		public string Culture
-		{
-			get => Options.Culture;
-			set => Options.Culture = value;
-		}
-
-		/// <summary>
-		/// Gets or sets if the value should be validated with custom function.
-		/// </summary>
-		public bool CustomValidation
-		{
-			get => Rules.Custom ?? false;
-			set => Rules.Custom = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the name of custom validation function
-		/// </summary>
-		public string CustomValidationFunction
-		{
-			get => Rules.CustomFunction;
-			set => Rules.CustomFunction = value;
-		}
-
-		/// <summary>
-		/// When overriden in delivered class, provides a list of events to apply to the element.
-		/// </summary>
-		protected virtual IList<JqGridColumnDataEvent> DataEvents => null;
-
-		/// <summary>
-		/// Gets or sets the function which will be called once when the element is created. This property is ignored in case of jQuery UI widgets.
-		/// </summary>
-		public string DataInit
-		{
-			get => Options.DataInit;
-			set => Options.DataInit = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the format for parsed and displayed dates (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>If the value for this property is not provided, but there is a JqGridColumnFormatterAttribute with JqGridColumnPredefinedFormatters.Date formatter the helper will try to provide the value based on JqGridColumnFormatterAttribute.OutputFormat.</remarks> 
-		public string DatepickerDateFormat
-		{
-			get => Options.DatePickerDateFormat;
-			set => Options.DatePickerDateFormat = value;
-		}
-
-		/// <summary>
-		/// Gets or sets if the value should be valid date.
-		/// </summary>
-		public bool DateValidation
-		{
-			get => Rules.Date ?? false;
-			set => Rules.Date = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the default value in the search input element.
-		/// </summary>
-		public string DefaultValue
-		{
-			get => Options.DefaultValue;
-			set => Options.DefaultValue = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the delay in milliseconds between when a keystroke occurs and when a search is performed (jQuery UI Autocomplete widget).
-		/// </summary>
-		public int Delay
-		{
-			get => Options.Delay;
-			set => Options.Delay = value;
-		}
-
-		/// <summary>
-		/// Gets or sets if the value should be valid email
-		/// </summary>
-		public bool EmailValidation
-		{
-			get => Rules.Email ?? false;
-			set => Rules.Email = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the first day of the week: Sunday is 0, Monday is 1, etc. (jQuery UI Datepicker widget).
-		/// </summary>
-		public int FirstDay
-		{
-			get => Options.FirstDay;
-			set => Options.FirstDay = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the current day link moves to the currently selected date instead of today. (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool GotoCurrent
-		{
-			get => Options.GotoCurrent;
-			set => Options.GotoCurrent = value;
-		}
-
-		/// <summary>
-		/// When overriden in delivered class, provides a dictionary where keys should be valid attributes for the element.
-		/// </summary>
-		protected virtual IDictionary<string, object> HtmlAttributes => null;
-
-		/// <summary>
-		/// Gets or sets value controlling the number of steps taken when holding down a spin button (jQuery UI Spinner widget).
-		/// </summary>
-		public bool Incremental
-		{
-			get => Options.Incremental;
-			set => Options.Incremental = value;
-		}
-
-		/// <summary>
-		/// Gets or sets maximum allowed value (jQuery UI Spinner widget).
-		/// </summary>
-		public int Max
-		{
-			get => Options.Max ?? int.MaxValue;
-			set => Options.Max = value;
-		}
-
-		/// <summary>
-		/// Gets or sets minimum allowed value (jQuery UI Spinner widget).
-		/// </summary>
-		public int Min
-		{
-			get => Options.Min ?? int.MinValue;
-			set => Options.Min = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the maximum selectable date. (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
-		public string MaxDate
-		{
-			get => Options.MaxDate;
-			set => Options.MaxDate = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the minimum selectable date. (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
-		public string MinDate
-		{
-			get => Options.MinDate;
-			set => Options.MinDate = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the minimum number of characters a user must type before a search is performed (jQuery UI Autocomplete widget).
-		/// </summary>
-		public int MinLength
-		{
-			get => Options.MinLength;
-			set => Options.MinLength = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the format of numbers passed to Globalize plugin if it is included (jQuery UI Spinner widget).
-		/// </summary>
-		public string NumberFormat
-		{
-			get => Options.NumberFormat;
-			set => Options.NumberFormat = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the number of months to show at once (jQuery UI Datepicker widget).
-		/// </summary>
-		public int NumberOfMonths
-		{
-			get => Options.NumberOfMonths;
-			set => Options.NumberOfMonths = value;
-		}
-
-		internal JqGridColumnElementOptions Options { get; set; }
-
-		/// <summary>
-		/// Gets or sets the number of steps to take when paging via the pageUp/pageDown JavaScript methods (jQuery UI Spinner widget).
-		/// </summary>
-		public int Page
-		{
-			get => Options.Page;
-			set => Options.Page = value;
-		}
-
-		internal JqGridColumnRules Rules { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating whether days in other months shown before or after the current month are selectable, this only applies if the ShowOtherMonths is set to true. (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool SelectOtherMonths
-		{
-			get => Options.SelectOtherMonths;
-			set => Options.SelectOtherMonths = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the cutoff year for determining the century for a date (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>This string must be a relative number of years from the current year, e.g., "+3" or "-5".</remarks> 
-		public string ShortYearCutoff
-		{
-			get => Options.ShortYearCutoff;
-			set => Options.ShortYearCutoff = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value which defines position to display the current month in, if the ShowOtherMonths is set to true (jQuery UI Datepicker widget).
-		/// </summary>
-		public int ShowCurrentAtPos
-		{
-			get => Options.ShowCurrentAtPos;
-			set => Options.ShowCurrentAtPos = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating whether to show the month after the year in the header (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ShowMonthAfterYear
-		{
-			get => Options.ShowMonthAfterYear;
-			set => Options.ShowMonthAfterYear = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating whether to display dates in other months (non-selectable) at the start or end of the current month, to make these days selectable set the SelectOtherMonths to true (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ShowOtherMonths
-		{
-			get => Options.ShowOtherMonths;
-			set => Options.ShowOtherMonths = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating whether to add column with the week of the year (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ShowWeek
-		{
-			get => Options.ShowWeek;
-			set => Options.ShowWeek = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget down button.
-		/// </summary>
-		public string SpinnerDownIcon
-		{
-			get => Options.SpinnerDownIcon;
-			set => Options.SpinnerDownIcon = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget up button.
-		/// </summary>
-		public string SpinnerUpIcon
-		{
-			get => Options.SpinnerUpIcon;
-			set => Options.SpinnerUpIcon = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the size of the step to take when spinning via buttons or via the stepUp/stepDown JavaScript methods (jQuery UI Spinner widget).
-		/// </summary>
-		public int Step
-		{
-			get => Options.Step;
-			set => Options.Step = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the value which defines how many months to move when clicking the previous/next links (jQuery UI Datepicker widget).
-		/// </summary>
-		public int StepMonths
-		{
-			get => Options.StepMonths;
-			set => Options.StepMonths = value;
-		}
-
-		/// <summary>
-		/// Gets or sets if the value should be valid time (hh:mm format and optional am/pm at the end).
-		/// </summary>
-		public bool TimeValidation
-		{
-			get => Rules.Time ?? false;
-			set => Rules.Time = value;
-		}
-
-		/// <summary>
-		/// Gets or sets if the value should be valid url.
-		/// </summary>
-		public bool UrlValidation
-		{
-			get => Rules.Url ?? false;
-			set => Rules.Url = value;
-		}
-
-		internal bool IsValueSetted { get; private set; }
-		internal bool IsValueNotOveriden { get; private set; }
-
-		/// <summary>
-		/// Gets or sets the set of value:label pairs for select element.
-		/// </summary>
-		public virtual string Value
-		{
-			get
-			{
-				IsValueNotOveriden = true;
-				return _value;
-			}
-			set
-			{
-				_value = value;
-				IsValueSetted = true;
-			}
-
-		}
-
-		internal Type ValueProviderType { get; set; }
-
-		internal string ValueProviderMethodName { get; set; }
-
-		internal IDictionary<string, string> ValueDictionary
-		{
-			get
-			{
-				if (ValueProviderType != null && !string.IsNullOrWhiteSpace(ValueProviderMethodName))
-				{
-					var valueProviderMethodInfo = ValueProviderType.GetMethod(ValueProviderMethodName);
-					if (valueProviderMethodInfo == null)
-						throw new InvalidOperationException("The method specified by ValueProviderType and ValueProviderMethodName could not be found.");
-
-					var valueProviderConstructorInfo = ValueProviderType.GetConstructor(Type.EmptyTypes);
-					if (valueProviderConstructorInfo == null)
-						throw new InvalidOperationException("The type specified by ValueProviderType does not have parameterless constructor.");
-
-					var valueProvider = valueProviderConstructorInfo.Invoke(null);
-					if (typeof(IDictionary<string, string>).IsAssignableFrom(valueProviderMethodInfo.ReturnType))
-						return (IDictionary<string, string>)valueProviderMethodInfo.Invoke(valueProvider, null);
-					throw new InvalidOperationException("The method specified by ValueProviderType and ValueProviderMethodName does not return IDictionary<string, string>.");
-				}
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the range of years displayed in the year dropdown (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>This string must be either relative to today's year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). Note that this option only affects what appears in the dropdown, to restrict which dates may be selected use the MinDate and/or MaxDate.</remarks> 
-		public string YearRange
-		{
-			get => Options.YearRange;
-			set => Options.YearRange = value;
-		}
-
-		/// <summary>
-		/// Gets or sets the additional text to display after the year in the month headers (jQuery UI Datepicker widget).
-		/// </summary>
-		public string YearSuffix
-		{
-			get => Options.YearSuffix;
-			set => Options.YearSuffix = value;
-		}
-		#endregion
-
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnElementAttribute class.
-		/// </summary>
-		protected JqGridColumnElementAttribute()
-		{
-			Rules = new JqGridColumnRules();
-		}
-		#endregion
-
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		public void OnMetadataCreated(ModelMetadata metadata)
-		{
-			if (!IsValueNotOveriden || IsValueSetted)
-				Options.Value = Value;
-
-			if (metadata.ModelType == typeof(short) || metadata.ModelType == typeof(int) || metadata.ModelType == typeof(long) || metadata.ModelType == typeof(ushort) || metadata.ModelType == typeof(uint) || metadata.ModelType == typeof(uint))
-				Rules.Integer = true;
-			else if (metadata.ModelType == typeof(decimal) || metadata.ModelType == typeof(double) || metadata.ModelType == typeof(float))
-				Rules.Number = true;
-
-			InternalOnMetadataCreated(metadata);
-		}
-
-		/// <summary>
-		/// Provides metadata to the model metadata creation process in derivered class.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		protected abstract void InternalOnMetadataCreated(ModelMetadata metadata);
-		#endregion
-	}
+    /// <summary>
+    /// Base class which specifies the options for jqGrid editable or searchable column element
+    /// </summary>
+    public abstract class JqGridColumnElementAttribute : Attribute, IMetadataAware
+    {
+        private string _value;
+
+        #region Properties
+        internal string DataUrl
+        {
+            get
+            {
+                if (HttpContext.Current != null && (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null))
+                {
+                    RouteValueDictionary dataUrlRouteValueDictionary = DataUrlRouteData;
+                    if (DataUrlRouteValues != null)
+                    {
+                        dataUrlRouteValueDictionary = new RouteValueDictionary(DataUrlRouteValues);
+                        if (DataUrlRouteData != null)
+                        {
+                            foreach (string key in DataUrlRouteData.Keys)
+                            {
+                                if (dataUrlRouteValueDictionary.ContainsKey(key))
+                                    dataUrlRouteValueDictionary[key] = DataUrlRouteData[key];
+                                else
+                                    dataUrlRouteValueDictionary.Add(key, DataUrlRouteData[key]);
+                            }
+                        }
+                    }
+                    VirtualPathData dataUrlPathData = RouteTable.Routes.GetVirtualPathForArea(HttpContext.Current.Request != null ? HttpContext.Current.Request.RequestContext : null, DataUrlRouteName, dataUrlRouteValueDictionary);
+
+                    if (dataUrlPathData == null)
+                        throw new InvalidOperationException("The DataUrl could not be resolved.");
+
+                    return dataUrlPathData.VirtualPath;
+                }
+                return null;
+            }
+        }
+
+        internal RouteValueDictionary DataUrlRouteData { get; set; }
+
+        internal string DataUrlRouteName { get; set; }
+
+        /// <summary>
+        /// When overriden in delivered class, provides additional route values for the select element AJAX request.
+        /// </summary>
+        protected virtual object DataUrlRouteValues => null;
+
+        /// <summary>
+        /// Gets or sets the text to display after each date field (jQuery UI Datepicker widget).
+        /// </summary>
+        public string AppendText
+        {
+            get => Options.AppendText;
+            set => Options.AppendText = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the first item will automatically be focused when the menu is shown (jQuery UI Autocomplete widget).
+        /// </summary>
+        public bool AutoFocus
+        {
+            get => Options.AutoFocus;
+            set => Options.AutoFocus = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the input field should be automatically resize to accommodate dates in the current format (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool AutoSize
+        {
+            get => Options.AutoSize;
+            set => Options.AutoSize = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the function which will build the select element in case where the server response can not build it (requires DataUrl property to be set).
+        /// </summary>
+        public string BuildSelect
+        {
+            get => Options.BuildSelect;
+            set => Options.BuildSelect = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the month should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ChangeMonth
+        {
+            get => Options.ChangeMonth;
+            set => Options.ChangeMonth = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the year should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ChangeYear
+        {
+            get => Options.ChangeYear;
+            set => Options.ChangeYear = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the input field should constrained to characters allowed by the current format (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ConstrainInput
+        {
+            get => Options.ConstrainInput;
+            set => Options.ConstrainInput = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the culture to use for parsing and formatting the value when Globalize plugin is included (jQuery UI Spinner widget).
+        /// </summary>
+        public string Culture
+        {
+            get => Options.Culture;
+            set => Options.Culture = value;
+        }
+
+        /// <summary>
+        /// Gets or sets if the value should be validated with custom function.
+        /// </summary>
+        public bool CustomValidation
+        {
+            get => Rules.Custom ?? false;
+            set => Rules.Custom = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of custom validation function
+        /// </summary>
+        public string CustomValidationFunction
+        {
+            get => Rules.CustomFunction;
+            set => Rules.CustomFunction = value;
+        }
+
+        /// <summary>
+        /// When overriden in delivered class, provides a list of events to apply to the element.
+        /// </summary>
+        protected virtual IList<JqGridColumnDataEvent> DataEvents => null;
+
+        /// <summary>
+        /// Gets or sets the function which will be called once when the element is created. This property is ignored in case of jQuery UI widgets.
+        /// </summary>
+        public string DataInit
+        {
+            get => Options.DataInit;
+            set => Options.DataInit = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the format for parsed and displayed dates (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>If the value for this property is not provided, but there is a JqGridColumnFormatterAttribute with JqGridColumnPredefinedFormatters.Date formatter the helper will try to provide the value based on JqGridColumnFormatterAttribute.OutputFormat.</remarks> 
+        public string DatepickerDateFormat
+        {
+            get => Options.DatePickerDateFormat;
+            set => Options.DatePickerDateFormat = value;
+        }
+
+        /// <summary>
+        /// Gets or sets if the value should be valid date.
+        /// </summary>
+        public bool DateValidation
+        {
+            get => Rules.Date ?? false;
+            set => Rules.Date = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the default value in the search input element.
+        /// </summary>
+        public string DefaultValue
+        {
+            get => Options.DefaultValue;
+            set => Options.DefaultValue = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the delay in milliseconds between when a keystroke occurs and when a search is performed (jQuery UI Autocomplete widget).
+        /// </summary>
+        public int Delay
+        {
+            get => Options.Delay;
+            set => Options.Delay = value;
+        }
+
+        /// <summary>
+        /// Gets or sets if the value should be valid email
+        /// </summary>
+        public bool EmailValidation
+        {
+            get => Rules.Email ?? false;
+            set => Rules.Email = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the first day of the week: Sunday is 0, Monday is 1, etc. (jQuery UI Datepicker widget).
+        /// </summary>
+        public int FirstDay
+        {
+            get => Options.FirstDay;
+            set => Options.FirstDay = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the current day link moves to the currently selected date instead of today. (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool GotoCurrent
+        {
+            get => Options.GotoCurrent;
+            set => Options.GotoCurrent = value;
+        }
+
+        /// <summary>
+        /// When overriden in delivered class, provides a dictionary where keys should be valid attributes for the element.
+        /// </summary>
+        protected virtual IDictionary<string, object> HtmlAttributes => null;
+
+        /// <summary>
+        /// Gets or sets value controlling the number of steps taken when holding down a spin button (jQuery UI Spinner widget).
+        /// </summary>
+        public bool Incremental
+        {
+            get => Options.Incremental;
+            set => Options.Incremental = value;
+        }
+
+        /// <summary>
+        /// Gets or sets maximum allowed value (jQuery UI Spinner widget).
+        /// </summary>
+        public int Max
+        {
+            get => Options.Max ?? int.MaxValue;
+            set => Options.Max = value;
+        }
+
+        /// <summary>
+        /// Gets or sets minimum allowed value (jQuery UI Spinner widget).
+        /// </summary>
+        public int Min
+        {
+            get => Options.Min ?? int.MinValue;
+            set => Options.Min = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum selectable date. (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
+        public string MaxDate
+        {
+            get => Options.MaxDate;
+            set => Options.MaxDate = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the minimum selectable date. (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
+        public string MinDate
+        {
+            get => Options.MinDate;
+            set => Options.MinDate = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the minimum number of characters a user must type before a search is performed (jQuery UI Autocomplete widget).
+        /// </summary>
+        public int MinLength
+        {
+            get => Options.MinLength;
+            set => Options.MinLength = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the format of numbers passed to Globalize plugin if it is included (jQuery UI Spinner widget).
+        /// </summary>
+        public string NumberFormat
+        {
+            get => Options.NumberFormat;
+            set => Options.NumberFormat = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the number of months to show at once (jQuery UI Datepicker widget).
+        /// </summary>
+        public int NumberOfMonths
+        {
+            get => Options.NumberOfMonths;
+            set => Options.NumberOfMonths = value;
+        }
+
+        internal JqGridColumnElementOptions Options { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of steps to take when paging via the pageUp/pageDown JavaScript methods (jQuery UI Spinner widget).
+        /// </summary>
+        public int Page
+        {
+            get => Options.Page;
+            set => Options.Page = value;
+        }
+
+        internal JqGridColumnRules Rules { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether days in other months shown before or after the current month are selectable, this only applies if the ShowOtherMonths is set to true. (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool SelectOtherMonths
+        {
+            get => Options.SelectOtherMonths;
+            set => Options.SelectOtherMonths = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the cutoff year for determining the century for a date (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>This string must be a relative number of years from the current year, e.g., "+3" or "-5".</remarks> 
+        public string ShortYearCutoff
+        {
+            get => Options.ShortYearCutoff;
+            set => Options.ShortYearCutoff = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value which defines position to display the current month in, if the ShowOtherMonths is set to true (jQuery UI Datepicker widget).
+        /// </summary>
+        public int ShowCurrentAtPos
+        {
+            get => Options.ShowCurrentAtPos;
+            set => Options.ShowCurrentAtPos = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to show the month after the year in the header (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ShowMonthAfterYear
+        {
+            get => Options.ShowMonthAfterYear;
+            set => Options.ShowMonthAfterYear = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to display dates in other months (non-selectable) at the start or end of the current month, to make these days selectable set the SelectOtherMonths to true (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ShowOtherMonths
+        {
+            get => Options.ShowOtherMonths;
+            set => Options.ShowOtherMonths = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to add column with the week of the year (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ShowWeek
+        {
+            get => Options.ShowWeek;
+            set => Options.ShowWeek = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget down button.
+        /// </summary>
+        public string SpinnerDownIcon
+        {
+            get => Options.SpinnerDownIcon;
+            set => Options.SpinnerDownIcon = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget up button.
+        /// </summary>
+        public string SpinnerUpIcon
+        {
+            get => Options.SpinnerUpIcon;
+            set => Options.SpinnerUpIcon = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the size of the step to take when spinning via buttons or via the stepUp/stepDown JavaScript methods (jQuery UI Spinner widget).
+        /// </summary>
+        public int Step
+        {
+            get => Options.Step;
+            set => Options.Step = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value which defines how many months to move when clicking the previous/next links (jQuery UI Datepicker widget).
+        /// </summary>
+        public int StepMonths
+        {
+            get => Options.StepMonths;
+            set => Options.StepMonths = value;
+        }
+
+        /// <summary>
+        /// Gets or sets if the value should be valid time (hh:mm format and optional am/pm at the end).
+        /// </summary>
+        public bool TimeValidation
+        {
+            get => Rules.Time ?? false;
+            set => Rules.Time = value;
+        }
+
+        /// <summary>
+        /// Gets or sets if the value should be valid url.
+        /// </summary>
+        public bool UrlValidation
+        {
+            get => Rules.Url ?? false;
+            set => Rules.Url = value;
+        }
+
+        internal bool IsValueSetted { get; private set; }
+        internal bool IsValueNotOveriden { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the set of value:label pairs for select element.
+        /// </summary>
+        public virtual string Value
+        {
+            get
+            {
+                IsValueNotOveriden = true;
+                return _value;
+            }
+            set
+            {
+                _value = value;
+                IsValueSetted = true;
+            }
+
+        }
+
+        internal Type ValueProviderType { get; set; }
+
+        internal string ValueProviderMethodName { get; set; }
+
+        internal IDictionary<string, string> ValueDictionary
+        {
+            get
+            {
+                if (ValueProviderType != null && !string.IsNullOrWhiteSpace(ValueProviderMethodName))
+                {
+                    MethodInfo valueProviderMethodInfo = ValueProviderType.GetMethod(ValueProviderMethodName);
+                    if (valueProviderMethodInfo == null)
+                        throw new InvalidOperationException("The method specified by ValueProviderType and ValueProviderMethodName could not be found.");
+
+                    ConstructorInfo valueProviderConstructorInfo = ValueProviderType.GetConstructor(Type.EmptyTypes);
+                    if (valueProviderConstructorInfo == null)
+                        throw new InvalidOperationException("The type specified by ValueProviderType does not have parameterless constructor.");
+
+                    object valueProvider = valueProviderConstructorInfo.Invoke(null);
+                    if (typeof(IDictionary<string, string>).IsAssignableFrom(valueProviderMethodInfo.ReturnType))
+                        return (IDictionary<string, string>)valueProviderMethodInfo.Invoke(valueProvider, null);
+                    throw new InvalidOperationException("The method specified by ValueProviderType and ValueProviderMethodName does not return IDictionary<string, string>.");
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the range of years displayed in the year dropdown (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>This string must be either relative to today's year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). Note that this option only affects what appears in the dropdown, to restrict which dates may be selected use the MinDate and/or MaxDate.</remarks> 
+        public string YearRange
+        {
+            get => Options.YearRange;
+            set => Options.YearRange = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the additional text to display after the year in the month headers (jQuery UI Datepicker widget).
+        /// </summary>
+        public string YearSuffix
+        {
+            get => Options.YearSuffix;
+            set => Options.YearSuffix = value;
+        }
+        #endregion
+
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnElementAttribute class.
+        /// </summary>
+        protected JqGridColumnElementAttribute()
+        {
+            Rules = new JqGridColumnRules();
+        }
+        #endregion
+
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        public void OnMetadataCreated(ModelMetadata metadata)
+        {
+            if (!IsValueNotOveriden || IsValueSetted)
+                Options.Value = Value;
+
+            if (metadata.ModelType == typeof(short) || metadata.ModelType == typeof(int) || metadata.ModelType == typeof(long) || metadata.ModelType == typeof(ushort) || metadata.ModelType == typeof(uint) || metadata.ModelType == typeof(uint))
+                Rules.Integer = true;
+            else if (metadata.ModelType == typeof(decimal) || metadata.ModelType == typeof(double) || metadata.ModelType == typeof(float))
+                Rules.Number = true;
+
+            InternalOnMetadataCreated(metadata);
+        }
+
+        /// <summary>
+        /// Provides metadata to the model metadata creation process in derivered class.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        protected abstract void InternalOnMetadataCreated(ModelMetadata metadata);
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnElementAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnElementAttribute.cs
@@ -1,524 +1,530 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Routing;
 using System.Web.Mvc;
 using System.Web;
-using System.Reflection;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Base class which specifies the options for jqGrid editable or searchable column element
-    /// </summary>
-    public abstract class JqGridColumnElementAttribute : Attribute, IMetadataAware
-    {
-        #region Properties
-        internal string DataUrl
-        {
-            get
-            {
-                if ((HttpContext.Current != null) && (!String.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null))
-                {
-                    RouteValueDictionary dataUrlRouteValueDictionary = DataUrlRouteData;
-                    if (DataUrlRouteValues != null)
-                    {
-                        dataUrlRouteValueDictionary = new RouteValueDictionary(DataUrlRouteValues);
-                        if (DataUrlRouteData != null)
-                        {
-                            foreach (string key in DataUrlRouteData.Keys)
-                            {
-                                if (dataUrlRouteValueDictionary.ContainsKey(key))
-                                    dataUrlRouteValueDictionary[key] = DataUrlRouteData[key];
-                                else
-                                    dataUrlRouteValueDictionary.Add(key, DataUrlRouteData[key]);
-                            }
-                        }
-                    }
-                    VirtualPathData dataUrlPathData = RouteTable.Routes.GetVirtualPathForArea(HttpContext.Current.Request != null ? HttpContext.Current.Request.RequestContext : null, DataUrlRouteName, dataUrlRouteValueDictionary);
+	/// <summary>
+	/// Base class which specifies the options for jqGrid editable or searchable column element
+	/// </summary>
+	public abstract class JqGridColumnElementAttribute : Attribute, IMetadataAware
+	{
+		private string _value;
 
-                    if (dataUrlPathData == null)
-                        throw new InvalidOperationException("The DataUrl could not be resolved.");
+		#region Properties
+		internal string DataUrl
+		{
+			get
+			{
+				if (HttpContext.Current != null && (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null))
+				{
+					var dataUrlRouteValueDictionary = DataUrlRouteData;
+					if (DataUrlRouteValues != null)
+					{
+						dataUrlRouteValueDictionary = new RouteValueDictionary(DataUrlRouteValues);
+						if (DataUrlRouteData != null)
+						{
+							foreach (var key in DataUrlRouteData.Keys)
+							{
+								if (dataUrlRouteValueDictionary.ContainsKey(key))
+									dataUrlRouteValueDictionary[key] = DataUrlRouteData[key];
+								else
+									dataUrlRouteValueDictionary.Add(key, DataUrlRouteData[key]);
+							}
+						}
+					}
+					var dataUrlPathData = RouteTable.Routes.GetVirtualPathForArea(HttpContext.Current.Request != null ? HttpContext.Current.Request.RequestContext : null, DataUrlRouteName, dataUrlRouteValueDictionary);
 
-                    return dataUrlPathData.VirtualPath;
-                }
-                return null;
-            }
-        }
+					if (dataUrlPathData == null)
+						throw new InvalidOperationException("The DataUrl could not be resolved.");
 
-        internal RouteValueDictionary DataUrlRouteData { get; set; }
+					return dataUrlPathData.VirtualPath;
+				}
+				return null;
+			}
+		}
 
-        internal string DataUrlRouteName { get; set; }
+		internal RouteValueDictionary DataUrlRouteData { get; set; }
 
-        /// <summary>
-        /// When overriden in delivered class, provides additional route values for the select element AJAX request.
-        /// </summary>
-        protected virtual object DataUrlRouteValues
-        {
-            get { return null; }
-        }
+		internal string DataUrlRouteName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text to display after each date field (jQuery UI Datepicker widget).
-        /// </summary>
-        public string AppendText
-        {
-            get { return Options.AppendText; }
-            set { Options.AppendText = value; }
-        }
+		/// <summary>
+		/// When overriden in delivered class, provides additional route values for the select element AJAX request.
+		/// </summary>
+		protected virtual object DataUrlRouteValues => null;
 
-        /// <summary>
-        /// Gets or sets the value indicating if the first item will automatically be focused when the menu is shown (jQuery UI Autocomplete widget).
-        /// </summary>
-        public bool AutoFocus
-        {
-            get { return Options.AutoFocus; }
-            set { Options.AutoFocus = value; }
-        }
+		/// <summary>
+		/// Gets or sets the text to display after each date field (jQuery UI Datepicker widget).
+		/// </summary>
+		public string AppendText
+		{
+			get => Options.AppendText;
+			set => Options.AppendText = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating if the input field should be automatically resize to accommodate dates in the current format (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool AutoSize
-        {
-            get { return Options.AutoSize; }
-            set { Options.AutoSize = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating if the first item will automatically be focused when the menu is shown (jQuery UI Autocomplete widget).
+		/// </summary>
+		public bool AutoFocus
+		{
+			get => Options.AutoFocus;
+			set => Options.AutoFocus = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the function which will build the select element in case where the server response can not build it (requires DataUrl property to be set).
-        /// </summary>
-        public string BuildSelect
-        {
-            get { return Options.BuildSelect; }
-            set { Options.BuildSelect = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating if the input field should be automatically resize to accommodate dates in the current format (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool AutoSize
+		{
+			get => Options.AutoSize;
+			set => Options.AutoSize = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating if the month should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ChangeMonth
-        {
-            get { return Options.ChangeMonth; }
-            set { Options.ChangeMonth = value; }
-        }
+		/// <summary>
+		/// Gets or sets the function which will build the select element in case where the server response can not build it (requires DataUrl property to be set).
+		/// </summary>
+		public string BuildSelect
+		{
+			get => Options.BuildSelect;
+			set => Options.BuildSelect = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating if the year should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ChangeYear
-        {
-            get { return Options.ChangeYear; }
-            set { Options.ChangeYear = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating if the month should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ChangeMonth
+		{
+			get => Options.ChangeMonth;
+			set => Options.ChangeMonth = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating if the input field should constrained to characters allowed by the current format (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ConstrainInput
-        {
-            get { return Options.ConstrainInput; }
-            set { Options.ConstrainInput = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating if the year should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ChangeYear
+		{
+			get => Options.ChangeYear;
+			set => Options.ChangeYear = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the culture to use for parsing and formatting the value when Globalize plugin is included (jQuery UI Spinner widget).
-        /// </summary>
-        public string Culture
-        {
-            get { return Options.Culture; }
-            set { Options.Culture = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating if the input field should constrained to characters allowed by the current format (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ConstrainInput
+		{
+			get => Options.ConstrainInput;
+			set => Options.ConstrainInput = value;
+		}
 
-        /// <summary>
-        /// Gets or sets if the value should be validated with custom function.
-        /// </summary>
-        public bool CustomValidation
-        {
-            get { return Rules.Custom; }
-            set { Rules.Custom = value; }
-        }
+		/// <summary>
+		/// Gets or sets the culture to use for parsing and formatting the value when Globalize plugin is included (jQuery UI Spinner widget).
+		/// </summary>
+		public string Culture
+		{
+			get => Options.Culture;
+			set => Options.Culture = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the name of custom validation function
-        /// </summary>
-        public string CustomValidationFunction
-        {
-            get { return Rules.CustomFunction; }
-            set { Rules.CustomFunction = value; }
-        }
+		/// <summary>
+		/// Gets or sets if the value should be validated with custom function.
+		/// </summary>
+		public bool CustomValidation
+		{
+			get => Rules.Custom ?? false;
+			set => Rules.Custom = value;
+		}
 
-        /// <summary>
-        /// When overriden in delivered class, provides a list of events to apply to the element.
-        /// </summary>
-        protected virtual IList<JqGridColumnDataEvent> DataEvents
-        {
-            get { return null; }
-        }
+		/// <summary>
+		/// Gets or sets the name of custom validation function
+		/// </summary>
+		public string CustomValidationFunction
+		{
+			get => Rules.CustomFunction;
+			set => Rules.CustomFunction = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the function which will be called once when the element is created. This property is ignored in case of jQuery UI widgets.
-        /// </summary>
-        public string DataInit
-        {
-            get { return Options.DataInit; }
-            set { Options.DataInit = value; }
-        }
+		/// <summary>
+		/// When overriden in delivered class, provides a list of events to apply to the element.
+		/// </summary>
+		protected virtual IList<JqGridColumnDataEvent> DataEvents => null;
 
-        /// <summary>
-        /// Gets or sets the format for parsed and displayed dates (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>If the value for this property is not provided, but there is a JqGridColumnFormatterAttribute with JqGridColumnPredefinedFormatters.Date formatter the helper will try to provide the value based on JqGridColumnFormatterAttribute.OutputFormat.</remarks> 
-        public string DatepickerDateFormat
-        {
-            get { return Options.DatePickerDateFormat; }
-            set { Options.DatePickerDateFormat = value; }
-        }
+		/// <summary>
+		/// Gets or sets the function which will be called once when the element is created. This property is ignored in case of jQuery UI widgets.
+		/// </summary>
+		public string DataInit
+		{
+			get => Options.DataInit;
+			set => Options.DataInit = value;
+		}
 
-        /// <summary>
-        /// Gets or sets if the value should be valid date.
-        /// </summary>
-        public bool DateValidation
-        {
-            get { return Rules.Date; }
-            set { Rules.Date = value; }
-        }
+		/// <summary>
+		/// Gets or sets the format for parsed and displayed dates (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>If the value for this property is not provided, but there is a JqGridColumnFormatterAttribute with JqGridColumnPredefinedFormatters.Date formatter the helper will try to provide the value based on JqGridColumnFormatterAttribute.OutputFormat.</remarks> 
+		public string DatepickerDateFormat
+		{
+			get => Options.DatePickerDateFormat;
+			set => Options.DatePickerDateFormat = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the default value in the search input element.
-        /// </summary>
-        public string DefaultValue
-        {
-            get { return Options.DefaultValue; }
-            set { Options.DefaultValue = value; }
-        }
+		/// <summary>
+		/// Gets or sets if the value should be valid date.
+		/// </summary>
+		public bool DateValidation
+		{
+			get => Rules.Date ?? false;
+			set => Rules.Date = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the delay in milliseconds between when a keystroke occurs and when a search is performed (jQuery UI Autocomplete widget).
-        /// </summary>
-        public int Delay
-        {
-            get { return Options.Delay; }
-            set { Options.Delay = value; }
-        }
+		/// <summary>
+		/// Gets or sets the default value in the search input element.
+		/// </summary>
+		public string DefaultValue
+		{
+			get => Options.DefaultValue;
+			set => Options.DefaultValue = value;
+		}
 
-        /// <summary>
-        /// Gets or sets if the value should be valid email
-        /// </summary>
-        public bool EmailValidation
-        {
-            get { return Rules.Email; }
-            set { Rules.Email = value; }
-        }
+		/// <summary>
+		/// Gets or sets the delay in milliseconds between when a keystroke occurs and when a search is performed (jQuery UI Autocomplete widget).
+		/// </summary>
+		public int Delay
+		{
+			get => Options.Delay;
+			set => Options.Delay = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the first day of the week: Sunday is 0, Monday is 1, etc. (jQuery UI Datepicker widget).
-        /// </summary>
-        public int FirstDay
-        {
-            get { return Options.FirstDay; }
-            set { Options.FirstDay = value; }
-        }
+		/// <summary>
+		/// Gets or sets if the value should be valid email
+		/// </summary>
+		public bool EmailValidation
+		{
+			get => Rules.Email ?? false;
+			set => Rules.Email = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating if the current day link moves to the currently selected date instead of today. (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool GotoCurrent
-        {
-            get { return Options.GotoCurrent; }
-            set { Options.GotoCurrent = value; }
-        }
+		/// <summary>
+		/// Gets or sets the first day of the week: Sunday is 0, Monday is 1, etc. (jQuery UI Datepicker widget).
+		/// </summary>
+		public int FirstDay
+		{
+			get => Options.FirstDay;
+			set => Options.FirstDay = value;
+		}
 
-        /// <summary>
-        /// When overriden in delivered class, provides a dictionary where keys should be valid attributes for the element.
-        /// </summary>
-        protected virtual IDictionary<string, object> HtmlAttributes
-        {
-            get { return null; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating if the current day link moves to the currently selected date instead of today. (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool GotoCurrent
+		{
+			get => Options.GotoCurrent;
+			set => Options.GotoCurrent = value;
+		}
 
-        /// <summary>
-        /// Gets or sets value controlling the number of steps taken when holding down a spin button (jQuery UI Spinner widget).
-        /// </summary>
-        public bool Incremental
-        {
-            get { return Options.Incremental; }
-            set { Options.Incremental = value; }
-        }
+		/// <summary>
+		/// When overriden in delivered class, provides a dictionary where keys should be valid attributes for the element.
+		/// </summary>
+		protected virtual IDictionary<string, object> HtmlAttributes => null;
 
-        /// <summary>
-        /// Gets or sets maximum allowed value (jQuery UI Spinner widget).
-        /// </summary>
-        public int Max
-        {
-            get { return Options.Max.HasValue ? Options.Max.Value : Int32.MaxValue; }
-            set { Options.Max = value; }
-        }
+		/// <summary>
+		/// Gets or sets value controlling the number of steps taken when holding down a spin button (jQuery UI Spinner widget).
+		/// </summary>
+		public bool Incremental
+		{
+			get => Options.Incremental;
+			set => Options.Incremental = value;
+		}
 
-        /// <summary>
-        /// Gets or sets minimum allowed value (jQuery UI Spinner widget).
-        /// </summary>
-        public int Min
-        {
-            get { return Options.Min.HasValue ? Options.Min.Value : Int32.MinValue; }
-            set { Options.Min = value; }
-        }
+		/// <summary>
+		/// Gets or sets maximum allowed value (jQuery UI Spinner widget).
+		/// </summary>
+		public int Max
+		{
+			get => Options.Max ?? int.MaxValue;
+			set => Options.Max = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the maximum selectable date. (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
-        public string MaxDate
-        {
-            get { return Options.MaxDate; }
-            set { Options.MaxDate = value; }
-        }
+		/// <summary>
+		/// Gets or sets minimum allowed value (jQuery UI Spinner widget).
+		/// </summary>
+		public int Min
+		{
+			get => Options.Min ?? int.MinValue;
+			set => Options.Min = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the minimum selectable date. (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
-        public string MinDate
-        {
-            get { return Options.MinDate; }
-            set { Options.MinDate = value; }
-        }
+		/// <summary>
+		/// Gets or sets the maximum selectable date. (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
+		public string MaxDate
+		{
+			get => Options.MaxDate;
+			set => Options.MaxDate = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the minimum number of characters a user must type before a search is performed (jQuery UI Autocomplete widget).
-        /// </summary>
-        public int MinLength
-        {
-            get { return Options.MinLength; }
-            set { Options.MinLength = value; }
-        }
+		/// <summary>
+		/// Gets or sets the minimum selectable date. (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
+		public string MinDate
+		{
+			get => Options.MinDate;
+			set => Options.MinDate = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the format of numbers passed to Globalize plugin if it is included (jQuery UI Spinner widget).
-        /// </summary>
-        public string NumberFormat
-        {
-            get { return Options.NumberFormat; }
-            set { Options.NumberFormat = value; }
-        }
+		/// <summary>
+		/// Gets or sets the minimum number of characters a user must type before a search is performed (jQuery UI Autocomplete widget).
+		/// </summary>
+		public int MinLength
+		{
+			get => Options.MinLength;
+			set => Options.MinLength = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the number of months to show at once (jQuery UI Datepicker widget).
-        /// </summary>
-        public int NumberOfMonths
-        {
-            get { return Options.NumberOfMonths; }
-            set { Options.NumberOfMonths = value; }
-        }
+		/// <summary>
+		/// Gets or sets the format of numbers passed to Globalize plugin if it is included (jQuery UI Spinner widget).
+		/// </summary>
+		public string NumberFormat
+		{
+			get => Options.NumberFormat;
+			set => Options.NumberFormat = value;
+		}
 
-        internal JqGridColumnElementOptions Options { get; set; }
+		/// <summary>
+		/// Gets or sets the number of months to show at once (jQuery UI Datepicker widget).
+		/// </summary>
+		public int NumberOfMonths
+		{
+			get => Options.NumberOfMonths;
+			set => Options.NumberOfMonths = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the number of steps to take when paging via the pageUp/pageDown JavaScript methods (jQuery UI Spinner widget).
-        /// </summary>
-        public int Page
-        {
-            get { return Options.Page; }
-            set { Options.Page = value; }
-        }
+		internal JqGridColumnElementOptions Options { get; set; }
 
-        internal JqGridColumnRules Rules { get; set; }
+		/// <summary>
+		/// Gets or sets the number of steps to take when paging via the pageUp/pageDown JavaScript methods (jQuery UI Spinner widget).
+		/// </summary>
+		public int Page
+		{
+			get => Options.Page;
+			set => Options.Page = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating whether days in other months shown before or after the current month are selectable, this only applies if the ShowOtherMonths is set to true. (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool SelectOtherMonths
-        {
-            get { return Options.SelectOtherMonths; }
-            set { Options.SelectOtherMonths = value; }
-        }
+		internal JqGridColumnRules Rules { get; set; }
 
-        /// <summary>
-        /// Gets or sets the cutoff year for determining the century for a date (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>This string must be a relative number of years from the current year, e.g., "+3" or "-5".</remarks> 
-        public string ShortYearCutoff
-        {
-            get { return Options.ShortYearCutoff; }
-            set { Options.ShortYearCutoff = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating whether days in other months shown before or after the current month are selectable, this only applies if the ShowOtherMonths is set to true. (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool SelectOtherMonths
+		{
+			get => Options.SelectOtherMonths;
+			set => Options.SelectOtherMonths = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value which defines position to display the current month in, if the ShowOtherMonths is set to true (jQuery UI Datepicker widget).
-        /// </summary>
-        public int ShowCurrentAtPos
-        {
-            get { return Options.ShowCurrentAtPos; }
-            set { Options.ShowCurrentAtPos = value; }
-        }
+		/// <summary>
+		/// Gets or sets the cutoff year for determining the century for a date (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>This string must be a relative number of years from the current year, e.g., "+3" or "-5".</remarks> 
+		public string ShortYearCutoff
+		{
+			get => Options.ShortYearCutoff;
+			set => Options.ShortYearCutoff = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating whether to show the month after the year in the header (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ShowMonthAfterYear
-        {
-            get { return Options.ShowMonthAfterYear; }
-            set { Options.ShowMonthAfterYear = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value which defines position to display the current month in, if the ShowOtherMonths is set to true (jQuery UI Datepicker widget).
+		/// </summary>
+		public int ShowCurrentAtPos
+		{
+			get => Options.ShowCurrentAtPos;
+			set => Options.ShowCurrentAtPos = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating whether to display dates in other months (non-selectable) at the start or end of the current month, to make these days selectable set the SelectOtherMonths to true (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ShowOtherMonths
-        {
-            get { return Options.ShowOtherMonths; }
-            set { Options.ShowOtherMonths = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating whether to show the month after the year in the header (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ShowMonthAfterYear
+		{
+			get => Options.ShowMonthAfterYear;
+			set => Options.ShowMonthAfterYear = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating whether to add column with the week of the year (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ShowWeek
-        {
-            get { return Options.ShowWeek; }
-            set { Options.ShowWeek = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating whether to display dates in other months (non-selectable) at the start or end of the current month, to make these days selectable set the SelectOtherMonths to true (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ShowOtherMonths
+		{
+			get => Options.ShowOtherMonths;
+			set => Options.ShowOtherMonths = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget down button.
-        /// </summary>
-        public string SpinnerDownIcon
-        {
-            get { return Options.SpinnerDownIcon; }
-            set { Options.SpinnerDownIcon = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating whether to add column with the week of the year (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ShowWeek
+		{
+			get => Options.ShowWeek;
+			set => Options.ShowWeek = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget up button.
-        /// </summary>
-        public string SpinnerUpIcon
-        {
-            get { return Options.SpinnerUpIcon; }
-            set { Options.SpinnerUpIcon = value; }
-        }
+		/// <summary>
+		/// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget down button.
+		/// </summary>
+		public string SpinnerDownIcon
+		{
+			get => Options.SpinnerDownIcon;
+			set => Options.SpinnerDownIcon = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the size of the step to take when spinning via buttons or via the stepUp/stepDown JavaScript methods (jQuery UI Spinner widget).
-        /// </summary>
-        public int Step
-        {
-            get { return Options.Step; }
-            set { Options.Step = value; }
-        }
+		/// <summary>
+		/// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget up button.
+		/// </summary>
+		public string SpinnerUpIcon
+		{
+			get => Options.SpinnerUpIcon;
+			set => Options.SpinnerUpIcon = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value which defines how many months to move when clicking the previous/next links (jQuery UI Datepicker widget).
-        /// </summary>
-        public int StepMonths
-        {
-            get { return Options.StepMonths; }
-            set { Options.StepMonths = value; }
-        }
+		/// <summary>
+		/// Gets or sets the size of the step to take when spinning via buttons or via the stepUp/stepDown JavaScript methods (jQuery UI Spinner widget).
+		/// </summary>
+		public int Step
+		{
+			get => Options.Step;
+			set => Options.Step = value;
+		}
 
-        /// <summary>
-        /// Gets or sets if the value should be valid time (hh:mm format and optional am/pm at the end).
-        /// </summary>
-        public bool TimeValidation
-        {
-            get { return Rules.Time; }
-            set { Rules.Time = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value which defines how many months to move when clicking the previous/next links (jQuery UI Datepicker widget).
+		/// </summary>
+		public int StepMonths
+		{
+			get => Options.StepMonths;
+			set => Options.StepMonths = value;
+		}
 
-        /// <summary>
-        /// Gets or sets if the value should be valid url.
-        /// </summary>
-        public bool UrlValidation
-        {
-            get { return Rules.Url; }
-            set { Rules.Url = value; }
-        }
+		/// <summary>
+		/// Gets or sets if the value should be valid time (hh:mm format and optional am/pm at the end).
+		/// </summary>
+		public bool TimeValidation
+		{
+			get => Rules.Time ?? false;
+			set => Rules.Time = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the set of value:label pairs for select element.
-        /// </summary>
-        public virtual string Value{ get; set; }
+		/// <summary>
+		/// Gets or sets if the value should be valid url.
+		/// </summary>
+		public bool UrlValidation
+		{
+			get => Rules.Url ?? false;
+			set => Rules.Url = value;
+		}
 
-        internal Type ValueProviderType { get; set; }
+		internal bool IsValueSetted { get; private set; }
+		internal bool IsValueNotOveriden { get; private set; }
 
-        internal string ValueProviderMethodName { get; set; }
+		/// <summary>
+		/// Gets or sets the set of value:label pairs for select element.
+		/// </summary>
+		public virtual string Value
+		{
+			get
+			{
+				IsValueNotOveriden = true;
+				return _value;
+			}
+			set
+			{
+				_value = value;
+				IsValueSetted = true;
+			}
 
-        internal IDictionary<string, string> ValueDictionary
-        {
-            get
-            {
-                if (ValueProviderType != null && !String.IsNullOrWhiteSpace(ValueProviderMethodName))
-                {
-                    MethodInfo valueProviderMethodInfo = ValueProviderType.GetMethod(ValueProviderMethodName);
-                    if (valueProviderMethodInfo == null)
-                        throw new InvalidOperationException("The method specified by ValueProviderType and ValueProviderMethodName could not be found.");
+		}
 
-                    ConstructorInfo valueProviderConstructorInfo = ValueProviderType.GetConstructor(Type.EmptyTypes);
-                    if (valueProviderConstructorInfo == null)
-                        throw new InvalidOperationException("The type specified by ValueProviderType does not have parameterless constructor.");
+		internal Type ValueProviderType { get; set; }
 
-                    object valueProvider = valueProviderConstructorInfo.Invoke(null);
-                    if (typeof(IDictionary<string, string>).IsAssignableFrom(valueProviderMethodInfo.ReturnType))
-                        return (IDictionary<string, string>)valueProviderMethodInfo.Invoke(valueProvider, null);
-                    else
-                        throw new InvalidOperationException("The method specified by ValueProviderType and ValueProviderMethodName does not return IDictionary<string, string>.");
-                }
-                return null;
-            }
-        }
+		internal string ValueProviderMethodName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the range of years displayed in the year dropdown (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>This string must be either relative to today's year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). Note that this option only affects what appears in the dropdown, to restrict which dates may be selected use the MinDate and/or MaxDate.</remarks> 
-        public string YearRange
-        {
-            get { return Options.YearRange; }
-            set { Options.YearRange = value; }
-        }
+		internal IDictionary<string, string> ValueDictionary
+		{
+			get
+			{
+				if (ValueProviderType != null && !string.IsNullOrWhiteSpace(ValueProviderMethodName))
+				{
+					var valueProviderMethodInfo = ValueProviderType.GetMethod(ValueProviderMethodName);
+					if (valueProviderMethodInfo == null)
+						throw new InvalidOperationException("The method specified by ValueProviderType and ValueProviderMethodName could not be found.");
 
-        /// <summary>
-        /// Gets or sets the additional text to display after the year in the month headers (jQuery UI Datepicker widget).
-        /// </summary>
-        public string YearSuffix
-        {
-            get { return Options.YearSuffix; }
-            set { Options.YearSuffix = value; }
-        }
-        #endregion
+					var valueProviderConstructorInfo = ValueProviderType.GetConstructor(Type.EmptyTypes);
+					if (valueProviderConstructorInfo == null)
+						throw new InvalidOperationException("The type specified by ValueProviderType does not have parameterless constructor.");
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnElementAttribute class.
-        /// </summary>
-        public JqGridColumnElementAttribute()
-        {
-            Rules = new JqGridColumnRules();
-        }
-        #endregion
+					var valueProvider = valueProviderConstructorInfo.Invoke(null);
+					if (typeof(IDictionary<string, string>).IsAssignableFrom(valueProviderMethodInfo.ReturnType))
+						return (IDictionary<string, string>)valueProviderMethodInfo.Invoke(valueProvider, null);
+					throw new InvalidOperationException("The method specified by ValueProviderType and ValueProviderMethodName does not return IDictionary<string, string>.");
+				}
+				return null;
+			}
+		}
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        public void OnMetadataCreated(ModelMetadata metadata)
-        {
-            Options.Value = Value;
+		/// <summary>
+		/// Gets or sets the range of years displayed in the year dropdown (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>This string must be either relative to today's year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). Note that this option only affects what appears in the dropdown, to restrict which dates may be selected use the MinDate and/or MaxDate.</remarks> 
+		public string YearRange
+		{
+			get => Options.YearRange;
+			set => Options.YearRange = value;
+		}
 
-            if ((metadata.ModelType == typeof(Int16)) || (metadata.ModelType == typeof(Int32)) || (metadata.ModelType == typeof(Int64)) || (metadata.ModelType == typeof(UInt16)) || (metadata.ModelType == typeof(UInt32)) || (metadata.ModelType == typeof(UInt32)))
-                Rules.Integer = true;
-            else if ((metadata.ModelType == typeof(Decimal)) || (metadata.ModelType == typeof(Double)) || (metadata.ModelType == typeof(Single)))
-                Rules.Number = true;
+		/// <summary>
+		/// Gets or sets the additional text to display after the year in the month headers (jQuery UI Datepicker widget).
+		/// </summary>
+		public string YearSuffix
+		{
+			get => Options.YearSuffix;
+			set => Options.YearSuffix = value;
+		}
+		#endregion
 
-            InternalOnMetadataCreated(metadata);
-        }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnElementAttribute class.
+		/// </summary>
+		protected JqGridColumnElementAttribute()
+		{
+			Rules = new JqGridColumnRules();
+		}
+		#endregion
 
-        /// <summary>
-        /// Provides metadata to the model metadata creation process in derivered class.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        protected abstract void InternalOnMetadataCreated(ModelMetadata metadata);
-        #endregion
-    }
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		public void OnMetadataCreated(ModelMetadata metadata)
+		{
+			if (!IsValueNotOveriden || IsValueSetted)
+				Options.Value = Value;
+
+			if (metadata.ModelType == typeof(short) || metadata.ModelType == typeof(int) || metadata.ModelType == typeof(long) || metadata.ModelType == typeof(ushort) || metadata.ModelType == typeof(uint) || metadata.ModelType == typeof(uint))
+				Rules.Integer = true;
+			else if (metadata.ModelType == typeof(decimal) || metadata.ModelType == typeof(double) || metadata.ModelType == typeof(float))
+				Rules.Number = true;
+
+			InternalOnMetadataCreated(metadata);
+		}
+
+		/// <summary>
+		/// Provides metadata to the model metadata creation process in derivered class.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		protected abstract void InternalOnMetadataCreated(ModelMetadata metadata);
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnFormatterAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnFormatterAttribute.cs
@@ -1,262 +1,276 @@
 ﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Specifies the custom formatter for column
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class JqGridColumnFormatterAttribute : Attribute, IMetadataAware
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the predefined formatter type ('' delimited string) or custom JavaScript formatting function name.
-        /// </summary>
-        public string Formatter { get; private set; }
+	/// <summary>
+	/// Specifies the custom formatter for column
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	public sealed class JqGridColumnFormatterAttribute : Attribute, IMetadataAware
+	{
 
-        /// <summary>
-        /// Gets or sets the options for predefined formatter (every predefined formatter uses only a subset of all options), which are overwriting the defaults from the language file.
-        /// </summary>
-        private JqGridColumnFormatterOptions Options { get; set; }
+		#region Fields
+		private string _unFormatter;
 
-        /// <summary>
-        /// Gets or sets the custom function to "unformat" a value of the cell when used in editing or client-side sorting
-        /// </summary>
-        public string UnFormatter { get; set; }
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the decimal places.
-        /// </summary>
-        public int DecimalPlaces
-        {
-            get { return Options.DecimalPlaces; }
-            set { Options.DecimalPlaces = value; }
-        }
+		#region Properties
 
-        /// <summary>
-        /// Gets or sets the decimal separator.
-        /// </summary>
-        public string DecimalSeparator
-        {
-            get { return Options.DecimalSeparator; }
-            set { Options.DecimalSeparator = value; }
-        }
+		/// <summary>
+		/// Gets the predefined formatter type ('' delimited string) or custom JavaScript formatting function name.
+		/// </summary>
+		public string Formatter { get; }
 
-        /// <summary>
-        /// Gets or sets the default value.
-        /// </summary>
-        public string DefaultValue
-        {
-            get { return Options.DefaultValue; }
-            set { Options.DefaultValue = value; }
-        }
+		/// <summary>
+		/// Gets or sets the options for predefined formatter (every predefined formatter uses only a subset of all options), which are overwriting the defaults from the language file.
+		/// </summary>
+		private JqGridColumnFormatterOptions Options { get; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if checkbox is disabled.
-        /// </summary>
-        public bool Disabled
-        {
-            get { return Options.Disabled; }
-            set { Options.Disabled = value; }
-        }
+		internal bool IsUnFormatterSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the custom function to "unformat" a value of the cell when used in editing or client-side sorting
+		/// </summary>
+		public string UnFormatter
+		{
+			get => _unFormatter;
+			set
+			{
+				_unFormatter = value;
+				IsUnFormatterSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the currency prefix.
-        /// </summary>
-        public string Prefix
-        {
-            get { return Options.Prefix; }
-            set { Options.Prefix = value; }
-        }
+		/// <summary>
+		/// Gets or sets the decimal places.
+		/// </summary>
+		public int DecimalPlaces
+		{
+			get => Options.DecimalPlaces ?? JqGridOptionsDefaults.FormatterDecimalPlaces;
+			set => Options.DecimalPlaces = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the currency suffix.
-        /// </summary>
-        public string Suffix
-        {
-            get { return Options.Suffix; }
-            set { Options.Suffix = value; }
-        }
+		/// <summary>
+		/// Gets or sets the decimal separator.
+		/// </summary>
+		public string DecimalSeparator
+		{
+			get => Options.DecimalSeparator;
+			set => Options.DecimalSeparator = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the date source format.
-        /// </summary>
-        public string SourceFormat
-        {
-            get { return Options.SourceFormat; }
-            set { Options.SourceFormat = value; }
-        }
+		/// <summary>
+		/// Gets or sets the default value.
+		/// </summary>
+		public string DefaultValue
+		{
+			get => Options.DefaultValue;
+			set => Options.DefaultValue = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the date output format.
-        /// </summary>
-        public string OutputFormat
-        {
-            get { return Options.OutputFormat; }
-            set { Options.OutputFormat = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value indicating if checkbox is disabled.
+		/// </summary>
+		public bool Disabled
+		{
+			get => Options.Disabled ?? false;
+			set => Options.Disabled = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the link for showlink formatter.
-        /// </summary>
-        public string BaseLinkUrl
-        {
-            get { return Options.BaseLinkUrl; }
-            set { Options.BaseLinkUrl = value; }
-        }
+		/// <summary>
+		/// Gets or sets the currency prefix.
+		/// </summary>
+		public string Prefix
+		{
+			get => Options.Prefix;
+			set => Options.Prefix = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the additional value which is added after the BaseLinkUrl.
-        /// </summary>
-        public string ShowAction
-        {
-            get { return Options.ShowAction; }
-            set { Options.ShowAction = value; }
-        }
+		/// <summary>
+		/// Gets or sets the currency suffix.
+		/// </summary>
+		public string Suffix
+		{
+			get => Options.Suffix;
+			set => Options.Suffix = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the additional parameter which can be added after the IdName property.
-        /// </summary>
-        public string AddParam
-        {
-            get { return Options.AddParam; }
-            set { Options.AddParam = value; }
-        }
+		/// <summary>
+		/// Gets or sets the date source format.
+		/// </summary>
+		public string SourceFormat
+		{
+			get => Options.SourceFormat;
+			set => Options.SourceFormat = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the target.
-        /// </summary>
-        public string Target
-        {
-            get { return Options.Target; }
-            set { Options.Target = value; }
-        }
+		/// <summary>
+		/// Gets or sets the date output format.
+		/// </summary>
+		public string OutputFormat
+		{
+			get => Options.OutputFormat;
+			set => Options.OutputFormat = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the first parameter that is added after the ShowAction.
-        /// </summary>
-        public string IdName
-        {
-            get { return Options.IdName; }
-            set { Options.IdName = value; }
-        }
+		/// <summary>
+		/// Gets or sets the link for showlink formatter.
+		/// </summary>
+		public string BaseLinkUrl
+		{
+			get => Options.BaseLinkUrl;
+			set => Options.BaseLinkUrl = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the thousands separator.
-        /// </summary>
-        public string ThousandsSeparator
-        {
-            get { return Options.ThousandsSeparator; }
-            set { Options.ThousandsSeparator = value; }
-        }
+		/// <summary>
+		/// Gets or sets the additional value which is added after the BaseLinkUrl.
+		/// </summary>
+		public string ShowAction
+		{
+			get => Options.ShowAction;
+			set => Options.ShowAction = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the primary icon class (form UI theme icons) for jQuery UI Button widget.
-        /// </summary>
-        public string PrimaryIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the additional parameter which can be added after the IdName property.
+		/// </summary>
+		public string AddParam
+		{
+			get => Options.AddParam;
+			set => Options.AddParam = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the secondary icon class (form UI theme icons) for jQuery UI Button widget.
-        /// </summary>
-        public string SecondaryIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the target.
+		/// </summary>
+		public string Target
+		{
+			get => Options.Target;
+			set => Options.Target = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the text to show in the button for jQuery UI Button widget.
-        /// </summary>
-        public string Label { get; set; }
+		/// <summary>
+		/// Gets or sets the first parameter that is added after the ShowAction.
+		/// </summary>
+		public string IdName
+		{
+			get => Options.IdName;
+			set => Options.IdName = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value whether to show the label in jQuery UI Button widget.
-        /// </summary>
-        public bool Text { get; set; }
+		/// <summary>
+		/// Gets or sets the thousands separator.
+		/// </summary>
+		public string ThousandsSeparator
+		{
+			get => Options.ThousandsSeparator;
+			set => Options.ThousandsSeparator = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the click handler (JavaScript) for jQuery UI Button widget.
-        /// </summary>
-        public string OnClick { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the primary icon class (form UI theme icons) for jQuery UI Button widget.
+		/// </summary>
+		public string PrimaryIcon { get; set; }
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnFormatterAttribute class.
-        /// </summary>
-        /// <param name="formatter">The predefined formatter type ('' delimited string) or custom JavaScript formatting function name.</param>
-        public JqGridColumnFormatterAttribute(string formatter)
-        {
-            if (String.IsNullOrWhiteSpace(formatter))
-                throw new ArgumentNullException("formatter");
-            Formatter = formatter;
-            Options = new JqGridColumnFormatterOptions(formatter);
-            PrimaryIcon = String.Empty;
-            SecondaryIcon = String.Empty;
-            Label = String.Empty;
-            Text = true;
-        }
-        #endregion
+		/// <summary>
+		/// Gets or sets the secondary icon class (form UI theme icons) for jQuery UI Button widget.
+		/// </summary>
+		public string SecondaryIcon { get; set; }
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        public void OnMetadataCreated(ModelMetadata metadata)
-        {
-            if (Formatter == JqGridColumnPredefinedFormatters.JQueryUIButton)
-                metadata.SetColumnFormatter(GetJQueryUIButtonFormatter());
-            else
-            {
-                metadata.SetColumnFormatter(Formatter);
-                metadata.SetColumnFormatterOptions(Options);
-                metadata.SetColumnUnFormatter(UnFormatter);
-            }
-        }
-        #endregion
+		/// <summary>
+		/// Gets or sets the text to show in the button for jQuery UI Button widget.
+		/// </summary>
+		public string Label { get; set; }
 
-        #region Methods
-        internal string GetJQueryUIButtonFormatter()
-        {
-            StringBuilder formatterBuilder = new StringBuilder(80);
-            formatterBuilder.Append("function(cellValue, options, rowObject) { setTimeout(function() { $('#' + options.rowId + '_JQueryUIButton').attr('data-cell-value', cellValue).button({ ");
+		/// <summary>
+		/// Gets or sets the value whether to show the label in jQuery UI Button widget.
+		/// </summary>
+		public bool Text { get; set; }
 
-            if (!String.IsNullOrEmpty(Label))
-                formatterBuilder.AppendFormat("label: '{0}', ", Label);
+		/// <summary>
+		/// Gets or sets the click handler (JavaScript) for jQuery UI Button widget.
+		/// </summary>
+		public string OnClick { get; set; }
+		#endregion
 
-            if (!String.IsNullOrWhiteSpace(PrimaryIcon) || !String.IsNullOrWhiteSpace(SecondaryIcon))
-            {
-                formatterBuilder.Append("icons: { ");
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnFormatterAttribute class.
+		/// </summary>
+		/// <param name="formatter">The predefined formatter type ('' delimited string) or custom JavaScript formatting function name. <c>null</c> for not using default formatter if setted in JqGrid</param>
+		public JqGridColumnFormatterAttribute(string formatter)
+		{
+			/*if (string.IsNullOrWhiteSpace(formatter))
+				throw new ArgumentNullException(nameof(formatter));*/
+			Formatter = formatter;
+			Options = new JqGridColumnFormatterOptions();
+			PrimaryIcon = string.Empty;
+			SecondaryIcon = string.Empty;
+			Label = string.Empty;
+			Text = true;
+		}
+		#endregion
 
-                if (!String.IsNullOrWhiteSpace(PrimaryIcon))
-                    formatterBuilder.AppendFormat("primary: '{0}', ", PrimaryIcon);
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		public void OnMetadataCreated(ModelMetadata metadata)
+		{
+			if (Formatter == JqGridColumnPredefinedFormatters.JQueryUIButton)
+				metadata.SetColumnFormatter(new SettedString(true, GetJQueryUIButtonFormatter()));
+			else
+			{
+				metadata.SetColumnFormatter(new SettedString(true, Formatter));
+				metadata.SetColumnFormatterOptions(Options);
+				metadata.SetColumnUnFormatter(new SettedString(IsUnFormatterSetted, UnFormatter));
+			}
+		}
+		#endregion
 
-                if (!String.IsNullOrWhiteSpace(SecondaryIcon))
-                    formatterBuilder.AppendFormat("secondary: '{0}', ", SecondaryIcon);
+		#region Methods
+		internal string GetJQueryUIButtonFormatter()
+		{
+			var formatterBuilder = new StringBuilder(80);
+			formatterBuilder.Append("function(cellValue, options, rowObject) { setTimeout(function() { $('#' + options.rowId + '_JQueryUIButton').attr('data-cell-value', cellValue).button({ ");
 
-                formatterBuilder.Remove(formatterBuilder.Length - 2, 2);
-                formatterBuilder.Append(" }, ");
-            }
+			if (!string.IsNullOrEmpty(Label))
+				formatterBuilder.AppendFormat("label: '{0}', ", Label);
 
-            if (!Text)
-                formatterBuilder.Append("text: false, ");
+			if (!string.IsNullOrWhiteSpace(PrimaryIcon) || !string.IsNullOrWhiteSpace(SecondaryIcon))
+			{
+				formatterBuilder.Append("icons: { ");
 
-            formatterBuilder.Remove(formatterBuilder.Length - 2, 2);
-            if (formatterBuilder[formatterBuilder.Length - 1] == '(')
-                formatterBuilder.Append(")");
-            else
-                formatterBuilder.Append(" })");
+				if (!string.IsNullOrWhiteSpace(PrimaryIcon))
+					formatterBuilder.AppendFormat("primary: '{0}', ", PrimaryIcon);
 
-            if (String.IsNullOrWhiteSpace(OnClick))
-                formatterBuilder.Append(";");
-            else
-                formatterBuilder.AppendFormat(".click({0});", OnClick);
-            formatterBuilder.Append(" }, 0); return '<button id=\"' + options.rowId + '_JQueryUIButton\" />'; }");
+				if (!string.IsNullOrWhiteSpace(SecondaryIcon))
+					formatterBuilder.AppendFormat("secondary: '{0}', ", SecondaryIcon);
 
-            return formatterBuilder.ToString();
-        }
-        #endregion
-    }
+				formatterBuilder.Remove(formatterBuilder.Length - 2, 2);
+				formatterBuilder.Append(" }, ");
+			}
+
+			if (!Text)
+				formatterBuilder.Append("text: false, ");
+
+			formatterBuilder.Remove(formatterBuilder.Length - 2, 2);
+			if (formatterBuilder[formatterBuilder.Length - 1] == '(')
+				formatterBuilder.Append(")");
+			else
+				formatterBuilder.Append(" })");
+
+			if (string.IsNullOrWhiteSpace(OnClick))
+				formatterBuilder.Append(";");
+			else
+				formatterBuilder.AppendFormat(".click({0});", OnClick);
+			formatterBuilder.Append(" }, 0); return '<button id=\"' + options.rowId + '_JQueryUIButton\" />'; }");
+
+			return formatterBuilder.ToString();
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnFormatterAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnFormatterAttribute.cs
@@ -5,272 +5,272 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <summary>
-	/// Specifies the custom formatter for column
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property)]
-	public sealed class JqGridColumnFormatterAttribute : Attribute, IMetadataAware
-	{
+    /// <summary>
+    /// Specifies the custom formatter for column
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class JqGridColumnFormatterAttribute : Attribute, IMetadataAware
+    {
 
-		#region Fields
-		private string _unFormatter;
+        #region Fields
+        private string _unFormatter;
 
-		#endregion
+        #endregion
 
-		#region Properties
+        #region Properties
 
-		/// <summary>
-		/// Gets the predefined formatter type ('' delimited string) or custom JavaScript formatting function name.
-		/// </summary>
-		public string Formatter { get; }
+        /// <summary>
+        /// Gets the predefined formatter type ('' delimited string) or custom JavaScript formatting function name.
+        /// </summary>
+        public string Formatter { get; }
 
-		/// <summary>
-		/// Gets or sets the options for predefined formatter (every predefined formatter uses only a subset of all options), which are overwriting the defaults from the language file.
-		/// </summary>
-		private JqGridColumnFormatterOptions Options { get; }
+        /// <summary>
+        /// Gets or sets the options for predefined formatter (every predefined formatter uses only a subset of all options), which are overwriting the defaults from the language file.
+        /// </summary>
+        private JqGridColumnFormatterOptions Options { get; }
 
-		internal bool IsUnFormatterSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the custom function to "unformat" a value of the cell when used in editing or client-side sorting
-		/// </summary>
-		public string UnFormatter
-		{
-			get => _unFormatter;
-			set
-			{
-				_unFormatter = value;
-				IsUnFormatterSetted = true;
-			}
-		}
+        internal bool IsUnFormatterSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the custom function to "unformat" a value of the cell when used in editing or client-side sorting
+        /// </summary>
+        public string UnFormatter
+        {
+            get => _unFormatter;
+            set
+            {
+                _unFormatter = value;
+                IsUnFormatterSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the decimal places.
-		/// </summary>
-		public int DecimalPlaces
-		{
-			get => Options.DecimalPlaces ?? JqGridOptionsDefaults.FormatterDecimalPlaces;
-			set => Options.DecimalPlaces = value;
-		}
+        /// <summary>
+        /// Gets or sets the decimal places.
+        /// </summary>
+        public int DecimalPlaces
+        {
+            get => Options.DecimalPlaces ?? JqGridOptionsDefaults.FormatterDecimalPlaces;
+            set => Options.DecimalPlaces = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the decimal separator.
-		/// </summary>
-		public string DecimalSeparator
-		{
-			get => Options.DecimalSeparator;
-			set => Options.DecimalSeparator = value;
-		}
+        /// <summary>
+        /// Gets or sets the decimal separator.
+        /// </summary>
+        public string DecimalSeparator
+        {
+            get => Options.DecimalSeparator;
+            set => Options.DecimalSeparator = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the default value.
-		/// </summary>
-		public string DefaultValue
-		{
-			get => Options.DefaultValue;
-			set => Options.DefaultValue = value;
-		}
+        /// <summary>
+        /// Gets or sets the default value.
+        /// </summary>
+        public string DefaultValue
+        {
+            get => Options.DefaultValue;
+            set => Options.DefaultValue = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the value indicating if checkbox is disabled.
-		/// </summary>
-		public bool Disabled
-		{
-			get => Options.Disabled ?? false;
-			set => Options.Disabled = value;
-		}
+        /// <summary>
+        /// Gets or sets the value indicating if checkbox is disabled.
+        /// </summary>
+        public bool Disabled
+        {
+            get => Options.Disabled ?? false;
+            set => Options.Disabled = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the currency prefix.
-		/// </summary>
-		public string Prefix
-		{
-			get => Options.Prefix;
-			set => Options.Prefix = value;
-		}
+        /// <summary>
+        /// Gets or sets the currency prefix.
+        /// </summary>
+        public string Prefix
+        {
+            get => Options.Prefix;
+            set => Options.Prefix = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the currency suffix.
-		/// </summary>
-		public string Suffix
-		{
-			get => Options.Suffix;
-			set => Options.Suffix = value;
-		}
+        /// <summary>
+        /// Gets or sets the currency suffix.
+        /// </summary>
+        public string Suffix
+        {
+            get => Options.Suffix;
+            set => Options.Suffix = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the date source format.
-		/// </summary>
-		public string SourceFormat
-		{
-			get => Options.SourceFormat;
-			set => Options.SourceFormat = value;
-		}
+        /// <summary>
+        /// Gets or sets the date source format.
+        /// </summary>
+        public string SourceFormat
+        {
+            get => Options.SourceFormat;
+            set => Options.SourceFormat = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the date output format.
-		/// </summary>
-		public string OutputFormat
-		{
-			get => Options.OutputFormat;
-			set => Options.OutputFormat = value;
-		}
+        /// <summary>
+        /// Gets or sets the date output format.
+        /// </summary>
+        public string OutputFormat
+        {
+            get => Options.OutputFormat;
+            set => Options.OutputFormat = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the link for showlink formatter.
-		/// </summary>
-		public string BaseLinkUrl
-		{
-			get => Options.BaseLinkUrl;
-			set => Options.BaseLinkUrl = value;
-		}
+        /// <summary>
+        /// Gets or sets the link for showlink formatter.
+        /// </summary>
+        public string BaseLinkUrl
+        {
+            get => Options.BaseLinkUrl;
+            set => Options.BaseLinkUrl = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the additional value which is added after the BaseLinkUrl.
-		/// </summary>
-		public string ShowAction
-		{
-			get => Options.ShowAction;
-			set => Options.ShowAction = value;
-		}
+        /// <summary>
+        /// Gets or sets the additional value which is added after the BaseLinkUrl.
+        /// </summary>
+        public string ShowAction
+        {
+            get => Options.ShowAction;
+            set => Options.ShowAction = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the additional parameter which can be added after the IdName property.
-		/// </summary>
-		public string AddParam
-		{
-			get => Options.AddParam;
-			set => Options.AddParam = value;
-		}
+        /// <summary>
+        /// Gets or sets the additional parameter which can be added after the IdName property.
+        /// </summary>
+        public string AddParam
+        {
+            get => Options.AddParam;
+            set => Options.AddParam = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the target.
-		/// </summary>
-		public string Target
-		{
-			get => Options.Target;
-			set => Options.Target = value;
-		}
+        /// <summary>
+        /// Gets or sets the target.
+        /// </summary>
+        public string Target
+        {
+            get => Options.Target;
+            set => Options.Target = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the first parameter that is added after the ShowAction.
-		/// </summary>
-		public string IdName
-		{
-			get => Options.IdName;
-			set => Options.IdName = value;
-		}
+        /// <summary>
+        /// Gets or sets the first parameter that is added after the ShowAction.
+        /// </summary>
+        public string IdName
+        {
+            get => Options.IdName;
+            set => Options.IdName = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the thousands separator.
-		/// </summary>
-		public string ThousandsSeparator
-		{
-			get => Options.ThousandsSeparator;
-			set => Options.ThousandsSeparator = value;
-		}
+        /// <summary>
+        /// Gets or sets the thousands separator.
+        /// </summary>
+        public string ThousandsSeparator
+        {
+            get => Options.ThousandsSeparator;
+            set => Options.ThousandsSeparator = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the primary icon class (form UI theme icons) for jQuery UI Button widget.
-		/// </summary>
-		public string PrimaryIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the primary icon class (form UI theme icons) for jQuery UI Button widget.
+        /// </summary>
+        public string PrimaryIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the secondary icon class (form UI theme icons) for jQuery UI Button widget.
-		/// </summary>
-		public string SecondaryIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the secondary icon class (form UI theme icons) for jQuery UI Button widget.
+        /// </summary>
+        public string SecondaryIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text to show in the button for jQuery UI Button widget.
-		/// </summary>
-		public string Label { get; set; }
+        /// <summary>
+        /// Gets or sets the text to show in the button for jQuery UI Button widget.
+        /// </summary>
+        public string Label { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value whether to show the label in jQuery UI Button widget.
-		/// </summary>
-		public bool Text { get; set; }
+        /// <summary>
+        /// Gets or sets the value whether to show the label in jQuery UI Button widget.
+        /// </summary>
+        public bool Text { get; set; }
 
-		/// <summary>
-		/// Gets or sets the click handler (JavaScript) for jQuery UI Button widget.
-		/// </summary>
-		public string OnClick { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the click handler (JavaScript) for jQuery UI Button widget.
+        /// </summary>
+        public string OnClick { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnFormatterAttribute class.
-		/// </summary>
-		/// <param name="formatter">The predefined formatter type ('' delimited string) or custom JavaScript formatting function name. <c>null</c> for not using default formatter if setted in JqGrid</param>
-		public JqGridColumnFormatterAttribute(string formatter)
-		{
-			/*if (string.IsNullOrWhiteSpace(formatter))
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnFormatterAttribute class.
+        /// </summary>
+        /// <param name="formatter">The predefined formatter type ('' delimited string) or custom JavaScript formatting function name. <c>null</c> for not using default formatter if setted in JqGrid</param>
+        public JqGridColumnFormatterAttribute(string formatter)
+        {
+            /*if (string.IsNullOrWhiteSpace(formatter))
 				throw new ArgumentNullException(nameof(formatter));*/
-			Formatter = formatter;
-			Options = new JqGridColumnFormatterOptions();
-			PrimaryIcon = string.Empty;
-			SecondaryIcon = string.Empty;
-			Label = string.Empty;
-			Text = true;
-		}
-		#endregion
+            Formatter = formatter;
+            Options = new JqGridColumnFormatterOptions();
+            PrimaryIcon = string.Empty;
+            SecondaryIcon = string.Empty;
+            Label = string.Empty;
+            Text = true;
+        }
+        #endregion
 
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		public void OnMetadataCreated(ModelMetadata metadata)
-		{
-			if (Formatter == JqGridColumnPredefinedFormatters.JQueryUIButton)
-				metadata.SetColumnFormatter(new SettedString(true, GetJQueryUIButtonFormatter()));
-			else
-			{
-				metadata.SetColumnFormatter(new SettedString(true, Formatter));
-				metadata.SetColumnFormatterOptions(Options);
-				metadata.SetColumnUnFormatter(new SettedString(IsUnFormatterSetted, UnFormatter));
-			}
-		}
-		#endregion
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        public void OnMetadataCreated(ModelMetadata metadata)
+        {
+            if (Formatter == JqGridColumnPredefinedFormatters.JQueryUIButton)
+                metadata.SetColumnFormatter(new SettedString(true, GetJQueryUIButtonFormatter()));
+            else
+            {
+                metadata.SetColumnFormatter(new SettedString(true, Formatter));
+                metadata.SetColumnFormatterOptions(Options);
+                metadata.SetColumnUnFormatter(new SettedString(IsUnFormatterSetted, UnFormatter));
+            }
+        }
+        #endregion
 
-		#region Methods
-		internal string GetJQueryUIButtonFormatter()
-		{
-			var formatterBuilder = new StringBuilder(80);
-			formatterBuilder.Append("function(cellValue, options, rowObject) { setTimeout(function() { $('#' + options.rowId + '_JQueryUIButton').attr('data-cell-value', cellValue).button({ ");
+        #region Methods
+        internal string GetJQueryUIButtonFormatter()
+        {
+            StringBuilder formatterBuilder = new StringBuilder(80);
+            formatterBuilder.Append("function(cellValue, options, rowObject) { setTimeout(function() { $('#' + options.rowId + '_JQueryUIButton').attr('data-cell-value', cellValue).button({ ");
 
-			if (!string.IsNullOrEmpty(Label))
-				formatterBuilder.AppendFormat("label: '{0}', ", Label);
+            if (!string.IsNullOrEmpty(Label))
+                formatterBuilder.AppendFormat("label: '{0}', ", Label);
 
-			if (!string.IsNullOrWhiteSpace(PrimaryIcon) || !string.IsNullOrWhiteSpace(SecondaryIcon))
-			{
-				formatterBuilder.Append("icons: { ");
+            if (!string.IsNullOrWhiteSpace(PrimaryIcon) || !string.IsNullOrWhiteSpace(SecondaryIcon))
+            {
+                formatterBuilder.Append("icons: { ");
 
-				if (!string.IsNullOrWhiteSpace(PrimaryIcon))
-					formatterBuilder.AppendFormat("primary: '{0}', ", PrimaryIcon);
+                if (!string.IsNullOrWhiteSpace(PrimaryIcon))
+                    formatterBuilder.AppendFormat("primary: '{0}', ", PrimaryIcon);
 
-				if (!string.IsNullOrWhiteSpace(SecondaryIcon))
-					formatterBuilder.AppendFormat("secondary: '{0}', ", SecondaryIcon);
+                if (!string.IsNullOrWhiteSpace(SecondaryIcon))
+                    formatterBuilder.AppendFormat("secondary: '{0}', ", SecondaryIcon);
 
-				formatterBuilder.Remove(formatterBuilder.Length - 2, 2);
-				formatterBuilder.Append(" }, ");
-			}
+                formatterBuilder.Remove(formatterBuilder.Length - 2, 2);
+                formatterBuilder.Append(" }, ");
+            }
 
-			if (!Text)
-				formatterBuilder.Append("text: false, ");
+            if (!Text)
+                formatterBuilder.Append("text: false, ");
 
-			formatterBuilder.Remove(formatterBuilder.Length - 2, 2);
-			if (formatterBuilder[formatterBuilder.Length - 1] == '(')
-				formatterBuilder.Append(")");
-			else
-				formatterBuilder.Append(" })");
+            formatterBuilder.Remove(formatterBuilder.Length - 2, 2);
+            if (formatterBuilder[formatterBuilder.Length - 1] == '(')
+                formatterBuilder.Append(")");
+            else
+                formatterBuilder.Append(" })");
 
-			if (string.IsNullOrWhiteSpace(OnClick))
-				formatterBuilder.Append(";");
-			else
-				formatterBuilder.AppendFormat(".click({0});", OnClick);
-			formatterBuilder.Append(" }, 0); return '<button id=\"' + options.rowId + '_JQueryUIButton\" />'; }");
+            if (string.IsNullOrWhiteSpace(OnClick))
+                formatterBuilder.Append(";");
+            else
+                formatterBuilder.AppendFormat(".click({0});", OnClick);
+            formatterBuilder.Append(" }, 0); return '<button id=\"' + options.rowId + '_JQueryUIButton\" />'; }");
 
-			return formatterBuilder.ToString();
-		}
-		#endregion
-	}
+            return formatterBuilder.ToString();
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnLabelAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnLabelAttribute.cs
@@ -1,79 +1,69 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Web.Routing;
 using System.Web.Mvc;
-using System.Web;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Specifies the label in the header for the column.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class JqGridColumnLabelAttribute : Attribute, IMetadataAware
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the content of the label (if empty string the content will not be changed).
-        /// </summary>
-        public string Label
-        {
-            get { return LabelOptions.Label; }
-            set { LabelOptions.Label = value; }
-        }
+	/// <summary>
+	/// Specifies the label in the header for the column.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	public class JqGridColumnLabelAttribute : Attribute, IMetadataAware
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the content of the label (if empty string the content will not be changed).
+		/// </summary>
+		public string Label
+		{
+			get => LabelOptions.Label;
+			set => LabelOptions.Label = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the additional class for the label.
-        /// </summary>
-        public string Class
-        {
-            get { return LabelOptions.Class; }
-            set { LabelOptions.Class = value; }
-        }
+		/// <summary>
+		/// Gets or sets the additional class for the label.
+		/// </summary>
+		public string Class
+		{
+			get => LabelOptions.Class;
+			set => LabelOptions.Class = value;
+		}
 
-        /// <summary>
-        /// When overriden in delivered class, provides a dictionary where keys should be CSS styles for the label (will be applied only if Class is null or empty string).
-        /// </summary>
-        protected virtual IDictionary<string, object> CssStyles
-        {
-            get { return null; }
-        }
+		/// <summary>
+		/// When overriden in delivered class, provides a dictionary where keys should be CSS styles for the label (will be applied only if Class is null or empty string).
+		/// </summary>
+		protected virtual IDictionary<string, object> CssStyles => null;
 
-        /// <summary>
-        /// When overriden in delivered class, provides a dictionary where keys should be valid attributes for the label.
-        /// </summary>
-        protected virtual IDictionary<string, object> HtmlAttributes
-        {
-            get { return null; }
-        }
+		/// <summary>
+		/// When overriden in delivered class, provides a dictionary where keys should be valid attributes for the label.
+		/// </summary>
+		protected virtual IDictionary<string, object> HtmlAttributes => null;
 
-        private JqGridColumnLabelOptions LabelOptions { get; set; }
-        #endregion
+		private JqGridColumnLabelOptions LabelOptions { get; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnLabelAttribute class.
-        /// </summary>
-        public JqGridColumnLabelAttribute()
-        {
-            LabelOptions = new JqGridColumnLabelOptions();
-        }
-        #endregion
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnLabelAttribute class.
+		/// </summary>
+		public JqGridColumnLabelAttribute()
+		{
+			LabelOptions = new JqGridColumnLabelOptions();
+		}
+		#endregion
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        public void OnMetadataCreated(ModelMetadata metadata)
-        {
-            LabelOptions.CssStyles = CssStyles;
-            LabelOptions.HtmlAttributes = HtmlAttributes;
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		public void OnMetadataCreated(ModelMetadata metadata)
+		{
+			LabelOptions.CssStyles = CssStyles;
+			LabelOptions.HtmlAttributes = HtmlAttributes;
 
-            metadata.SetColumnLabelOptions(LabelOptions);
-        }
-        #endregion
-    }
+			metadata.SetColumnLabelOptions(LabelOptions);
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnLabelAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnLabelAttribute.cs
@@ -4,66 +4,66 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <summary>
-	/// Specifies the label in the header for the column.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property)]
-	public class JqGridColumnLabelAttribute : Attribute, IMetadataAware
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the content of the label (if empty string the content will not be changed).
-		/// </summary>
-		public string Label
-		{
-			get => LabelOptions.Label;
-			set => LabelOptions.Label = value;
-		}
+    /// <summary>
+    /// Specifies the label in the header for the column.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class JqGridColumnLabelAttribute : Attribute, IMetadataAware
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the content of the label (if empty string the content will not be changed).
+        /// </summary>
+        public string Label
+        {
+            get => LabelOptions.Label;
+            set => LabelOptions.Label = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the additional class for the label.
-		/// </summary>
-		public string Class
-		{
-			get => LabelOptions.Class;
-			set => LabelOptions.Class = value;
-		}
+        /// <summary>
+        /// Gets or sets the additional class for the label.
+        /// </summary>
+        public string Class
+        {
+            get => LabelOptions.Class;
+            set => LabelOptions.Class = value;
+        }
 
-		/// <summary>
-		/// When overriden in delivered class, provides a dictionary where keys should be CSS styles for the label (will be applied only if Class is null or empty string).
-		/// </summary>
-		protected virtual IDictionary<string, object> CssStyles => null;
+        /// <summary>
+        /// When overriden in delivered class, provides a dictionary where keys should be CSS styles for the label (will be applied only if Class is null or empty string).
+        /// </summary>
+        protected virtual IDictionary<string, object> CssStyles => null;
 
-		/// <summary>
-		/// When overriden in delivered class, provides a dictionary where keys should be valid attributes for the label.
-		/// </summary>
-		protected virtual IDictionary<string, object> HtmlAttributes => null;
+        /// <summary>
+        /// When overriden in delivered class, provides a dictionary where keys should be valid attributes for the label.
+        /// </summary>
+        protected virtual IDictionary<string, object> HtmlAttributes => null;
 
-		private JqGridColumnLabelOptions LabelOptions { get; }
-		#endregion
+        private JqGridColumnLabelOptions LabelOptions { get; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnLabelAttribute class.
-		/// </summary>
-		public JqGridColumnLabelAttribute()
-		{
-			LabelOptions = new JqGridColumnLabelOptions();
-		}
-		#endregion
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnLabelAttribute class.
+        /// </summary>
+        public JqGridColumnLabelAttribute()
+        {
+            LabelOptions = new JqGridColumnLabelOptions();
+        }
+        #endregion
 
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		public void OnMetadataCreated(ModelMetadata metadata)
-		{
-			LabelOptions.CssStyles = CssStyles;
-			LabelOptions.HtmlAttributes = HtmlAttributes;
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        public void OnMetadataCreated(ModelMetadata metadata)
+        {
+            LabelOptions.CssStyles = CssStyles;
+            LabelOptions.HtmlAttributes = HtmlAttributes;
 
-			metadata.SetColumnLabelOptions(LabelOptions);
-		}
-		#endregion
-	}
+            metadata.SetColumnLabelOptions(LabelOptions);
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnLayoutAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnLayoutAttribute.cs
@@ -1,104 +1,157 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Specifies the layout attributes of grid column
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class JqGridColumnLayoutAttribute : Attribute, IMetadataAware
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the alignment of the cell in the grid body layer.
-        /// </summary>
-        public JqGridAlignments Alignment { get; set; }
+	/// <summary>
+	/// Specifies the layout attributes of grid column
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	public sealed class JqGridColumnLayoutAttribute : Attribute, IMetadataAware
+	{
 
-        /// <summary>
-        /// Gets or sets the function which can add attributes to the cell during the creation of the data (dynamically).
-        /// </summary>
-        public string CellAttributes { get; set; }
+		#region Fields
+		private string _cellAttributes;
+		private string _classes;
+		private bool? _fixed;
+		private bool? _frozen;
+		private bool? _hideInDialog;
+		private bool? _resizable;
+		private bool? _title;
+		private bool? _viewable;
+		private int? _width;
 
-        /// <summary>
-        /// Gets or sets additional CSS classes for the column (separated by space).
-        /// </summary>
-        public string Classes { get; set; }
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the value which defines if internal recalculation of the width of the column is disabled (default false).
-        /// </summary>
-        public bool Fixed { get; set; }
+		#region Properties
+		/// <summary>
+		/// Gets or sets the alignment of the cell in the grid body layer.
+		/// </summary>
+		public JqGridAlignments Alignment { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if column shouldn't scroll out of view when user is moving horizontally across the grid.
-        /// </summary>
-        public bool Frozen { get; set; }
+		internal bool IsCellAttriburesSetted { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if column will appear in the modal dialog where users can choose which columns to show or hide.
-        /// </summary>
-        public bool HideInDialog { get; set; }
+		/// <summary>
+		/// Gets or sets the function which can add attributes to the cell during the creation of the data (dynamically).
+		/// </summary>
+		public string CellAttributes
+		{
+			get => _cellAttributes;
+			set
+			{
+				_cellAttributes = value;
+				IsCellAttriburesSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the value which defines if column can be resized (default true).
-        /// </summary>
-        public bool Resizable { get; set; }
+		internal bool IsClassesSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets additional CSS classes for the column (separated by space).
+		/// </summary>
+		public string Classes
+		{
+			get => _classes;
+			set
+			{
+				_classes = value;
+				IsClassesSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the value which defines if the title should be displayed in the column when user hovers a cell with the mouse.
-        /// </summary>
-        public bool Title { get; set; }
 
-        /// <summary>
-        /// Gets or sets the initial width in pixels of the column (default 150).
-        /// </summary>
-        public int Width { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if internal recalculation of the width of the column is disabled (default false).
+		/// </summary>
+		public bool Fixed
+		{
+			get => _fixed ?? false;
+			set => _fixed = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value which defines if the column should appear in view form.
-        /// </summary>
-        public bool Viewable { get; set; }
-        #endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnLayoutAttribute class.
-        /// </summary>
-        public JqGridColumnLayoutAttribute()
-        {
-            Alignment = JqGridAlignments.Left;
-            CellAttributes = null;
-            Fixed = false;
-            Frozen = false;
-            HideInDialog = false;
-            Resizable = true;
-            Title = true;
-            Width = 150;
-            Viewable = true;
-        }
-        #endregion
+		/// <summary>
+		/// Gets or sets the value indicating if column shouldn't scroll out of view when user is moving horizontally across the grid.
+		/// </summary>
+		public bool Frozen
+		{
+			get => _frozen ?? false;
+			set => _frozen = value;
+		}
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        public void OnMetadataCreated(ModelMetadata metadata)
-        {
-            metadata.SetColumnAlignment(Alignment);
-            metadata.SetColumnCellAttributes(CellAttributes);
-            metadata.SetColumnClasses(Classes);
-            metadata.SetColumnFixed(Fixed);
-            metadata.SetColumnFrozen(Frozen);
-            metadata.SetColumnHideInDialog(HideInDialog);
-            metadata.SetColumnResizable(Resizable);
-            metadata.SetColumnTitle(Title);
-            metadata.SetColumnWidth(Width);
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Gets or sets the value which defines if column will appear in the modal dialog where users can choose which columns to show or hide.
+		/// </summary>
+		public bool HideInDialog
+		{
+			get => _hideInDialog ?? false;
+			set => _hideInDialog = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the value which defines if column can be resized (default true).
+		/// </summary>
+		public bool Resizable
+		{
+			get => _resizable ?? true;
+			set => _resizable = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the value which defines if the title should be displayed in the column when user hovers a cell with the mouse.
+		/// </summary>
+		public bool Title
+		{
+			get => _title ?? true;
+			set => _title = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the initial width in pixels of the column (default 150).
+		/// </summary>
+		public int Width
+		{
+			get => _width ?? 150;
+			set => _width = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the value which defines if the column should appear in view form.
+		/// </summary>
+		public bool Viewable
+		{
+			get => _viewable ?? true;
+			set => _viewable = value;
+		}
+
+		#endregion
+
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnLayoutAttribute class.
+		/// </summary>
+		public JqGridColumnLayoutAttribute()
+		{
+			Alignment = JqGridAlignments.Default;
+		}
+		#endregion
+
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		public void OnMetadataCreated(ModelMetadata metadata)
+		{
+			if (Alignment != JqGridAlignments.Default) metadata.SetColumnAlignment(Alignment);
+			metadata.SetColumnCellAttributes(new SettedString(IsCellAttriburesSetted, CellAttributes));
+			metadata.SetColumnClasses(new SettedString(IsClassesSetted, Classes));
+			metadata.SetColumnFixed(_fixed);
+			metadata.SetColumnFrozen(_frozen);
+			metadata.SetColumnHideInDialog(_hideInDialog);
+			metadata.SetColumnResizable(_resizable);
+			metadata.SetColumnTitle(_title);
+			metadata.SetColumnWidth(_width);
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnLayoutAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnLayoutAttribute.cs
@@ -3,155 +3,155 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <summary>
-	/// Specifies the layout attributes of grid column
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property)]
-	public sealed class JqGridColumnLayoutAttribute : Attribute, IMetadataAware
-	{
+    /// <summary>
+    /// Specifies the layout attributes of grid column
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class JqGridColumnLayoutAttribute : Attribute, IMetadataAware
+    {
 
-		#region Fields
-		private string _cellAttributes;
-		private string _classes;
-		private bool? _fixed;
-		private bool? _frozen;
-		private bool? _hideInDialog;
-		private bool? _resizable;
-		private bool? _title;
-		private bool? _viewable;
-		private int? _width;
+        #region Fields
+        private string _cellAttributes;
+        private string _classes;
+        private bool? _fixed;
+        private bool? _frozen;
+        private bool? _hideInDialog;
+        private bool? _resizable;
+        private bool? _title;
+        private bool? _viewable;
+        private int? _width;
 
-		#endregion
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets the alignment of the cell in the grid body layer.
-		/// </summary>
-		public JqGridAlignments Alignment { get; set; }
+        #region Properties
+        /// <summary>
+        /// Gets or sets the alignment of the cell in the grid body layer.
+        /// </summary>
+        public JqGridAlignments Alignment { get; set; }
 
-		internal bool IsCellAttriburesSetted { get; set; }
+        internal bool IsCellAttriburesSetted { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function which can add attributes to the cell during the creation of the data (dynamically).
-		/// </summary>
-		public string CellAttributes
-		{
-			get => _cellAttributes;
-			set
-			{
-				_cellAttributes = value;
-				IsCellAttriburesSetted = true;
-			}
-		}
+        /// <summary>
+        /// Gets or sets the function which can add attributes to the cell during the creation of the data (dynamically).
+        /// </summary>
+        public string CellAttributes
+        {
+            get => _cellAttributes;
+            set
+            {
+                _cellAttributes = value;
+                IsCellAttriburesSetted = true;
+            }
+        }
 
-		internal bool IsClassesSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets additional CSS classes for the column (separated by space).
-		/// </summary>
-		public string Classes
-		{
-			get => _classes;
-			set
-			{
-				_classes = value;
-				IsClassesSetted = true;
-			}
-		}
-
-
-		/// <summary>
-		/// Gets or sets the value which defines if internal recalculation of the width of the column is disabled (default false).
-		/// </summary>
-		public bool Fixed
-		{
-			get => _fixed ?? false;
-			set => _fixed = value;
-		}
+        internal bool IsClassesSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets additional CSS classes for the column (separated by space).
+        /// </summary>
+        public string Classes
+        {
+            get => _classes;
+            set
+            {
+                _classes = value;
+                IsClassesSetted = true;
+            }
+        }
 
 
-		/// <summary>
-		/// Gets or sets the value indicating if column shouldn't scroll out of view when user is moving horizontally across the grid.
-		/// </summary>
-		public bool Frozen
-		{
-			get => _frozen ?? false;
-			set => _frozen = value;
-		}
+        /// <summary>
+        /// Gets or sets the value which defines if internal recalculation of the width of the column is disabled (default false).
+        /// </summary>
+        public bool Fixed
+        {
+            get => _fixed ?? false;
+            set => _fixed = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the value which defines if column will appear in the modal dialog where users can choose which columns to show or hide.
-		/// </summary>
-		public bool HideInDialog
-		{
-			get => _hideInDialog ?? false;
-			set => _hideInDialog = value;
-		}
 
-		/// <summary>
-		/// Gets or sets the value which defines if column can be resized (default true).
-		/// </summary>
-		public bool Resizable
-		{
-			get => _resizable ?? true;
-			set => _resizable = value;
-		}
+        /// <summary>
+        /// Gets or sets the value indicating if column shouldn't scroll out of view when user is moving horizontally across the grid.
+        /// </summary>
+        public bool Frozen
+        {
+            get => _frozen ?? false;
+            set => _frozen = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the value which defines if the title should be displayed in the column when user hovers a cell with the mouse.
-		/// </summary>
-		public bool Title
-		{
-			get => _title ?? true;
-			set => _title = value;
-		}
+        /// <summary>
+        /// Gets or sets the value which defines if column will appear in the modal dialog where users can choose which columns to show or hide.
+        /// </summary>
+        public bool HideInDialog
+        {
+            get => _hideInDialog ?? false;
+            set => _hideInDialog = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the initial width in pixels of the column (default 150).
-		/// </summary>
-		public int Width
-		{
-			get => _width ?? 150;
-			set => _width = value;
-		}
+        /// <summary>
+        /// Gets or sets the value which defines if column can be resized (default true).
+        /// </summary>
+        public bool Resizable
+        {
+            get => _resizable ?? true;
+            set => _resizable = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the value which defines if the column should appear in view form.
-		/// </summary>
-		public bool Viewable
-		{
-			get => _viewable ?? true;
-			set => _viewable = value;
-		}
+        /// <summary>
+        /// Gets or sets the value which defines if the title should be displayed in the column when user hovers a cell with the mouse.
+        /// </summary>
+        public bool Title
+        {
+            get => _title ?? true;
+            set => _title = value;
+        }
 
-		#endregion
+        /// <summary>
+        /// Gets or sets the initial width in pixels of the column (default 150).
+        /// </summary>
+        public int Width
+        {
+            get => _width ?? 150;
+            set => _width = value;
+        }
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnLayoutAttribute class.
-		/// </summary>
-		public JqGridColumnLayoutAttribute()
-		{
-			Alignment = JqGridAlignments.Default;
-		}
-		#endregion
+        /// <summary>
+        /// Gets or sets the value which defines if the column should appear in view form.
+        /// </summary>
+        public bool Viewable
+        {
+            get => _viewable ?? true;
+            set => _viewable = value;
+        }
 
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		public void OnMetadataCreated(ModelMetadata metadata)
-		{
-			if (Alignment != JqGridAlignments.Default) metadata.SetColumnAlignment(Alignment);
-			metadata.SetColumnCellAttributes(new SettedString(IsCellAttriburesSetted, CellAttributes));
-			metadata.SetColumnClasses(new SettedString(IsClassesSetted, Classes));
-			metadata.SetColumnFixed(_fixed);
-			metadata.SetColumnFrozen(_frozen);
-			metadata.SetColumnHideInDialog(_hideInDialog);
-			metadata.SetColumnResizable(_resizable);
-			metadata.SetColumnTitle(_title);
-			metadata.SetColumnWidth(_width);
-		}
-		#endregion
-	}
+        #endregion
+
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnLayoutAttribute class.
+        /// </summary>
+        public JqGridColumnLayoutAttribute()
+        {
+            Alignment = JqGridAlignments.Default;
+        }
+        #endregion
+
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        public void OnMetadataCreated(ModelMetadata metadata)
+        {
+            if (Alignment != JqGridAlignments.Default) metadata.SetColumnAlignment(Alignment);
+            metadata.SetColumnCellAttributes(new SettedString(IsCellAttriburesSetted, CellAttributes));
+            metadata.SetColumnClasses(new SettedString(IsClassesSetted, Classes));
+            metadata.SetColumnFixed(_fixed);
+            metadata.SetColumnFrozen(_frozen);
+            metadata.SetColumnHideInDialog(_hideInDialog);
+            metadata.SetColumnResizable(_resizable);
+            metadata.SetColumnTitle(_title);
+            metadata.SetColumnWidth(_width);
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnMappingAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnMappingAttribute.cs
@@ -3,57 +3,57 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <summary>
-	/// Specifies the mapping properties for the column.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property)]
-	public class JqGridColumnMappingAttribute : Attribute, IMetadataAware
-	{
-		private bool? _key;
+    /// <summary>
+    /// Specifies the mapping properties for the column.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class JqGridColumnMappingAttribute : Attribute, IMetadataAware
+    {
+        private bool? _key;
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets the JSON mapping for the column in the incoming JSON string.
-		/// </summary>
-		public string JsonMapping { get; set; }
+        #region Properties
+        /// <summary>
+        /// Gets or sets the JSON mapping for the column in the incoming JSON string.
+        /// </summary>
+        public string JsonMapping { get; set; }
 
-		/// <summary>
-		/// Defines if this column value should be used as unique row id (in case there is no id from the server). 
-		/// </summary>
-		public bool Key
-		{
-			get => _key ?? false;
-			set => _key = value;
-		}
+        /// <summary>
+        /// Defines if this column value should be used as unique row id (in case there is no id from the server). 
+        /// </summary>
+        public bool Key
+        {
+            get => _key ?? false;
+            set => _key = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the XML mapping for the column in the incomming XML file.
-		/// </summary>
-		public string XmlMapping { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the XML mapping for the column in the incomming XML file.
+        /// </summary>
+        public string XmlMapping { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnMappingAttribute class.
-		/// </summary>
-		public JqGridColumnMappingAttribute()
-		{
-			JsonMapping = null;
-			XmlMapping = null;
-		}
-		#endregion
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnMappingAttribute class.
+        /// </summary>
+        public JqGridColumnMappingAttribute()
+        {
+            JsonMapping = null;
+            XmlMapping = null;
+        }
+        #endregion
 
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		public void OnMetadataCreated(ModelMetadata metadata)
-		{
-			metadata.SetColumnJsonMapping(JsonMapping);
-			metadata.SetColumnKey(_key);
-			metadata.SetColumnXmlMapping(XmlMapping);
-		}
-		#endregion
-	}
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        public void OnMetadataCreated(ModelMetadata metadata)
+        {
+            metadata.SetColumnJsonMapping(JsonMapping);
+            metadata.SetColumnKey(_key);
+            metadata.SetColumnXmlMapping(XmlMapping);
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnMappingAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnMappingAttribute.cs
@@ -1,57 +1,59 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Specifies the mapping properties for the column.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class JqGridColumnMappingAttribute : Attribute, IMetadataAware
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the JSON mapping for the column in the incoming JSON string.
-        /// </summary>
-        public string JsonMapping { get; set; }
+	/// <summary>
+	/// Specifies the mapping properties for the column.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	public class JqGridColumnMappingAttribute : Attribute, IMetadataAware
+	{
+		private bool? _key;
 
-        /// <summary>
-        /// Defines if this column value should be used as unique row id (in case there is no id from the server). 
-        /// </summary>
-        public bool Key { get; set; }
+		#region Properties
+		/// <summary>
+		/// Gets or sets the JSON mapping for the column in the incoming JSON string.
+		/// </summary>
+		public string JsonMapping { get; set; }
 
-        /// <summary>
-        /// Gets or sets the XML mapping for the column in the incomming XML file.
-        /// </summary>
-        public string XmlMapping { get; set; }
-        #endregion
+		/// <summary>
+		/// Defines if this column value should be used as unique row id (in case there is no id from the server). 
+		/// </summary>
+		public bool Key
+		{
+			get => _key ?? false;
+			set => _key = value;
+		}
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnMappingAttribute class.
-        /// </summary>
-        public JqGridColumnMappingAttribute()
-        {
-            JsonMapping = null;
-            Key = false;
-            XmlMapping = null;
-        }
-        #endregion
+		/// <summary>
+		/// Gets or sets the XML mapping for the column in the incomming XML file.
+		/// </summary>
+		public string XmlMapping { get; set; }
+		#endregion
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        public void OnMetadataCreated(ModelMetadata metadata)
-        {
-            metadata.SetColumnJsonMapping(JsonMapping);
-            metadata.SetColumnKey(Key);
-            metadata.SetColumnXmlMapping(XmlMapping);
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnMappingAttribute class.
+		/// </summary>
+		public JqGridColumnMappingAttribute()
+		{
+			JsonMapping = null;
+			XmlMapping = null;
+		}
+		#endregion
+
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		public void OnMetadataCreated(ModelMetadata metadata)
+		{
+			metadata.SetColumnJsonMapping(JsonMapping);
+			metadata.SetColumnKey(_key);
+			metadata.SetColumnXmlMapping(XmlMapping);
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSearchableAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSearchableAttribute.cs
@@ -1,185 +1,180 @@
 ﻿using System;
 using System.Web.Mvc;
 using System.Web.Routing;
+using JetBrains.Annotations;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Specifies the searching options for column
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class JqGridColumnSearchableAttribute : JqGridColumnElementAttribute
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the value which defines if Clear ("X") button is available at the end of search field for this column in jqGrid filter toolbar.
-        /// </summary>
-        public bool ClearSearch
-        {
-            get { return SearchOptions.ClearSearch; }
-            set { SearchOptions.ClearSearch = value; }
-        }
+	/// <inheritdoc />
+	/// <summary>
+	/// Specifies the searching options for column
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	public class JqGridColumnSearchableAttribute : JqGridColumnElementAttribute
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the value which defines if Clear ("X") button is available at the end of search field for this column in jqGrid filter toolbar.
+		/// </summary>
+		public bool ClearSearch
+		{
+			get => SearchOptions.ClearSearch ?? true;
+			set => SearchOptions.ClearSearch = value;
+		}
 
-        /// <summary>
-        /// Gets or sets if the value is required while searching.
-        /// </summary>
-        public bool RequiredValidation
-        {
-            get { return Rules.Required; }
-            set { Rules.Required = value; }
-        }
+		/// <summary>
+		/// Gets or sets if the value is required while searching.
+		/// </summary>
+		public bool RequiredValidation
+		{
+			get => Rules.Required ?? false;
+			set => Rules.Required = value;
+		}
 
-        /// <summary>
-        /// Gets the value defining if this column can be searched.
-        /// </summary>
-        public bool Searchable { get; private set; }
+		/// <summary>
+		/// Gets the value defining if this column can be searched.
+		/// </summary>
+		public bool Searchable { get; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if hidden column can be searched.
-        /// </summary>
-        public bool SearchHidden
-        {
-            get { return SearchOptions.SearchHidden; }
-            set { SearchOptions.SearchHidden = value; }
-        }
+		/// <summary>
+		/// Gets or sets the value which defines if hidden column can be searched.
+		/// </summary>
+		public bool SearchHidden
+		{
+			get => SearchOptions.SearchHidden ?? false;
+			set => SearchOptions.SearchHidden = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the available search operators for the column (default JqGridSearchOperators.Eq).
-        /// </summary>
-        public JqGridSearchOperators SearchOperators
-        {
-            get { return SearchOptions.SearchOperators; }
-            set { SearchOptions.SearchOperators = value; }
-        }
+		/// <summary>
+		/// Gets or sets the available search operators for the column (default JqGridSearchOperators.Eq).
+		/// </summary>
+		public JqGridSearchOperators SearchOperators
+		{
+			get => SearchOptions.SearchOperators;
+			set => SearchOptions.SearchOperators = value;
+		}
 
-        private JqGridColumnSearchOptions SearchOptions
-        {
-            get { return (base.Options as JqGridColumnSearchOptions); }
-            set { base.Options = value; }
-        }
+		private JqGridColumnSearchOptions SearchOptions
+		{
+			get => Options as JqGridColumnSearchOptions;
+			set => Options = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the type of the search field (default JqGridColumnSearchTypes.Text).
-        /// </summary>
-        public JqGridColumnSearchTypes SearchType { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the type of the search field (default JqGridColumnSearchTypes.Text).
+		/// </summary>
+		public JqGridColumnSearchTypes SearchType { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnSearchableAttribute class.
-        /// </summary>
-        /// <param name="searchable">If this column can be searched</param>
-        public JqGridColumnSearchableAttribute(bool searchable)
-            : base()
-        {
-            Searchable = searchable;
-            SearchOptions = new JqGridColumnSearchOptions();
-            SearchType = JqGridColumnSearchTypes.Text;
-        }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnSearchableAttribute class.
+		/// </summary>
+		/// <param name="searchable">If this column can be searched</param>
+		public JqGridColumnSearchableAttribute(bool searchable = true)
+		{
+			Searchable = searchable;
+			SearchOptions = new JqGridColumnSearchOptions();
+			SearchType = JqGridColumnSearchTypes.Default;
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnSearchableAttribute class.
-        /// </summary>
-        /// <param name="searchable">If this column can be searched</param>
-        /// <param name="dataUrlRouteName">Route name for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-        public JqGridColumnSearchableAttribute(bool searchable, string dataUrlRouteName)
-            : this(searchable)
-        {
-            if (String.IsNullOrWhiteSpace(dataUrlRouteName))
-                throw new ArgumentNullException("dataUrlRouteName");
-            
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
+		/// </summary>
+		/// <param name="dataUrlRouteName">Route name for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+		public JqGridColumnSearchableAttribute(string dataUrlRouteName)
+			: this()
+		{
+			if (string.IsNullOrWhiteSpace(dataUrlRouteName))
+				throw new ArgumentNullException(nameof(dataUrlRouteName));
 
-            DataUrlRouteName = dataUrlRouteName;
-            DataUrlRouteData = new RouteValueDictionary();
-        }
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnSearchableAttribute class.
-        /// </summary>
-        /// <param name="searchable">If this column can be searched</param>
-        /// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-        /// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-        public JqGridColumnSearchableAttribute(bool searchable, string dataUrlAction, string dataUrlController) :
-            this(searchable, dataUrlAction, dataUrlController, null)
-        { }
+			DataUrlRouteName = dataUrlRouteName;
+			DataUrlRouteData = new RouteValueDictionary();
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnSearchableAttribute class.
-        /// </summary>
-        /// <param name="searchable">If this column can be searched</param>
-        /// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-        /// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-        /// <param name="dataUrlAreaName">Area for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-        public JqGridColumnSearchableAttribute(bool searchable, string dataUrlAction, string dataUrlController, string dataUrlAreaName)
-            : this(searchable)
-        {
-            if (String.IsNullOrWhiteSpace(dataUrlAction))
-                throw new ArgumentNullException("dataUrlAction");
-            
-            if (String.IsNullOrWhiteSpace(dataUrlController))
-                throw new ArgumentNullException("dataUrlController");
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
+		/// </summary>
+		/// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+		/// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+		public JqGridColumnSearchableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController) :
+			this(dataUrlAction, dataUrlController, null)
+		{ }
 
-            DataUrlRouteData = new RouteValueDictionary();
-            DataUrlRouteData["controller"] = dataUrlController;
-            DataUrlRouteData["action"] = dataUrlAction;
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
+		/// </summary>
+		/// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+		/// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+		/// <param name="dataUrlAreaName">Area for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+		public JqGridColumnSearchableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController, [AspMvcArea] string dataUrlAreaName)
+			: this()
+		{
+			if (string.IsNullOrWhiteSpace(dataUrlAction))
+				throw new ArgumentNullException(nameof(dataUrlAction));
 
-            if (dataUrlAreaName != null)
-                DataUrlRouteData["area"] = dataUrlAreaName;
-        }
+			if (string.IsNullOrWhiteSpace(dataUrlController))
+				throw new ArgumentNullException(nameof(dataUrlController));
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnSearchableAttribute class.
-        /// </summary>
-        /// <param name="searchable">If this column can be searched</param>
-        /// <param name="valueProviderType">The type of class which contains a method which will provide data for select element (if is JqGridColumnSearchTypes.Select). This class must have public parameterless constructor.</param>
-        /// <param name="valueProviderMethodName">The name of method which will provide data for select element (if is JqGridColumnSearchTypes.Select). This method must return an object which implements IDictionary&lt;string, string&gt;.</param>
-        public JqGridColumnSearchableAttribute(bool searchable, Type valueProviderType, string valueProviderMethodName)
-            : this(searchable)
-        {
-            if (valueProviderType == null)
-                throw new ArgumentNullException("valueProviderType");
+			DataUrlRouteData = new RouteValueDictionary();
+			DataUrlRouteData["controller"] = dataUrlController;
+			DataUrlRouteData["action"] = dataUrlAction;
 
-            if (String.IsNullOrWhiteSpace(valueProviderMethodName))
-                throw new ArgumentNullException("valueProviderMethodName");
+			if (dataUrlAreaName != null)
+				DataUrlRouteData["area"] = dataUrlAreaName;
+		}
 
-            ValueProviderType = valueProviderType;
-            ValueProviderMethodName = valueProviderMethodName;
-        }
-        #endregion
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
+		/// </summary>
+		/// <param name="valueProviderType">The type of class which contains a method which will provide data for select element (if is JqGridColumnSearchTypes.Select). This class must have public parameterless constructor.</param>
+		/// <param name="valueProviderMethodName">The name of method which will provide data for select element (if is JqGridColumnSearchTypes.Select). This method must return an object which implements IDictionary&lt;string, string&gt;.</param>
+		public JqGridColumnSearchableAttribute(Type valueProviderType, string valueProviderMethodName)
+			: this()
+		{
+			if (string.IsNullOrWhiteSpace(valueProviderMethodName))
+				throw new ArgumentNullException(nameof(valueProviderMethodName));
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        protected override void InternalOnMetadataCreated(ModelMetadata metadata)
-        {
-            SearchOptions.DataEvents = DataEvents;
-            SearchOptions.DataUrl = DataUrl;
-            SearchOptions.HtmlAttributes = HtmlAttributes;
-            SearchOptions.ValueDictionary = ValueDictionary;
+			ValueProviderType = valueProviderType ?? throw new ArgumentNullException(nameof(valueProviderType));
+			ValueProviderMethodName = valueProviderMethodName;
+		}
+		#endregion
 
-            if (SearchType == JqGridColumnSearchTypes.JQueryUIAutocomplete)
-            {
-                SearchType = JqGridColumnSearchTypes.Text;
-                SearchOptions.ConfigureJQueryUIAutocomplete();
-            }
-            else if (SearchType == JqGridColumnSearchTypes.JQueryUIDatepicker)
-            {
-                SearchType = JqGridColumnSearchTypes.Text;
-                SearchOptions.ConfigureJQueryUIDatepicker(metadata);
-            }
-            else if (SearchType == JqGridColumnSearchTypes.JQueryUISpinner)
-            {
-                SearchType = JqGridColumnSearchTypes.Text;
-                SearchOptions.ConfigureJQueryUISpinner();
-            }
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		protected override void InternalOnMetadataCreated(ModelMetadata metadata)
+		{
+			SearchOptions.DataEvents = DataEvents;
+			if (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null)
+				SearchOptions.DataUrl = DataUrl;
+			SearchOptions.HtmlAttributes = HtmlAttributes;
+			SearchOptions.ValueDictionary = ValueDictionary;
 
-            metadata.SetColumnSearchable(Searchable);
-            metadata.SetColumnSearchOptions(SearchOptions);
-            metadata.SetColumnSearchRules(Rules);
-            metadata.SetColumnSearchType(SearchType);
-        }
-        #endregion
-    }
+			if (SearchType == JqGridColumnSearchTypes.JQueryUIAutocomplete)
+			{
+				SearchType = JqGridColumnSearchTypes.Text;
+				SearchOptions.ConfigureJQueryUIAutocomplete();
+			}
+			else if (SearchType == JqGridColumnSearchTypes.JQueryUIDatepicker)
+			{
+				SearchType = JqGridColumnSearchTypes.Text;
+				SearchOptions.ConfigureJQueryUIDatepicker(metadata);
+			}
+			else if (SearchType == JqGridColumnSearchTypes.JQueryUISpinner)
+			{
+				SearchType = JqGridColumnSearchTypes.Text;
+				SearchOptions.ConfigureJQueryUISpinner();
+			}
+
+			metadata.SetColumnSearchable(Searchable);
+			metadata.SetColumnSearchOptions(SearchOptions);
+			metadata.SetColumnSearchRules(Rules);
+			metadata.SetColumnSearchType(SearchType);
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSearchableAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSearchableAttribute.cs
@@ -5,176 +5,176 @@ using JetBrains.Annotations;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <inheritdoc />
-	/// <summary>
-	/// Specifies the searching options for column
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property)]
-	public class JqGridColumnSearchableAttribute : JqGridColumnElementAttribute
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the value which defines if Clear ("X") button is available at the end of search field for this column in jqGrid filter toolbar.
-		/// </summary>
-		public bool ClearSearch
-		{
-			get => SearchOptions.ClearSearch ?? true;
-			set => SearchOptions.ClearSearch = value;
-		}
+    /// <inheritdoc />
+    /// <summary>
+    /// Specifies the searching options for column
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class JqGridColumnSearchableAttribute : JqGridColumnElementAttribute
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the value which defines if Clear ("X") button is available at the end of search field for this column in jqGrid filter toolbar.
+        /// </summary>
+        public bool ClearSearch
+        {
+            get => SearchOptions.ClearSearch ?? true;
+            set => SearchOptions.ClearSearch = value;
+        }
 
-		/// <summary>
-		/// Gets or sets if the value is required while searching.
-		/// </summary>
-		public bool RequiredValidation
-		{
-			get => Rules.Required ?? false;
-			set => Rules.Required = value;
-		}
+        /// <summary>
+        /// Gets or sets if the value is required while searching.
+        /// </summary>
+        public bool RequiredValidation
+        {
+            get => Rules.Required ?? false;
+            set => Rules.Required = value;
+        }
 
-		/// <summary>
-		/// Gets the value defining if this column can be searched.
-		/// </summary>
-		public bool Searchable { get; }
+        /// <summary>
+        /// Gets the value defining if this column can be searched.
+        /// </summary>
+        public bool Searchable { get; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if hidden column can be searched.
-		/// </summary>
-		public bool SearchHidden
-		{
-			get => SearchOptions.SearchHidden ?? false;
-			set => SearchOptions.SearchHidden = value;
-		}
+        /// <summary>
+        /// Gets or sets the value which defines if hidden column can be searched.
+        /// </summary>
+        public bool SearchHidden
+        {
+            get => SearchOptions.SearchHidden ?? false;
+            set => SearchOptions.SearchHidden = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the available search operators for the column (default JqGridSearchOperators.Eq).
-		/// </summary>
-		public JqGridSearchOperators SearchOperators
-		{
-			get => SearchOptions.SearchOperators;
-			set => SearchOptions.SearchOperators = value;
-		}
+        /// <summary>
+        /// Gets or sets the available search operators for the column (default JqGridSearchOperators.Eq).
+        /// </summary>
+        public JqGridSearchOperators SearchOperators
+        {
+            get => SearchOptions.SearchOperators;
+            set => SearchOptions.SearchOperators = value;
+        }
 
-		private JqGridColumnSearchOptions SearchOptions
-		{
-			get => Options as JqGridColumnSearchOptions;
-			set => Options = value;
-		}
+        private JqGridColumnSearchOptions SearchOptions
+        {
+            get => Options as JqGridColumnSearchOptions;
+            set => Options = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the type of the search field (default JqGridColumnSearchTypes.Text).
-		/// </summary>
-		public JqGridColumnSearchTypes SearchType { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the type of the search field (default JqGridColumnSearchTypes.Text).
+        /// </summary>
+        public JqGridColumnSearchTypes SearchType { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnSearchableAttribute class.
-		/// </summary>
-		/// <param name="searchable">If this column can be searched</param>
-		public JqGridColumnSearchableAttribute(bool searchable = true)
-		{
-			Searchable = searchable;
-			SearchOptions = new JqGridColumnSearchOptions();
-			SearchType = JqGridColumnSearchTypes.Default;
-		}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnSearchableAttribute class.
+        /// </summary>
+        /// <param name="searchable">If this column can be searched</param>
+        public JqGridColumnSearchableAttribute(bool searchable = true)
+        {
+            Searchable = searchable;
+            SearchOptions = new JqGridColumnSearchOptions();
+            SearchType = JqGridColumnSearchTypes.Default;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
-		/// </summary>
-		/// <param name="dataUrlRouteName">Route name for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-		public JqGridColumnSearchableAttribute(string dataUrlRouteName)
-			: this()
-		{
-			if (string.IsNullOrWhiteSpace(dataUrlRouteName))
-				throw new ArgumentNullException(nameof(dataUrlRouteName));
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
+        /// </summary>
+        /// <param name="dataUrlRouteName">Route name for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+        public JqGridColumnSearchableAttribute(string dataUrlRouteName)
+            : this()
+        {
+            if (string.IsNullOrWhiteSpace(dataUrlRouteName))
+                throw new ArgumentNullException(nameof(dataUrlRouteName));
 
 
-			DataUrlRouteName = dataUrlRouteName;
-			DataUrlRouteData = new RouteValueDictionary();
-		}
+            DataUrlRouteName = dataUrlRouteName;
+            DataUrlRouteData = new RouteValueDictionary();
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
-		/// </summary>
-		/// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-		/// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-		public JqGridColumnSearchableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController) :
-			this(dataUrlAction, dataUrlController, null)
-		{ }
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
+        /// </summary>
+        /// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+        /// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+        public JqGridColumnSearchableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController) :
+            this(dataUrlAction, dataUrlController, null)
+        { }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
-		/// </summary>
-		/// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-		/// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-		/// <param name="dataUrlAreaName">Area for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
-		public JqGridColumnSearchableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController, [AspMvcArea] string dataUrlAreaName)
-			: this()
-		{
-			if (string.IsNullOrWhiteSpace(dataUrlAction))
-				throw new ArgumentNullException(nameof(dataUrlAction));
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
+        /// </summary>
+        /// <param name="dataUrlAction">Action for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+        /// <param name="dataUrlController">Controller for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+        /// <param name="dataUrlAreaName">Area for the URL to get the AJAX data for the select element (if is JqGridColumnSearchTypes.Select) or jQuery UI Autocomplete widget (if SearchType is JqGridColumnSearchTypes.Autocomplete).</param>
+        public JqGridColumnSearchableAttribute([AspMvcAction] string dataUrlAction, [AspMvcController] string dataUrlController, [AspMvcArea] string dataUrlAreaName)
+            : this()
+        {
+            if (string.IsNullOrWhiteSpace(dataUrlAction))
+                throw new ArgumentNullException(nameof(dataUrlAction));
 
-			if (string.IsNullOrWhiteSpace(dataUrlController))
-				throw new ArgumentNullException(nameof(dataUrlController));
+            if (string.IsNullOrWhiteSpace(dataUrlController))
+                throw new ArgumentNullException(nameof(dataUrlController));
 
-			DataUrlRouteData = new RouteValueDictionary();
-			DataUrlRouteData["controller"] = dataUrlController;
-			DataUrlRouteData["action"] = dataUrlAction;
+            DataUrlRouteData = new RouteValueDictionary();
+            DataUrlRouteData["controller"] = dataUrlController;
+            DataUrlRouteData["action"] = dataUrlAction;
 
-			if (dataUrlAreaName != null)
-				DataUrlRouteData["area"] = dataUrlAreaName;
-		}
+            if (dataUrlAreaName != null)
+                DataUrlRouteData["area"] = dataUrlAreaName;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
-		/// </summary>
-		/// <param name="valueProviderType">The type of class which contains a method which will provide data for select element (if is JqGridColumnSearchTypes.Select). This class must have public parameterless constructor.</param>
-		/// <param name="valueProviderMethodName">The name of method which will provide data for select element (if is JqGridColumnSearchTypes.Select). This method must return an object which implements IDictionary&lt;string, string&gt;.</param>
-		public JqGridColumnSearchableAttribute(Type valueProviderType, string valueProviderMethodName)
-			: this()
-		{
-			if (string.IsNullOrWhiteSpace(valueProviderMethodName))
-				throw new ArgumentNullException(nameof(valueProviderMethodName));
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnSearchableAttribute class and make column searchable force.
+        /// </summary>
+        /// <param name="valueProviderType">The type of class which contains a method which will provide data for select element (if is JqGridColumnSearchTypes.Select). This class must have public parameterless constructor.</param>
+        /// <param name="valueProviderMethodName">The name of method which will provide data for select element (if is JqGridColumnSearchTypes.Select). This method must return an object which implements IDictionary&lt;string, string&gt;.</param>
+        public JqGridColumnSearchableAttribute(Type valueProviderType, string valueProviderMethodName)
+            : this()
+        {
+            if (string.IsNullOrWhiteSpace(valueProviderMethodName))
+                throw new ArgumentNullException(nameof(valueProviderMethodName));
 
-			ValueProviderType = valueProviderType ?? throw new ArgumentNullException(nameof(valueProviderType));
-			ValueProviderMethodName = valueProviderMethodName;
-		}
-		#endregion
+            ValueProviderType = valueProviderType ?? throw new ArgumentNullException(nameof(valueProviderType));
+            ValueProviderMethodName = valueProviderMethodName;
+        }
+        #endregion
 
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		protected override void InternalOnMetadataCreated(ModelMetadata metadata)
-		{
-			SearchOptions.DataEvents = DataEvents;
-			if (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null)
-				SearchOptions.DataUrl = DataUrl;
-			SearchOptions.HtmlAttributes = HtmlAttributes;
-			SearchOptions.ValueDictionary = ValueDictionary;
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        protected override void InternalOnMetadataCreated(ModelMetadata metadata)
+        {
+            SearchOptions.DataEvents = DataEvents;
+            if (!string.IsNullOrWhiteSpace(DataUrlRouteName) || DataUrlRouteData != null)
+                SearchOptions.DataUrl = DataUrl;
+            SearchOptions.HtmlAttributes = HtmlAttributes;
+            SearchOptions.ValueDictionary = ValueDictionary;
 
-			if (SearchType == JqGridColumnSearchTypes.JQueryUIAutocomplete)
-			{
-				SearchType = JqGridColumnSearchTypes.Text;
-				SearchOptions.ConfigureJQueryUIAutocomplete();
-			}
-			else if (SearchType == JqGridColumnSearchTypes.JQueryUIDatepicker)
-			{
-				SearchType = JqGridColumnSearchTypes.Text;
-				SearchOptions.ConfigureJQueryUIDatepicker(metadata);
-			}
-			else if (SearchType == JqGridColumnSearchTypes.JQueryUISpinner)
-			{
-				SearchType = JqGridColumnSearchTypes.Text;
-				SearchOptions.ConfigureJQueryUISpinner();
-			}
+            if (SearchType == JqGridColumnSearchTypes.JQueryUIAutocomplete)
+            {
+                SearchType = JqGridColumnSearchTypes.Text;
+                SearchOptions.ConfigureJQueryUIAutocomplete();
+            }
+            else if (SearchType == JqGridColumnSearchTypes.JQueryUIDatepicker)
+            {
+                SearchType = JqGridColumnSearchTypes.Text;
+                SearchOptions.ConfigureJQueryUIDatepicker(metadata);
+            }
+            else if (SearchType == JqGridColumnSearchTypes.JQueryUISpinner)
+            {
+                SearchType = JqGridColumnSearchTypes.Text;
+                SearchOptions.ConfigureJQueryUISpinner();
+            }
 
-			metadata.SetColumnSearchable(Searchable);
-			metadata.SetColumnSearchOptions(SearchOptions);
-			metadata.SetColumnSearchRules(Rules);
-			metadata.SetColumnSearchType(SearchType);
-		}
-		#endregion
-	}
+            metadata.SetColumnSearchable(Searchable);
+            metadata.SetColumnSearchOptions(SearchOptions);
+            metadata.SetColumnSearchRules(Rules);
+            metadata.SetColumnSearchType(SearchType);
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSortableAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSortableAttribute.cs
@@ -3,89 +3,89 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <summary>
-	/// Specifies the sorting options for column
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property)]
-	public sealed class JqGridColumnSortableAttribute : Attribute, IMetadataAware
-	{
-		#region Fields
-		private string _sortFunction;
-		private string _index;
+    /// <summary>
+    /// Specifies the sorting options for column
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class JqGridColumnSortableAttribute : Attribute, IMetadataAware
+    {
+        #region Fields
+        private string _sortFunction;
+        private string _index;
 
-		#endregion
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets the value defining if this column can be sorted.
-		/// </summary>
-		public bool Sortable { get; }
+        #region Properties
+        /// <summary>
+        /// Gets the value defining if this column can be sorted.
+        /// </summary>
+        public bool Sortable { get; }
 
-		/// <summary>
-		/// Gets or sets the type of the column for appropriate sorting when datatype is local.
-		/// </summary>
-		public JqGridColumnSortTypes SortType { get; set; }
+        /// <summary>
+        /// Gets or sets the type of the column for appropriate sorting when datatype is local.
+        /// </summary>
+        public JqGridColumnSortTypes SortType { get; set; }
 
-		internal bool IsSortFunctionSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the custom sorting function when the SortType is set to JqGridColumnSortTypes.Function.
-		/// </summary>
-		public string SortFunction
-		{
-			get => _sortFunction;
-			set
-			{
-				_sortFunction = value;
-				IsSortFunctionSetted = true;
-			}
-		}
+        internal bool IsSortFunctionSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the custom sorting function when the SortType is set to JqGridColumnSortTypes.Function.
+        /// </summary>
+        public string SortFunction
+        {
+            get => _sortFunction;
+            set
+            {
+                _sortFunction = value;
+                IsSortFunctionSetted = true;
+            }
+        }
 
-		internal bool IsIndexSetted { get; set; }
-		/// <summary>
-		/// Gets or sets the index name for sorting and searching.
-		/// </summary>
-		public string Index
-		{
-			get => _index;
-			set
-			{
-				_index = value;
-				IsIndexSetted = true;
-			}
-		}
+        internal bool IsIndexSetted { get; set; }
+        /// <summary>
+        /// Gets or sets the index name for sorting and searching.
+        /// </summary>
+        public string Index
+        {
+            get => _index;
+            set
+            {
+                _index = value;
+                IsIndexSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the sorting order for first column sorting (default JqGridSortingOrders.Asc).
-		/// </summary>
-		public JqGridSortingOrders InitialSortingOrder { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the sorting order for first column sorting (default JqGridSortingOrders.Asc).
+        /// </summary>
+        public JqGridSortingOrders InitialSortingOrder { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnSortingNameAttribute class.
-		/// </summary>
-		/// <param name="sortable">If this column can be sorted</param>
-		public JqGridColumnSortableAttribute(bool sortable = true)
-		{
-			Sortable = sortable;
-			SortType = JqGridColumnSortTypes.Default;
-			InitialSortingOrder = JqGridSortingOrders.Default;
-		}
-		#endregion
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnSortingNameAttribute class.
+        /// </summary>
+        /// <param name="sortable">If this column can be sorted</param>
+        public JqGridColumnSortableAttribute(bool sortable = true)
+        {
+            Sortable = sortable;
+            SortType = JqGridColumnSortTypes.Default;
+            InitialSortingOrder = JqGridSortingOrders.Default;
+        }
+        #endregion
 
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		public void OnMetadataCreated(ModelMetadata metadata)
-		{
-			metadata.SetColumnIndex(new SettedString(IsIndexSetted, Index));
-			metadata.SetColumnInitialSortingOrder(InitialSortingOrder);
-			metadata.SetColumnSortable(Sortable);
-			metadata.SetColumnSortType(SortType);
-			metadata.SetColumnSortFunction(new SettedString(IsSortFunctionSetted, SortFunction));
-		}
-		#endregion
-	}
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        public void OnMetadataCreated(ModelMetadata metadata)
+        {
+            metadata.SetColumnIndex(new SettedString(IsIndexSetted, Index));
+            metadata.SetColumnInitialSortingOrder(InitialSortingOrder);
+            metadata.SetColumnSortable(Sortable);
+            metadata.SetColumnSortType(SortType);
+            metadata.SetColumnSortFunction(new SettedString(IsSortFunctionSetted, SortFunction));
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSortableAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSortableAttribute.cs
@@ -1,71 +1,91 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Specifies the sorting options for column
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class JqGridColumnSortableAttribute : Attribute, IMetadataAware
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the value defining if this column can be sorted.
-        /// </summary>
-        public bool Sortable { get; private set; }
+	/// <summary>
+	/// Specifies the sorting options for column
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	public sealed class JqGridColumnSortableAttribute : Attribute, IMetadataAware
+	{
+		#region Fields
+		private string _sortFunction;
+		private string _index;
 
-        /// <summary>
-        /// Gets or sets the type of the column for appropriate sorting when datatype is local.
-        /// </summary>
-        public JqGridColumnSortTypes SortType { get; set; }
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the custom sorting function when the SortType is set to JqGridColumnSortTypes.Function.
-        /// </summary>
-        public string SortFunction { get; set; }
+		#region Properties
+		/// <summary>
+		/// Gets the value defining if this column can be sorted.
+		/// </summary>
+		public bool Sortable { get; }
 
-        /// <summary>
-        /// Gets or sets the index name for sorting and searching.
-        /// </summary>
-        public string Index { get; set; }
+		/// <summary>
+		/// Gets or sets the type of the column for appropriate sorting when datatype is local.
+		/// </summary>
+		public JqGridColumnSortTypes SortType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the sorting order for first column sorting (default JqGridSortingOrders.Asc).
-        /// </summary>
-        public JqGridSortingOrders InitialSortingOrder { get; set; }
-        #endregion
+		internal bool IsSortFunctionSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the custom sorting function when the SortType is set to JqGridColumnSortTypes.Function.
+		/// </summary>
+		public string SortFunction
+		{
+			get => _sortFunction;
+			set
+			{
+				_sortFunction = value;
+				IsSortFunctionSetted = true;
+			}
+		}
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnSortingNameAttribute class.
-        /// </summary>
-        /// <param name="sortable">If this column can be sorted</param>
-        public JqGridColumnSortableAttribute(bool sortable)
-        {
-            Sortable = sortable;
-            SortType = JqGridColumnSortTypes.Text;
-            SortFunction = String.Empty;
-            InitialSortingOrder = JqGridSortingOrders.Asc;
-        }
-        #endregion
+		internal bool IsIndexSetted { get; set; }
+		/// <summary>
+		/// Gets or sets the index name for sorting and searching.
+		/// </summary>
+		public string Index
+		{
+			get => _index;
+			set
+			{
+				_index = value;
+				IsIndexSetted = true;
+			}
+		}
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        public void OnMetadataCreated(ModelMetadata metadata)
-        {
-            metadata.SetColumnIndex(Index);
-            metadata.SetColumnInitialSortingOrder(InitialSortingOrder);
-            metadata.SetColumnSortable(Sortable);
-            metadata.SetColumnSortType(SortType);
-            metadata.SetColumnSortFunction(SortFunction);
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Gets or sets the sorting order for first column sorting (default JqGridSortingOrders.Asc).
+		/// </summary>
+		public JqGridSortingOrders InitialSortingOrder { get; set; }
+		#endregion
+
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnSortingNameAttribute class.
+		/// </summary>
+		/// <param name="sortable">If this column can be sorted</param>
+		public JqGridColumnSortableAttribute(bool sortable = true)
+		{
+			Sortable = sortable;
+			SortType = JqGridColumnSortTypes.Default;
+			InitialSortingOrder = JqGridSortingOrders.Default;
+		}
+		#endregion
+
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		public void OnMetadataCreated(ModelMetadata metadata)
+		{
+			metadata.SetColumnIndex(new SettedString(IsIndexSetted, Index));
+			metadata.SetColumnInitialSortingOrder(InitialSortingOrder);
+			metadata.SetColumnSortable(Sortable);
+			metadata.SetColumnSortType(SortType);
+			metadata.SetColumnSortFunction(new SettedString(IsSortFunctionSetted, SortFunction));
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSummaryAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSummaryAttribute.cs
@@ -1,57 +1,68 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    /// <summary>
-    /// Specifies the grouping summary for column.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class JqGridColumnSummaryAttribute: Attribute, IMetadataAware
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the grouping summary type.
-        /// </summary>
-        public JqGridColumnSummaryTypes Type { get; private set; }
+	/// <summary>
+	/// Specifies the grouping summary for column.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property)]
+	public sealed class JqGridColumnSummaryAttribute : Attribute, IMetadataAware
+	{
+		#region Fields
+		private string _template;
 
-        /// <summary>
-        /// Gets or sets the grouping summary template.
-        /// </summary>
-        public string Template { get; set; }
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the grouping summary function for custom type.
-        /// </summary>
-        public string Function { get; set; }
-        #endregion
+		#region Properties
+		/// <summary>
+		/// Gets the grouping summary type.
+		/// </summary>
+		public JqGridColumnSummaryTypes Type { get; private set; }
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnGroupingSummaryAttribute class.
-        /// </summary>
-        /// <param name="type">Type of summary</param>
-        public JqGridColumnSummaryAttribute(JqGridColumnSummaryTypes type)
-        {
-            this.Type = type;
-            this.Template = "{0}";
-        }
-        #endregion
+		internal bool IsTemplateSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the grouping summary template.
+		/// </summary>
+		public string Template
+		{
+			get => _template;
+			set
+			{
+				_template = value;
+				IsTemplateSetted = true;
+			}
+		}
 
-        #region IMetadataAware
-        /// <summary>
-        /// Provides metadata to the model metadata creation process.
-        /// </summary>
-        /// <param name="metadata">The model metadata.</param>
-        public void OnMetadataCreated(ModelMetadata metadata)
-        {
-            metadata.SetColumnSummaryType(this.Type);
-            metadata.SetColumnSummaryTemplate(this.Template);
-            metadata.SetColumnSummaryFunction(this.Function);
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Gets or sets the grouping summary function for custom type.
+		/// </summary>
+		public string Function { get; set; }
+
+		#endregion
+
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnGroupingSummaryAttribute class.
+		/// </summary>
+		/// <param name="type">Type of summary</param>
+		public JqGridColumnSummaryAttribute(JqGridColumnSummaryTypes type)
+		{
+			Type = type;
+		}
+		#endregion
+
+		#region IMetadataAware
+		/// <summary>
+		/// Provides metadata to the model metadata creation process.
+		/// </summary>
+		/// <param name="metadata">The model metadata.</param>
+		public void OnMetadataCreated(ModelMetadata metadata)
+		{
+			metadata.SetColumnSummaryType(Type);
+			metadata.SetColumnSummaryTemplate(new SettedString(IsTemplateSetted, Template));
+			metadata.SetColumnSummaryFunction(Function);
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSummaryAttribute.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridColumnSummaryAttribute.cs
@@ -3,66 +3,66 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	/// <summary>
-	/// Specifies the grouping summary for column.
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property)]
-	public sealed class JqGridColumnSummaryAttribute : Attribute, IMetadataAware
-	{
-		#region Fields
-		private string _template;
+    /// <summary>
+    /// Specifies the grouping summary for column.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class JqGridColumnSummaryAttribute : Attribute, IMetadataAware
+    {
+        #region Fields
+        private string _template;
 
-		#endregion
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets the grouping summary type.
-		/// </summary>
-		public JqGridColumnSummaryTypes Type { get; private set; }
+        #region Properties
+        /// <summary>
+        /// Gets the grouping summary type.
+        /// </summary>
+        public JqGridColumnSummaryTypes Type { get; private set; }
 
-		internal bool IsTemplateSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the grouping summary template.
-		/// </summary>
-		public string Template
-		{
-			get => _template;
-			set
-			{
-				_template = value;
-				IsTemplateSetted = true;
-			}
-		}
+        internal bool IsTemplateSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the grouping summary template.
+        /// </summary>
+        public string Template
+        {
+            get => _template;
+            set
+            {
+                _template = value;
+                IsTemplateSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the grouping summary function for custom type.
-		/// </summary>
-		public string Function { get; set; }
+        /// <summary>
+        /// Gets or sets the grouping summary function for custom type.
+        /// </summary>
+        public string Function { get; set; }
 
-		#endregion
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnGroupingSummaryAttribute class.
-		/// </summary>
-		/// <param name="type">Type of summary</param>
-		public JqGridColumnSummaryAttribute(JqGridColumnSummaryTypes type)
-		{
-			Type = type;
-		}
-		#endregion
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnGroupingSummaryAttribute class.
+        /// </summary>
+        /// <param name="type">Type of summary</param>
+        public JqGridColumnSummaryAttribute(JqGridColumnSummaryTypes type)
+        {
+            Type = type;
+        }
+        #endregion
 
-		#region IMetadataAware
-		/// <summary>
-		/// Provides metadata to the model metadata creation process.
-		/// </summary>
-		/// <param name="metadata">The model metadata.</param>
-		public void OnMetadataCreated(ModelMetadata metadata)
-		{
-			metadata.SetColumnSummaryType(Type);
-			metadata.SetColumnSummaryTemplate(new SettedString(IsTemplateSetted, Template));
-			metadata.SetColumnSummaryFunction(Function);
-		}
-		#endregion
-	}
+        #region IMetadataAware
+        /// <summary>
+        /// Provides metadata to the model metadata creation process.
+        /// </summary>
+        /// <param name="metadata">The model metadata.</param>
+        public void OnMetadataCreated(ModelMetadata metadata)
+        {
+            metadata.SetColumnSummaryType(Type);
+            metadata.SetColumnSummaryTemplate(new SettedString(IsTemplateSetted, Template));
+            metadata.SetColumnSummaryFunction(Function);
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridModelMetadataExtensions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridModelMetadataExtensions.cs
@@ -3,466 +3,466 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-	internal static class JqGridModelMetadataExtensions
-	{
-		#region Fields
-		private const string _alignmentKey = "JqGridColumnModel.Alignment";
-		private const string _cellAttributesKey = "JqGridColumnModel.CellAttributes";
-		private const string _classesKey = "JqGridColumnModel.Classes";
-		private const string _dateFormatKey = "JqGridColumnModel.DateFormat";
-		private const string _fixedKey = "JqGridColumnModel.Fixed";
-		private const string _frozenKey = "JqGridColumnModel.Frozen";
-		private const string _hideInDialogKey = "JqGridColumnModel.HideInDialog";
-		private const string _resizableKey = "JqGridColumnModel.Resizable";
-		private const string _titleKey = "JqGridColumnModel.Title";
-		private const string _widthKey = "JqGridColumnModel.Width";
-		private const string _viewableKey = "JqGridColumnModel.Viewable";
-		private const string _editableKey = "JqGridColumnModel.Editable";
-		private const string _editOptionsKey = "JqGridColumnModel.EditOptions";
-		private const string _editRulesKey = "JqGridColumnModel.EditRules";
-		private const string _formOptionsKey = "JqGridColumnModel.FormOptions";
-		private const string _editTypeKey = "JqGridColumnModel.EditType";
-		private const string _formatterKey = "JqGridColumnModel.Formatter";
-		private const string _formatterOptionsKey = "JqGridColumnModel.FormatterOptions";
-		private const string _unFormatterKey = "JqGridColumnModel.UnFormatter";
-		private const string _labelOptionsKey = "JqGridColumnModel.LabelOptions";
-		private const string _searchableKey = "JqGridColumnModel.Searchable";
-		private const string _searchOptionsKey = "JqGridColumnModel.SearchOptions";
-		private const string _searchRulesKey = "JqGridColumnModel.SearchRules";
-		private const string _searchTypeKey = "JqGridColumnModel.SearchType";
-		private const string _sortableKey = "JqGridColumnModel.Sortable";
-		private const string _sortTypeKey = "JqGridColumnModel.SortType";
-		private const string _sortFunctionKey = "JqGridColumnModel.SortFunction";
-		private const string _indexKey = "JqGridColumnModel.Index";
-		private const string _initialSortingOrderKey = "JqGridColumnModel.InitialSortingOrder";
-		private const string _summaryTypeKey = "JqGridColumnModel.SummaryType";
-		private const string _summaryTemplateKey = "JqGridColumnModel.SummaryTemplate";
-		private const string _summaryFunctionKey = "JqGridColumnModel.SummaryFunction";
-		private const string _jsonMappingKey = "JqGridColumnModel.JsonMapping";
-		private const string _keyKey = "JqGridColumnModel.Key";
-		private const string _xmlMappingKey = "JqGridColumnModel.XmlMapping";
-		#endregion
-
-		#region Methods
-		internal static void SetColumnAlignment(this ModelMetadata metadata, JqGridAlignments alignment)
-		{
-			metadata.AdditionalValues.Add(_alignmentKey, alignment);
-		}
-
-		internal static JqGridAlignments GetColumnAlignment(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_alignmentKey))
-				return (JqGridAlignments)metadata.AdditionalValues[_alignmentKey];
-			return JqGridAlignments.Default;
-		}
-
-		internal static void SetColumnCellAttributes(this ModelMetadata metadata, SettedString cellAttributes)
-		{
-			metadata.AdditionalValues.Add(_cellAttributesKey, cellAttributes);
-		}
-
-		internal static SettedString GetColumnCellAttributes(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_cellAttributesKey))
-				return (SettedString)metadata.AdditionalValues[_cellAttributesKey];
-			return null;
-		}
-
-		internal static void SetColumnClasses(this ModelMetadata metadata, SettedString classes)
-		{
-			metadata.AdditionalValues.Add(_classesKey, classes);
-		}
-
-		internal static SettedString GetColumnClasses(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_classesKey))
-				return (SettedString)metadata.AdditionalValues[_classesKey];
-			return null;
-		}
-
-		internal static void SetColumnDateFormat(this ModelMetadata metadata, SettedString dateFormat)
-		{
-			metadata.AdditionalValues.Add(_dateFormatKey, dateFormat);
-		}
-
-		internal static SettedString GetColumnDateFormat(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_dateFormatKey))
-				return (SettedString)metadata.AdditionalValues[_dateFormatKey];
-			return null;
-		}
-
-		internal static void SetColumnFixed(this ModelMetadata metadata, bool? @fixed)
-		{
-			metadata.AdditionalValues.Add(_fixedKey, @fixed);
-		}
-
-		internal static bool? GetColumnFixed(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_fixedKey))
-				return (bool?)metadata.AdditionalValues[_fixedKey];
-			return null;
-		}
-
-		internal static void SetColumnFrozen(this ModelMetadata metadata, bool? frozen)
-		{
-			metadata.AdditionalValues.Add(_frozenKey, frozen);
-		}
-
-		internal static bool? GetColumnFrozen(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_frozenKey))
-				return (bool?)metadata.AdditionalValues[_frozenKey];
-			return null;
-		}
-
-		internal static void SetColumnHideInDialog(this ModelMetadata metadata, bool? hideInDialog)
-		{
-			metadata.AdditionalValues.Add(_hideInDialogKey, hideInDialog);
-		}
-
-		internal static bool? GetColumnHideInDialog(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_hideInDialogKey))
-				return (bool?)metadata.AdditionalValues[_hideInDialogKey];
-			return null;
-		}
-
-		internal static void SetColumnResizable(this ModelMetadata metadata, bool? resizable)
-		{
-			metadata.AdditionalValues.Add(_resizableKey, resizable);
-		}
-
-		internal static bool? GetColumnResizable(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_resizableKey))
-				return (bool?)metadata.AdditionalValues[_resizableKey];
-			return null;
-		}
-
-		internal static void SetColumnTitle(this ModelMetadata metadata, bool? title)
-		{
-			metadata.AdditionalValues.Add(_titleKey, title);
-		}
-
-		internal static bool? GetColumnTitle(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_titleKey))
-				return (bool?)metadata.AdditionalValues[_titleKey];
-			return null;
-		}
-
-		internal static void SetColumnWidth(this ModelMetadata metadata, int? width)
-		{
-			metadata.AdditionalValues.Add(_widthKey, width);
-		}
-
-		internal static int? GetColumnWidth(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_widthKey))
-				return (int?)metadata.AdditionalValues[_widthKey];
-			return null;
-		}
-
-		internal static void SetColumnViewable(this ModelMetadata metadata, bool? viewable)
-		{
-			metadata.AdditionalValues.Add(_viewableKey, viewable);
-		}
-
-		internal static bool? GetColumnViewable(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_viewableKey))
-				return (bool?)metadata.AdditionalValues[_viewableKey];
-			return null;
-		}
-
-		internal static void SetColumnLabelOptions(this ModelMetadata metadata, JqGridColumnLabelOptions labelOptions)
-		{
-			metadata.AdditionalValues.Add(_labelOptionsKey, labelOptions);
-		}
-
-		internal static void SetColumnEditable(this ModelMetadata metadata, bool? editable)
-		{
-			metadata.AdditionalValues.Add(_editableKey, editable);
-		}
-
-		internal static bool? GetColumnEditable(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_editableKey))
-				return (bool?)metadata.AdditionalValues[_editableKey];
-			return null;
-		}
-
-		internal static void SetColumnEditOptions(this ModelMetadata metadata, JqGridColumnEditOptions editOptions)
-		{
-			metadata.AdditionalValues.Add(_editOptionsKey, editOptions);
-		}
-
-		internal static JqGridColumnEditOptions GetColumnEditOptions(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_editOptionsKey))
-				return (JqGridColumnEditOptions)metadata.AdditionalValues[_editOptionsKey];
-			return null;
-		}
-
-		internal static void SetColumnEditRules(this ModelMetadata metadata, JqGridColumnRules editRules)
-		{
-			metadata.AdditionalValues.Add(_editRulesKey, editRules);
-		}
-
-		internal static JqGridColumnRules GetColumnEditRules(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_editRulesKey))
-				return (JqGridColumnRules)metadata.AdditionalValues[_editRulesKey];
-			return null;
-		}
-
-		internal static void SetColumnEditType(this ModelMetadata metadata, JqGridColumnEditTypes editType)
-		{
-			metadata.AdditionalValues.Add(_editTypeKey, editType);
-		}
-
-		internal static JqGridColumnEditTypes GetColumnEditType(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_editTypeKey))
-				return (JqGridColumnEditTypes)metadata.AdditionalValues[_editTypeKey];
-			return JqGridColumnEditTypes.Default;
-		}
-
-		internal static void SetColumnFormOptions(this ModelMetadata metadata, JqGridColumnFormOptions formOptions)
-		{
-			metadata.AdditionalValues.Add(_formOptionsKey, formOptions);
-		}
-
-		internal static JqGridColumnFormOptions GetColumnFormOptions(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_formOptionsKey))
-				return (JqGridColumnFormOptions)metadata.AdditionalValues[_formOptionsKey];
-			return null;
-		}
-
-		internal static void SetColumnFormatter(this ModelMetadata metadata, SettedString formatter)
-		{
-			metadata.AdditionalValues.Add(_formatterKey, formatter);
-		}
-
-		internal static SettedString GetColumnFormatter(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_formatterKey))
-				return (SettedString)metadata.AdditionalValues[_formatterKey];
-			return null;
-		}
-
-		internal static void SetColumnFormatterOptions(this ModelMetadata metadata, JqGridColumnFormatterOptions formatterOptions)
-		{
-			metadata.AdditionalValues.Add(_formatterOptionsKey, formatterOptions);
-		}
-
-		internal static JqGridColumnFormatterOptions GetColumnFormatterOptions(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_formatterOptionsKey))
-				return (JqGridColumnFormatterOptions)metadata.AdditionalValues[_formatterOptionsKey];
-			return null;
-		}
-
-		internal static void SetColumnUnFormatter(this ModelMetadata metadata, SettedString unFormatter)
-		{
-			metadata.AdditionalValues.Add(_unFormatterKey, unFormatter);
-		}
-
-		internal static SettedString GetColumnUnFormatter(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_unFormatterKey))
-				return (SettedString)metadata.AdditionalValues[_unFormatterKey];
-			return null;
-		}
-
-		internal static JqGridColumnLabelOptions GetColumnLabelOptions(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_labelOptionsKey))
-				return (JqGridColumnLabelOptions)metadata.AdditionalValues[_labelOptionsKey];
-			return null;
-		}
-
-		internal static void SetColumnSearchable(this ModelMetadata metadata, bool? searchable)
-		{
-			metadata.AdditionalValues.Add(_searchableKey, searchable);
-		}
-
-		internal static bool? GetColumnSearchable(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_searchableKey))
-				return (bool?)metadata.AdditionalValues[_searchableKey];
-			return null;
-		}
-
-		internal static void SetColumnSearchOptions(this ModelMetadata metadata, JqGridColumnSearchOptions searchOptions)
-		{
-			metadata.AdditionalValues.Add(_searchOptionsKey, searchOptions);
-		}
-
-		internal static JqGridColumnSearchOptions GetColumnSearchOptions(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_searchOptionsKey))
-				return (JqGridColumnSearchOptions)metadata.AdditionalValues[_searchOptionsKey];
-			return null;
-		}
-
-		internal static void SetColumnSearchRules(this ModelMetadata metadata, JqGridColumnRules searchRules)
-		{
-			metadata.AdditionalValues.Add(_searchRulesKey, searchRules);
-		}
-
-		internal static JqGridColumnRules GetColumnSearchRules(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_searchRulesKey))
-				return (JqGridColumnRules)metadata.AdditionalValues[_searchRulesKey];
-			return null;
-		}
-
-		internal static void SetColumnSearchType(this ModelMetadata metadata, JqGridColumnSearchTypes searchType)
-		{
-			metadata.AdditionalValues.Add(_searchTypeKey, searchType);
-		}
-
-		internal static JqGridColumnSearchTypes GetColumnSearchType(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_searchTypeKey))
-				return (JqGridColumnSearchTypes)metadata.AdditionalValues[_searchTypeKey];
-			return JqGridColumnSearchTypes.Default;
-		}
-
-		internal static void SetColumnSortable(this ModelMetadata metadata, bool? sortable)
-		{
-			metadata.AdditionalValues.Add(_sortableKey, sortable);
-		}
-
-		internal static bool? GetColumnSortable(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_sortableKey))
-				return (bool?)metadata.AdditionalValues[_sortableKey];
-			return null;
-		}
-
-		internal static void SetColumnSortType(this ModelMetadata metadata, JqGridColumnSortTypes sortType)
-		{
-			metadata.AdditionalValues.Add(_sortTypeKey, sortType);
-		}
-
-		internal static JqGridColumnSortTypes GetColumnSortType(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_sortTypeKey))
-				return (JqGridColumnSortTypes)metadata.AdditionalValues[_sortTypeKey];
-			return JqGridColumnSortTypes.Default;
-		}
-
-		internal static void SetColumnSortFunction(this ModelMetadata metadata, SettedString sortFunction)
-		{
-			metadata.AdditionalValues.Add(_sortFunctionKey, sortFunction);
-		}
-
-		internal static SettedString GetColumnSortFunction(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_sortFunctionKey))
-				return (SettedString)metadata.AdditionalValues[_sortFunctionKey];
-			return null;
-		}
-
-		internal static void SetColumnIndex(this ModelMetadata metadata, SettedString index)
-		{
-			metadata.AdditionalValues.Add(_indexKey, index);
-		}
-
-		internal static SettedString GetColumnIndex(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_indexKey))
-				return (SettedString)metadata.AdditionalValues[_indexKey];
-			return null;
-		}
-
-		internal static void SetColumnInitialSortingOrder(this ModelMetadata metadata, JqGridSortingOrders initialSortingOrder)
-		{
-			metadata.AdditionalValues.Add(_initialSortingOrderKey, initialSortingOrder);
-		}
-
-		internal static JqGridSortingOrders GetColumnInitialSortingOrder(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_initialSortingOrderKey))
-				return (JqGridSortingOrders)metadata.AdditionalValues[_initialSortingOrderKey];
-			return JqGridSortingOrders.Default;
-		}
-
-		internal static void SetColumnSummaryType(this ModelMetadata metadata, JqGridColumnSummaryTypes type)
-		{
-			metadata.AdditionalValues.Add(_summaryTypeKey, type);
-		}
-
-		internal static JqGridColumnSummaryTypes? GetColumnSummaryType(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_summaryTypeKey))
-				return (JqGridColumnSummaryTypes)metadata.AdditionalValues[_summaryTypeKey];
-			return null;
-		}
-
-		internal static void SetColumnSummaryTemplate(this ModelMetadata metadata, SettedString template)
-		{
-			metadata.AdditionalValues.Add(_summaryTemplateKey, template);
-		}
-
-		internal static SettedString GetColumnSummaryTemplate(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_summaryTemplateKey))
-				return (SettedString)metadata.AdditionalValues[_summaryTemplateKey];
-			return null;
-		}
-
-		internal static void SetColumnSummaryFunction(this ModelMetadata metadata, string function)
-		{
-			metadata.AdditionalValues.Add(_summaryFunctionKey, function);
-		}
-
-		internal static string GetColumnSummaryFunction(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_summaryFunctionKey))
-				return (string)metadata.AdditionalValues[_summaryFunctionKey];
-			return null;
-		}
-
-		internal static void SetColumnJsonMapping(this ModelMetadata metadata, string jsonMapping)
-		{
-			metadata.AdditionalValues.Add(_jsonMappingKey, jsonMapping);
-		}
-
-		internal static string GetColumnJsonMapping(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_jsonMappingKey))
-				return (string)metadata.AdditionalValues[_jsonMappingKey];
-			return null;
-		}
-
-		internal static void SetColumnKey(this ModelMetadata metadata, bool? key)
-		{
-			metadata.AdditionalValues.Add(_keyKey, key);
-		}
-
-		internal static bool? GetColumnKey(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_keyKey))
-				return (bool?)metadata.AdditionalValues[_keyKey];
-			return null;
-		}
-
-		internal static void SetColumnXmlMapping(this ModelMetadata metadata, string xmlMapping)
-		{
-			metadata.AdditionalValues.Add(_xmlMappingKey, xmlMapping);
-		}
-
-		internal static string GetColumnXmlMapping(this ModelMetadata metadata)
-		{
-			if (metadata.AdditionalValues.ContainsKey(_xmlMappingKey))
-				return (string)metadata.AdditionalValues[_xmlMappingKey];
-			return String.Empty;
-		}
-		#endregion
-	}
+    internal static class JqGridModelMetadataExtensions
+    {
+        #region Fields
+        private const string _alignmentKey = "JqGridColumnModel.Alignment";
+        private const string _cellAttributesKey = "JqGridColumnModel.CellAttributes";
+        private const string _classesKey = "JqGridColumnModel.Classes";
+        private const string _dateFormatKey = "JqGridColumnModel.DateFormat";
+        private const string _fixedKey = "JqGridColumnModel.Fixed";
+        private const string _frozenKey = "JqGridColumnModel.Frozen";
+        private const string _hideInDialogKey = "JqGridColumnModel.HideInDialog";
+        private const string _resizableKey = "JqGridColumnModel.Resizable";
+        private const string _titleKey = "JqGridColumnModel.Title";
+        private const string _widthKey = "JqGridColumnModel.Width";
+        private const string _viewableKey = "JqGridColumnModel.Viewable";
+        private const string _editableKey = "JqGridColumnModel.Editable";
+        private const string _editOptionsKey = "JqGridColumnModel.EditOptions";
+        private const string _editRulesKey = "JqGridColumnModel.EditRules";
+        private const string _formOptionsKey = "JqGridColumnModel.FormOptions";
+        private const string _editTypeKey = "JqGridColumnModel.EditType";
+        private const string _formatterKey = "JqGridColumnModel.Formatter";
+        private const string _formatterOptionsKey = "JqGridColumnModel.FormatterOptions";
+        private const string _unFormatterKey = "JqGridColumnModel.UnFormatter";
+        private const string _labelOptionsKey = "JqGridColumnModel.LabelOptions";
+        private const string _searchableKey = "JqGridColumnModel.Searchable";
+        private const string _searchOptionsKey = "JqGridColumnModel.SearchOptions";
+        private const string _searchRulesKey = "JqGridColumnModel.SearchRules";
+        private const string _searchTypeKey = "JqGridColumnModel.SearchType";
+        private const string _sortableKey = "JqGridColumnModel.Sortable";
+        private const string _sortTypeKey = "JqGridColumnModel.SortType";
+        private const string _sortFunctionKey = "JqGridColumnModel.SortFunction";
+        private const string _indexKey = "JqGridColumnModel.Index";
+        private const string _initialSortingOrderKey = "JqGridColumnModel.InitialSortingOrder";
+        private const string _summaryTypeKey = "JqGridColumnModel.SummaryType";
+        private const string _summaryTemplateKey = "JqGridColumnModel.SummaryTemplate";
+        private const string _summaryFunctionKey = "JqGridColumnModel.SummaryFunction";
+        private const string _jsonMappingKey = "JqGridColumnModel.JsonMapping";
+        private const string _keyKey = "JqGridColumnModel.Key";
+        private const string _xmlMappingKey = "JqGridColumnModel.XmlMapping";
+        #endregion
+
+        #region Methods
+        internal static void SetColumnAlignment(this ModelMetadata metadata, JqGridAlignments alignment)
+        {
+            metadata.AdditionalValues.Add(_alignmentKey, alignment);
+        }
+
+        internal static JqGridAlignments GetColumnAlignment(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_alignmentKey))
+                return (JqGridAlignments)metadata.AdditionalValues[_alignmentKey];
+            return JqGridAlignments.Default;
+        }
+
+        internal static void SetColumnCellAttributes(this ModelMetadata metadata, SettedString cellAttributes)
+        {
+            metadata.AdditionalValues.Add(_cellAttributesKey, cellAttributes);
+        }
+
+        internal static SettedString GetColumnCellAttributes(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_cellAttributesKey))
+                return (SettedString)metadata.AdditionalValues[_cellAttributesKey];
+            return null;
+        }
+
+        internal static void SetColumnClasses(this ModelMetadata metadata, SettedString classes)
+        {
+            metadata.AdditionalValues.Add(_classesKey, classes);
+        }
+
+        internal static SettedString GetColumnClasses(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_classesKey))
+                return (SettedString)metadata.AdditionalValues[_classesKey];
+            return null;
+        }
+
+        internal static void SetColumnDateFormat(this ModelMetadata metadata, SettedString dateFormat)
+        {
+            metadata.AdditionalValues.Add(_dateFormatKey, dateFormat);
+        }
+
+        internal static SettedString GetColumnDateFormat(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_dateFormatKey))
+                return (SettedString)metadata.AdditionalValues[_dateFormatKey];
+            return null;
+        }
+
+        internal static void SetColumnFixed(this ModelMetadata metadata, bool? @fixed)
+        {
+            metadata.AdditionalValues.Add(_fixedKey, @fixed);
+        }
+
+        internal static bool? GetColumnFixed(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_fixedKey))
+                return (bool?)metadata.AdditionalValues[_fixedKey];
+            return null;
+        }
+
+        internal static void SetColumnFrozen(this ModelMetadata metadata, bool? frozen)
+        {
+            metadata.AdditionalValues.Add(_frozenKey, frozen);
+        }
+
+        internal static bool? GetColumnFrozen(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_frozenKey))
+                return (bool?)metadata.AdditionalValues[_frozenKey];
+            return null;
+        }
+
+        internal static void SetColumnHideInDialog(this ModelMetadata metadata, bool? hideInDialog)
+        {
+            metadata.AdditionalValues.Add(_hideInDialogKey, hideInDialog);
+        }
+
+        internal static bool? GetColumnHideInDialog(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_hideInDialogKey))
+                return (bool?)metadata.AdditionalValues[_hideInDialogKey];
+            return null;
+        }
+
+        internal static void SetColumnResizable(this ModelMetadata metadata, bool? resizable)
+        {
+            metadata.AdditionalValues.Add(_resizableKey, resizable);
+        }
+
+        internal static bool? GetColumnResizable(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_resizableKey))
+                return (bool?)metadata.AdditionalValues[_resizableKey];
+            return null;
+        }
+
+        internal static void SetColumnTitle(this ModelMetadata metadata, bool? title)
+        {
+            metadata.AdditionalValues.Add(_titleKey, title);
+        }
+
+        internal static bool? GetColumnTitle(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_titleKey))
+                return (bool?)metadata.AdditionalValues[_titleKey];
+            return null;
+        }
+
+        internal static void SetColumnWidth(this ModelMetadata metadata, int? width)
+        {
+            metadata.AdditionalValues.Add(_widthKey, width);
+        }
+
+        internal static int? GetColumnWidth(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_widthKey))
+                return (int?)metadata.AdditionalValues[_widthKey];
+            return null;
+        }
+
+        internal static void SetColumnViewable(this ModelMetadata metadata, bool? viewable)
+        {
+            metadata.AdditionalValues.Add(_viewableKey, viewable);
+        }
+
+        internal static bool? GetColumnViewable(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_viewableKey))
+                return (bool?)metadata.AdditionalValues[_viewableKey];
+            return null;
+        }
+
+        internal static void SetColumnLabelOptions(this ModelMetadata metadata, JqGridColumnLabelOptions labelOptions)
+        {
+            metadata.AdditionalValues.Add(_labelOptionsKey, labelOptions);
+        }
+
+        internal static void SetColumnEditable(this ModelMetadata metadata, bool? editable)
+        {
+            metadata.AdditionalValues.Add(_editableKey, editable);
+        }
+
+        internal static bool? GetColumnEditable(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_editableKey))
+                return (bool?)metadata.AdditionalValues[_editableKey];
+            return null;
+        }
+
+        internal static void SetColumnEditOptions(this ModelMetadata metadata, JqGridColumnEditOptions editOptions)
+        {
+            metadata.AdditionalValues.Add(_editOptionsKey, editOptions);
+        }
+
+        internal static JqGridColumnEditOptions GetColumnEditOptions(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_editOptionsKey))
+                return (JqGridColumnEditOptions)metadata.AdditionalValues[_editOptionsKey];
+            return null;
+        }
+
+        internal static void SetColumnEditRules(this ModelMetadata metadata, JqGridColumnRules editRules)
+        {
+            metadata.AdditionalValues.Add(_editRulesKey, editRules);
+        }
+
+        internal static JqGridColumnRules GetColumnEditRules(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_editRulesKey))
+                return (JqGridColumnRules)metadata.AdditionalValues[_editRulesKey];
+            return null;
+        }
+
+        internal static void SetColumnEditType(this ModelMetadata metadata, JqGridColumnEditTypes editType)
+        {
+            metadata.AdditionalValues.Add(_editTypeKey, editType);
+        }
+
+        internal static JqGridColumnEditTypes GetColumnEditType(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_editTypeKey))
+                return (JqGridColumnEditTypes)metadata.AdditionalValues[_editTypeKey];
+            return JqGridColumnEditTypes.Default;
+        }
+
+        internal static void SetColumnFormOptions(this ModelMetadata metadata, JqGridColumnFormOptions formOptions)
+        {
+            metadata.AdditionalValues.Add(_formOptionsKey, formOptions);
+        }
+
+        internal static JqGridColumnFormOptions GetColumnFormOptions(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_formOptionsKey))
+                return (JqGridColumnFormOptions)metadata.AdditionalValues[_formOptionsKey];
+            return null;
+        }
+
+        internal static void SetColumnFormatter(this ModelMetadata metadata, SettedString formatter)
+        {
+            metadata.AdditionalValues.Add(_formatterKey, formatter);
+        }
+
+        internal static SettedString GetColumnFormatter(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_formatterKey))
+                return (SettedString)metadata.AdditionalValues[_formatterKey];
+            return null;
+        }
+
+        internal static void SetColumnFormatterOptions(this ModelMetadata metadata, JqGridColumnFormatterOptions formatterOptions)
+        {
+            metadata.AdditionalValues.Add(_formatterOptionsKey, formatterOptions);
+        }
+
+        internal static JqGridColumnFormatterOptions GetColumnFormatterOptions(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_formatterOptionsKey))
+                return (JqGridColumnFormatterOptions)metadata.AdditionalValues[_formatterOptionsKey];
+            return null;
+        }
+
+        internal static void SetColumnUnFormatter(this ModelMetadata metadata, SettedString unFormatter)
+        {
+            metadata.AdditionalValues.Add(_unFormatterKey, unFormatter);
+        }
+
+        internal static SettedString GetColumnUnFormatter(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_unFormatterKey))
+                return (SettedString)metadata.AdditionalValues[_unFormatterKey];
+            return null;
+        }
+
+        internal static JqGridColumnLabelOptions GetColumnLabelOptions(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_labelOptionsKey))
+                return (JqGridColumnLabelOptions)metadata.AdditionalValues[_labelOptionsKey];
+            return null;
+        }
+
+        internal static void SetColumnSearchable(this ModelMetadata metadata, bool? searchable)
+        {
+            metadata.AdditionalValues.Add(_searchableKey, searchable);
+        }
+
+        internal static bool? GetColumnSearchable(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_searchableKey))
+                return (bool?)metadata.AdditionalValues[_searchableKey];
+            return null;
+        }
+
+        internal static void SetColumnSearchOptions(this ModelMetadata metadata, JqGridColumnSearchOptions searchOptions)
+        {
+            metadata.AdditionalValues.Add(_searchOptionsKey, searchOptions);
+        }
+
+        internal static JqGridColumnSearchOptions GetColumnSearchOptions(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_searchOptionsKey))
+                return (JqGridColumnSearchOptions)metadata.AdditionalValues[_searchOptionsKey];
+            return null;
+        }
+
+        internal static void SetColumnSearchRules(this ModelMetadata metadata, JqGridColumnRules searchRules)
+        {
+            metadata.AdditionalValues.Add(_searchRulesKey, searchRules);
+        }
+
+        internal static JqGridColumnRules GetColumnSearchRules(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_searchRulesKey))
+                return (JqGridColumnRules)metadata.AdditionalValues[_searchRulesKey];
+            return null;
+        }
+
+        internal static void SetColumnSearchType(this ModelMetadata metadata, JqGridColumnSearchTypes searchType)
+        {
+            metadata.AdditionalValues.Add(_searchTypeKey, searchType);
+        }
+
+        internal static JqGridColumnSearchTypes GetColumnSearchType(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_searchTypeKey))
+                return (JqGridColumnSearchTypes)metadata.AdditionalValues[_searchTypeKey];
+            return JqGridColumnSearchTypes.Default;
+        }
+
+        internal static void SetColumnSortable(this ModelMetadata metadata, bool? sortable)
+        {
+            metadata.AdditionalValues.Add(_sortableKey, sortable);
+        }
+
+        internal static bool? GetColumnSortable(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_sortableKey))
+                return (bool?)metadata.AdditionalValues[_sortableKey];
+            return null;
+        }
+
+        internal static void SetColumnSortType(this ModelMetadata metadata, JqGridColumnSortTypes sortType)
+        {
+            metadata.AdditionalValues.Add(_sortTypeKey, sortType);
+        }
+
+        internal static JqGridColumnSortTypes GetColumnSortType(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_sortTypeKey))
+                return (JqGridColumnSortTypes)metadata.AdditionalValues[_sortTypeKey];
+            return JqGridColumnSortTypes.Default;
+        }
+
+        internal static void SetColumnSortFunction(this ModelMetadata metadata, SettedString sortFunction)
+        {
+            metadata.AdditionalValues.Add(_sortFunctionKey, sortFunction);
+        }
+
+        internal static SettedString GetColumnSortFunction(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_sortFunctionKey))
+                return (SettedString)metadata.AdditionalValues[_sortFunctionKey];
+            return null;
+        }
+
+        internal static void SetColumnIndex(this ModelMetadata metadata, SettedString index)
+        {
+            metadata.AdditionalValues.Add(_indexKey, index);
+        }
+
+        internal static SettedString GetColumnIndex(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_indexKey))
+                return (SettedString)metadata.AdditionalValues[_indexKey];
+            return null;
+        }
+
+        internal static void SetColumnInitialSortingOrder(this ModelMetadata metadata, JqGridSortingOrders initialSortingOrder)
+        {
+            metadata.AdditionalValues.Add(_initialSortingOrderKey, initialSortingOrder);
+        }
+
+        internal static JqGridSortingOrders GetColumnInitialSortingOrder(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_initialSortingOrderKey))
+                return (JqGridSortingOrders)metadata.AdditionalValues[_initialSortingOrderKey];
+            return JqGridSortingOrders.Default;
+        }
+
+        internal static void SetColumnSummaryType(this ModelMetadata metadata, JqGridColumnSummaryTypes type)
+        {
+            metadata.AdditionalValues.Add(_summaryTypeKey, type);
+        }
+
+        internal static JqGridColumnSummaryTypes? GetColumnSummaryType(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_summaryTypeKey))
+                return (JqGridColumnSummaryTypes)metadata.AdditionalValues[_summaryTypeKey];
+            return null;
+        }
+
+        internal static void SetColumnSummaryTemplate(this ModelMetadata metadata, SettedString template)
+        {
+            metadata.AdditionalValues.Add(_summaryTemplateKey, template);
+        }
+
+        internal static SettedString GetColumnSummaryTemplate(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_summaryTemplateKey))
+                return (SettedString)metadata.AdditionalValues[_summaryTemplateKey];
+            return null;
+        }
+
+        internal static void SetColumnSummaryFunction(this ModelMetadata metadata, string function)
+        {
+            metadata.AdditionalValues.Add(_summaryFunctionKey, function);
+        }
+
+        internal static string GetColumnSummaryFunction(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_summaryFunctionKey))
+                return (string)metadata.AdditionalValues[_summaryFunctionKey];
+            return null;
+        }
+
+        internal static void SetColumnJsonMapping(this ModelMetadata metadata, string jsonMapping)
+        {
+            metadata.AdditionalValues.Add(_jsonMappingKey, jsonMapping);
+        }
+
+        internal static string GetColumnJsonMapping(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_jsonMappingKey))
+                return (string)metadata.AdditionalValues[_jsonMappingKey];
+            return null;
+        }
+
+        internal static void SetColumnKey(this ModelMetadata metadata, bool? key)
+        {
+            metadata.AdditionalValues.Add(_keyKey, key);
+        }
+
+        internal static bool? GetColumnKey(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_keyKey))
+                return (bool?)metadata.AdditionalValues[_keyKey];
+            return null;
+        }
+
+        internal static void SetColumnXmlMapping(this ModelMetadata metadata, string xmlMapping)
+        {
+            metadata.AdditionalValues.Add(_xmlMappingKey, xmlMapping);
+        }
+
+        internal static string GetColumnXmlMapping(this ModelMetadata metadata)
+        {
+            if (metadata.AdditionalValues.ContainsKey(_xmlMappingKey))
+                return (string)metadata.AdditionalValues[_xmlMappingKey];
+            return String.Empty;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridModelMetadataExtensions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/DataAnnotations/JqGridModelMetadataExtensions.cs
@@ -1,507 +1,468 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations
 {
-    internal static class JqGridModelMetadataExtensions
-    {
-        #region Fields
-        private const string _alignmentKey = "JqGridColumnModel.Alignment";
-        private const string _cellAttributesKey = "JqGridColumnModel.CellAttributes";
-        private const string _classesKey = "JqGridColumnModel.Classes";
-        private const string _dateFormatKey = "JqGridColumnModel.DateFormat";
-        private const string _fixedKey = "JqGridColumnModel.Fixed";
-        private const string _frozenKey = "JqGridColumnModel.Frozen";
-        private const string _hideInDialogKey = "JqGridColumnModel.HideInDialog";
-        private const string _resizableKey = "JqGridColumnModel.Resizable";
-        private const string _titleKey = "JqGridColumnModel.Title";
-        private const string _widthKey = "JqGridColumnModel.Width";
-        private const string _viewableKey = "JqGridColumnModel.Viewable";
-        private const string _editableKey = "JqGridColumnModel.Editable";
-        private const string _editOptionsKey = "JqGridColumnModel.EditOptions";
-        private const string _editRulesKey = "JqGridColumnModel.EditRules";
-        private const string _formOptionsKey = "JqGridColumnModel.FormOptions";
-        private const string _editTypeKey = "JqGridColumnModel.EditType";
-        private const string _formatterKey = "JqGridColumnModel.Formatter";
-        private const string _formatterOptionsKey = "JqGridColumnModel.FormatterOptions";
-        private const string _unFormatterKey = "JqGridColumnModel.UnFormatter";
-        private const string _labelOptionsKey = "JqGridColumnModel.LabelOptions";
-        private const string _searchableKey = "JqGridColumnModel.Searchable";
-        private const string _searchOptionsKey = "JqGridColumnModel.SearchOptions";
-        private const string _searchRulesKey = "JqGridColumnModel.SearchRules";
-        private const string _searchTypeKey = "JqGridColumnModel.SearchType";
-        private const string _sortableKey = "JqGridColumnModel.Sortable";
-        private const string _sortTypeKey = "JqGridColumnModel.SortType";
-        private const string _sortFunctionKey = "JqGridColumnModel.SortFunction";
-        private const string _indexKey = "JqGridColumnModel.Index";
-        private const string _initialSortingOrderKey = "JqGridColumnModel.InitialSortingOrder";
-        private const string _summaryTypeKey = "JqGridColumnModel.SummaryType";
-        private const string _summaryTemplateKey = "JqGridColumnModel.SummaryTemplate";
-        private const string _summaryFunctionKey = "JqGridColumnModel.SummaryFunction";
-        private const string _jsonMappingKey = "JqGridColumnModel.JsonMapping";
-        private const string _keyKey = "JqGridColumnModel.Key";
-        private const string _xmlMappingKey = "JqGridColumnModel.XmlMapping";
-        #endregion
-
-        #region Methods
-        internal static void SetColumnAlignment(this ModelMetadata metadata, JqGridAlignments alignment)
-        {
-            metadata.AdditionalValues.Add(_alignmentKey, alignment);
-        }
-
-        internal static JqGridAlignments GetColumnAlignment(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_alignmentKey))
-                return (JqGridAlignments)metadata.AdditionalValues[_alignmentKey];
-            else
-                return JqGridAlignments.Left;
-        }
-
-        internal static void SetColumnCellAttributes(this ModelMetadata metadata, string cellAttributes)
-        {
-            metadata.AdditionalValues.Add(_cellAttributesKey, cellAttributes);
-        }
-
-        internal static string GetColumnCellAttributes(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_cellAttributesKey))
-                return (string)metadata.AdditionalValues[_cellAttributesKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnClasses(this ModelMetadata metadata, string classes)
-        {
-            metadata.AdditionalValues.Add(_classesKey, classes);
-        }
-
-        internal static string GetColumnClasses(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_classesKey))
-                return (string)metadata.AdditionalValues[_classesKey];
-            else
-                return String.Empty;
-        }
-
-        internal static void SetColumnDateFormat(this ModelMetadata metadata, string dateFormat)
-        {
-            metadata.AdditionalValues.Add(_dateFormatKey, dateFormat);
-        }
-
-        internal static string GetColumnDateFormat(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_dateFormatKey))
-                return (string)metadata.AdditionalValues[_dateFormatKey];
-            else
-                return JqGridOptionsDefaults.DateFormat;
-        }
-
-        internal static void SetColumnFixed(this ModelMetadata metadata, bool @fixed)
-        {
-            metadata.AdditionalValues.Add(_fixedKey, @fixed);
-        }
-
-        internal static bool GetColumnFixed(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_fixedKey))
-                return (bool)metadata.AdditionalValues[_fixedKey];
-            else
-                return false;
-        }
-
-        internal static void SetColumnFrozen(this ModelMetadata metadata, bool frozen)
-        {
-            metadata.AdditionalValues.Add(_frozenKey, frozen);
-        }
-
-        internal static bool GetColumnFrozen(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_frozenKey))
-                return (bool)metadata.AdditionalValues[_frozenKey];
-            else
-                return false;
-        }
-
-        internal static void SetColumnHideInDialog(this ModelMetadata metadata, bool hideInDialog)
-        {
-            metadata.AdditionalValues.Add(_hideInDialogKey, hideInDialog);
-        }
-
-        internal static bool GetColumnHideInDialog(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_hideInDialogKey))
-                return (bool)metadata.AdditionalValues[_hideInDialogKey];
-            else
-                return false;
-        }
-
-        internal static void SetColumnResizable(this ModelMetadata metadata, bool resizable)
-        {
-            metadata.AdditionalValues.Add(_resizableKey, resizable);
-        }
-
-        internal static bool GetColumnResizable(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_resizableKey))
-                return (bool)metadata.AdditionalValues[_resizableKey];
-            else
-                return true;
-        }
-
-        internal static void SetColumnTitle(this ModelMetadata metadata, bool title)
-        {
-            metadata.AdditionalValues.Add(_titleKey, title);
-        }
-
-        internal static bool GetColumnTitle(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_titleKey))
-                return (bool)metadata.AdditionalValues[_titleKey];
-            else
-                return true;
-        }
-
-        internal static void SetColumnWidth(this ModelMetadata metadata, int width)
-        {
-            metadata.AdditionalValues.Add(_widthKey, width);
-        }
-
-        internal static int GetColumnWidth(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_widthKey))
-                return (int)metadata.AdditionalValues[_widthKey];
-            else
-                return 150;
-        }
-
-        internal static void SetColumnViewable(this ModelMetadata metadata, bool viewable)
-        {
-            metadata.AdditionalValues.Add(_viewableKey, viewable);
-        }
-
-        internal static bool GetColumnViewable(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_viewableKey))
-                return (bool)metadata.AdditionalValues[_viewableKey];
-            else
-                return true;
-        }
-
-        internal static void SetColumnLabelOptions(this ModelMetadata metadata, JqGridColumnLabelOptions labelOptions)
-        {
-            metadata.AdditionalValues.Add(_labelOptionsKey, labelOptions);
-        }
-
-        internal static void SetColumnEditable(this ModelMetadata metadata, bool editable)
-        {
-            metadata.AdditionalValues.Add(_editableKey, editable);
-        }
-
-        internal static bool GetColumnEditable(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_editableKey))
-                return (bool)metadata.AdditionalValues[_editableKey];
-            else
-                return false;
-        }
-
-        internal static void SetColumnEditOptions(this ModelMetadata metadata, JqGridColumnEditOptions editOptions)
-        {
-            metadata.AdditionalValues.Add(_editOptionsKey, editOptions);
-        }
-
-        internal static JqGridColumnEditOptions GetColumnEditOptions(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_editOptionsKey))
-                return (JqGridColumnEditOptions)metadata.AdditionalValues[_editOptionsKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnEditRules(this ModelMetadata metadata, JqGridColumnRules editRules)
-        {
-            metadata.AdditionalValues.Add(_editRulesKey, editRules);
-        }
-
-        internal static JqGridColumnRules GetColumnEditRules(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_editRulesKey))
-                return (JqGridColumnRules)metadata.AdditionalValues[_editRulesKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnEditType(this ModelMetadata metadata, JqGridColumnEditTypes editType)
-        {
-            metadata.AdditionalValues.Add(_editTypeKey, editType);
-        }
-
-        internal static JqGridColumnEditTypes GetColumnEditType(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_editTypeKey))
-                return (JqGridColumnEditTypes)metadata.AdditionalValues[_editTypeKey];
-            else
-                return JqGridColumnEditTypes.Text;
-        }
-
-        internal static void SetColumnFormOptions(this ModelMetadata metadata, JqGridColumnFormOptions formOptions)
-        {
-            metadata.AdditionalValues.Add(_formOptionsKey, formOptions);
-        }
-
-        internal static JqGridColumnFormOptions GetColumnFormOptions(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_formOptionsKey))
-                return (JqGridColumnFormOptions)metadata.AdditionalValues[_formOptionsKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnFormatter(this ModelMetadata metadata, string formatter)
-        {
-            metadata.AdditionalValues.Add(_formatterKey, formatter);
-        }
-
-        internal static string GetColumnFormatter(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_formatterKey))
-                return (string)metadata.AdditionalValues[_formatterKey];
-            else
-                return String.Empty;
-        }
-
-        internal static void SetColumnFormatterOptions(this ModelMetadata metadata, JqGridColumnFormatterOptions formatterOptions)
-        {
-            metadata.AdditionalValues.Add(_formatterOptionsKey, formatterOptions);
-        }
-
-        internal static JqGridColumnFormatterOptions GetColumnFormatterOptions(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_formatterOptionsKey))
-                return (JqGridColumnFormatterOptions)metadata.AdditionalValues[_formatterOptionsKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnUnFormatter(this ModelMetadata metadata, string unFormatter)
-        {
-            metadata.AdditionalValues.Add(_unFormatterKey, unFormatter);
-        }
-
-        internal static string GetColumnUnFormatter(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_unFormatterKey))
-                return (string)metadata.AdditionalValues[_unFormatterKey];
-            else
-                return String.Empty;
-        }
-
-        internal static JqGridColumnLabelOptions GetColumnLabelOptions(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_labelOptionsKey))
-                return (JqGridColumnLabelOptions)metadata.AdditionalValues[_labelOptionsKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnSearchable(this ModelMetadata metadata, bool searchable)
-        {
-            metadata.AdditionalValues.Add(_searchableKey, searchable);
-        }
-
-        internal static bool GetColumnSearchable(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_searchableKey))
-                return (bool)metadata.AdditionalValues[_searchableKey];
-            else
-                return true;
-        }
-
-        internal static void SetColumnSearchOptions(this ModelMetadata metadata, JqGridColumnSearchOptions searchOptions)
-        {
-            metadata.AdditionalValues.Add(_searchOptionsKey, searchOptions);
-        }
-
-        internal static JqGridColumnSearchOptions GetColumnSearchOptions(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_searchOptionsKey))
-                return (JqGridColumnSearchOptions)metadata.AdditionalValues[_searchOptionsKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnSearchRules(this ModelMetadata metadata, JqGridColumnRules searchRules)
-        {
-            metadata.AdditionalValues.Add(_searchRulesKey, searchRules);
-        }
-
-        internal static JqGridColumnRules GetColumnSearchRules(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_searchRulesKey))
-                return (JqGridColumnRules)metadata.AdditionalValues[_searchRulesKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnSearchType(this ModelMetadata metadata, JqGridColumnSearchTypes searchType)
-        {
-            metadata.AdditionalValues.Add(_searchTypeKey, searchType);
-        }
-
-        internal static JqGridColumnSearchTypes GetColumnSearchType(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_searchTypeKey))
-                return (JqGridColumnSearchTypes)metadata.AdditionalValues[_searchTypeKey];
-            else
-                return JqGridColumnSearchTypes.Text;
-        }
-
-        internal static void SetColumnSortable(this ModelMetadata metadata, bool sortable)
-        {
-            metadata.AdditionalValues.Add(_sortableKey, sortable);
-        }
-
-        internal static bool GetColumnSortable(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_sortableKey))
-                return (bool)metadata.AdditionalValues[_sortableKey];
-            else
-                return true;
-        }
-
-        internal static void SetColumnSortType(this ModelMetadata metadata, JqGridColumnSortTypes sortType)
-        {
-            metadata.AdditionalValues.Add(_sortTypeKey, sortType);
-        }
-
-        internal static JqGridColumnSortTypes GetColumnSortType(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_sortTypeKey))
-                return (JqGridColumnSortTypes)metadata.AdditionalValues[_sortTypeKey];
-            else
-                return JqGridColumnSortTypes.Text;
-        }
-
-        internal static void SetColumnSortFunction(this ModelMetadata metadata, string sortFunction)
-        {
-            metadata.AdditionalValues.Add(_sortFunctionKey, sortFunction);
-        }
-
-        internal static string GetColumnSortFunction(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_sortFunctionKey))
-                return (string)metadata.AdditionalValues[_sortFunctionKey];
-            else
-                return String.Empty;
-        }
-
-        internal static void SetColumnIndex(this ModelMetadata metadata, string index)
-        {
-            metadata.AdditionalValues.Add(_indexKey, index);
-        }
-
-        internal static string GetColumnIndex(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_indexKey))
-                return (string)metadata.AdditionalValues[_indexKey];
-            else
-                return String.Empty;
-        }
-
-        internal static void SetColumnInitialSortingOrder(this ModelMetadata metadata, JqGridSortingOrders initialSortingOrder)
-        {
-            metadata.AdditionalValues.Add(_initialSortingOrderKey, initialSortingOrder);
-        }
-
-        internal static JqGridSortingOrders GetColumnInitialSortingOrder(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_initialSortingOrderKey))
-                return (JqGridSortingOrders)metadata.AdditionalValues[_initialSortingOrderKey];
-            else
-                return JqGridSortingOrders.Asc;
-        }
-
-        internal static void SetColumnSummaryType(this ModelMetadata metadata, JqGridColumnSummaryTypes type)
-        {
-            metadata.AdditionalValues.Add(_summaryTypeKey, type);
-        }
-
-        internal static JqGridColumnSummaryTypes? GetColumnSummaryType(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_summaryTypeKey))
-                return (JqGridColumnSummaryTypes)metadata.AdditionalValues[_summaryTypeKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnSummaryTemplate(this ModelMetadata metadata, string template)
-        {
-            metadata.AdditionalValues.Add(_summaryTemplateKey, template);
-        }
-
-        internal static string GetColumnSummaryTemplate(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_summaryTemplateKey))
-                return (string)metadata.AdditionalValues[_summaryTemplateKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnSummaryFunction(this ModelMetadata metadata, string function)
-        {
-            metadata.AdditionalValues.Add(_summaryFunctionKey, function);
-        }
-
-        internal static string GetColumnSummaryFunction(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_summaryFunctionKey))
-                return (string)metadata.AdditionalValues[_summaryFunctionKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnJsonMapping(this ModelMetadata metadata, string jsonMapping)
-        {
-            metadata.AdditionalValues.Add(_jsonMappingKey, jsonMapping);
-        }
-
-        internal static string GetColumnJsonMapping(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_jsonMappingKey))
-                return (string)metadata.AdditionalValues[_jsonMappingKey];
-            else
-                return null;
-        }
-
-        internal static void SetColumnKey(this ModelMetadata metadata, bool key)
-        {
-            metadata.AdditionalValues.Add(_keyKey, key);
-        }
-
-        internal static bool GetColumnKey(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_keyKey))
-                return (bool)metadata.AdditionalValues[_keyKey];
-            else
-                return false;
-        }
-
-        internal static void SetColumnXmlMapping(this ModelMetadata metadata, string xmlMapping)
-        {
-            metadata.AdditionalValues.Add(_xmlMappingKey, xmlMapping);
-        }
-
-        internal static string GetColumnXmlMapping(this ModelMetadata metadata)
-        {
-            if (metadata.AdditionalValues.ContainsKey(_xmlMappingKey))
-                return (string)metadata.AdditionalValues[_xmlMappingKey];
-            else
-                return String.Empty;
-        }
-        #endregion
-    }
+	internal static class JqGridModelMetadataExtensions
+	{
+		#region Fields
+		private const string _alignmentKey = "JqGridColumnModel.Alignment";
+		private const string _cellAttributesKey = "JqGridColumnModel.CellAttributes";
+		private const string _classesKey = "JqGridColumnModel.Classes";
+		private const string _dateFormatKey = "JqGridColumnModel.DateFormat";
+		private const string _fixedKey = "JqGridColumnModel.Fixed";
+		private const string _frozenKey = "JqGridColumnModel.Frozen";
+		private const string _hideInDialogKey = "JqGridColumnModel.HideInDialog";
+		private const string _resizableKey = "JqGridColumnModel.Resizable";
+		private const string _titleKey = "JqGridColumnModel.Title";
+		private const string _widthKey = "JqGridColumnModel.Width";
+		private const string _viewableKey = "JqGridColumnModel.Viewable";
+		private const string _editableKey = "JqGridColumnModel.Editable";
+		private const string _editOptionsKey = "JqGridColumnModel.EditOptions";
+		private const string _editRulesKey = "JqGridColumnModel.EditRules";
+		private const string _formOptionsKey = "JqGridColumnModel.FormOptions";
+		private const string _editTypeKey = "JqGridColumnModel.EditType";
+		private const string _formatterKey = "JqGridColumnModel.Formatter";
+		private const string _formatterOptionsKey = "JqGridColumnModel.FormatterOptions";
+		private const string _unFormatterKey = "JqGridColumnModel.UnFormatter";
+		private const string _labelOptionsKey = "JqGridColumnModel.LabelOptions";
+		private const string _searchableKey = "JqGridColumnModel.Searchable";
+		private const string _searchOptionsKey = "JqGridColumnModel.SearchOptions";
+		private const string _searchRulesKey = "JqGridColumnModel.SearchRules";
+		private const string _searchTypeKey = "JqGridColumnModel.SearchType";
+		private const string _sortableKey = "JqGridColumnModel.Sortable";
+		private const string _sortTypeKey = "JqGridColumnModel.SortType";
+		private const string _sortFunctionKey = "JqGridColumnModel.SortFunction";
+		private const string _indexKey = "JqGridColumnModel.Index";
+		private const string _initialSortingOrderKey = "JqGridColumnModel.InitialSortingOrder";
+		private const string _summaryTypeKey = "JqGridColumnModel.SummaryType";
+		private const string _summaryTemplateKey = "JqGridColumnModel.SummaryTemplate";
+		private const string _summaryFunctionKey = "JqGridColumnModel.SummaryFunction";
+		private const string _jsonMappingKey = "JqGridColumnModel.JsonMapping";
+		private const string _keyKey = "JqGridColumnModel.Key";
+		private const string _xmlMappingKey = "JqGridColumnModel.XmlMapping";
+		#endregion
+
+		#region Methods
+		internal static void SetColumnAlignment(this ModelMetadata metadata, JqGridAlignments alignment)
+		{
+			metadata.AdditionalValues.Add(_alignmentKey, alignment);
+		}
+
+		internal static JqGridAlignments GetColumnAlignment(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_alignmentKey))
+				return (JqGridAlignments)metadata.AdditionalValues[_alignmentKey];
+			return JqGridAlignments.Default;
+		}
+
+		internal static void SetColumnCellAttributes(this ModelMetadata metadata, SettedString cellAttributes)
+		{
+			metadata.AdditionalValues.Add(_cellAttributesKey, cellAttributes);
+		}
+
+		internal static SettedString GetColumnCellAttributes(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_cellAttributesKey))
+				return (SettedString)metadata.AdditionalValues[_cellAttributesKey];
+			return null;
+		}
+
+		internal static void SetColumnClasses(this ModelMetadata metadata, SettedString classes)
+		{
+			metadata.AdditionalValues.Add(_classesKey, classes);
+		}
+
+		internal static SettedString GetColumnClasses(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_classesKey))
+				return (SettedString)metadata.AdditionalValues[_classesKey];
+			return null;
+		}
+
+		internal static void SetColumnDateFormat(this ModelMetadata metadata, SettedString dateFormat)
+		{
+			metadata.AdditionalValues.Add(_dateFormatKey, dateFormat);
+		}
+
+		internal static SettedString GetColumnDateFormat(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_dateFormatKey))
+				return (SettedString)metadata.AdditionalValues[_dateFormatKey];
+			return null;
+		}
+
+		internal static void SetColumnFixed(this ModelMetadata metadata, bool? @fixed)
+		{
+			metadata.AdditionalValues.Add(_fixedKey, @fixed);
+		}
+
+		internal static bool? GetColumnFixed(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_fixedKey))
+				return (bool?)metadata.AdditionalValues[_fixedKey];
+			return null;
+		}
+
+		internal static void SetColumnFrozen(this ModelMetadata metadata, bool? frozen)
+		{
+			metadata.AdditionalValues.Add(_frozenKey, frozen);
+		}
+
+		internal static bool? GetColumnFrozen(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_frozenKey))
+				return (bool?)metadata.AdditionalValues[_frozenKey];
+			return null;
+		}
+
+		internal static void SetColumnHideInDialog(this ModelMetadata metadata, bool? hideInDialog)
+		{
+			metadata.AdditionalValues.Add(_hideInDialogKey, hideInDialog);
+		}
+
+		internal static bool? GetColumnHideInDialog(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_hideInDialogKey))
+				return (bool?)metadata.AdditionalValues[_hideInDialogKey];
+			return null;
+		}
+
+		internal static void SetColumnResizable(this ModelMetadata metadata, bool? resizable)
+		{
+			metadata.AdditionalValues.Add(_resizableKey, resizable);
+		}
+
+		internal static bool? GetColumnResizable(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_resizableKey))
+				return (bool?)metadata.AdditionalValues[_resizableKey];
+			return null;
+		}
+
+		internal static void SetColumnTitle(this ModelMetadata metadata, bool? title)
+		{
+			metadata.AdditionalValues.Add(_titleKey, title);
+		}
+
+		internal static bool? GetColumnTitle(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_titleKey))
+				return (bool?)metadata.AdditionalValues[_titleKey];
+			return null;
+		}
+
+		internal static void SetColumnWidth(this ModelMetadata metadata, int? width)
+		{
+			metadata.AdditionalValues.Add(_widthKey, width);
+		}
+
+		internal static int? GetColumnWidth(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_widthKey))
+				return (int?)metadata.AdditionalValues[_widthKey];
+			return null;
+		}
+
+		internal static void SetColumnViewable(this ModelMetadata metadata, bool? viewable)
+		{
+			metadata.AdditionalValues.Add(_viewableKey, viewable);
+		}
+
+		internal static bool? GetColumnViewable(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_viewableKey))
+				return (bool?)metadata.AdditionalValues[_viewableKey];
+			return null;
+		}
+
+		internal static void SetColumnLabelOptions(this ModelMetadata metadata, JqGridColumnLabelOptions labelOptions)
+		{
+			metadata.AdditionalValues.Add(_labelOptionsKey, labelOptions);
+		}
+
+		internal static void SetColumnEditable(this ModelMetadata metadata, bool? editable)
+		{
+			metadata.AdditionalValues.Add(_editableKey, editable);
+		}
+
+		internal static bool? GetColumnEditable(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_editableKey))
+				return (bool?)metadata.AdditionalValues[_editableKey];
+			return null;
+		}
+
+		internal static void SetColumnEditOptions(this ModelMetadata metadata, JqGridColumnEditOptions editOptions)
+		{
+			metadata.AdditionalValues.Add(_editOptionsKey, editOptions);
+		}
+
+		internal static JqGridColumnEditOptions GetColumnEditOptions(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_editOptionsKey))
+				return (JqGridColumnEditOptions)metadata.AdditionalValues[_editOptionsKey];
+			return null;
+		}
+
+		internal static void SetColumnEditRules(this ModelMetadata metadata, JqGridColumnRules editRules)
+		{
+			metadata.AdditionalValues.Add(_editRulesKey, editRules);
+		}
+
+		internal static JqGridColumnRules GetColumnEditRules(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_editRulesKey))
+				return (JqGridColumnRules)metadata.AdditionalValues[_editRulesKey];
+			return null;
+		}
+
+		internal static void SetColumnEditType(this ModelMetadata metadata, JqGridColumnEditTypes editType)
+		{
+			metadata.AdditionalValues.Add(_editTypeKey, editType);
+		}
+
+		internal static JqGridColumnEditTypes GetColumnEditType(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_editTypeKey))
+				return (JqGridColumnEditTypes)metadata.AdditionalValues[_editTypeKey];
+			return JqGridColumnEditTypes.Default;
+		}
+
+		internal static void SetColumnFormOptions(this ModelMetadata metadata, JqGridColumnFormOptions formOptions)
+		{
+			metadata.AdditionalValues.Add(_formOptionsKey, formOptions);
+		}
+
+		internal static JqGridColumnFormOptions GetColumnFormOptions(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_formOptionsKey))
+				return (JqGridColumnFormOptions)metadata.AdditionalValues[_formOptionsKey];
+			return null;
+		}
+
+		internal static void SetColumnFormatter(this ModelMetadata metadata, SettedString formatter)
+		{
+			metadata.AdditionalValues.Add(_formatterKey, formatter);
+		}
+
+		internal static SettedString GetColumnFormatter(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_formatterKey))
+				return (SettedString)metadata.AdditionalValues[_formatterKey];
+			return null;
+		}
+
+		internal static void SetColumnFormatterOptions(this ModelMetadata metadata, JqGridColumnFormatterOptions formatterOptions)
+		{
+			metadata.AdditionalValues.Add(_formatterOptionsKey, formatterOptions);
+		}
+
+		internal static JqGridColumnFormatterOptions GetColumnFormatterOptions(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_formatterOptionsKey))
+				return (JqGridColumnFormatterOptions)metadata.AdditionalValues[_formatterOptionsKey];
+			return null;
+		}
+
+		internal static void SetColumnUnFormatter(this ModelMetadata metadata, SettedString unFormatter)
+		{
+			metadata.AdditionalValues.Add(_unFormatterKey, unFormatter);
+		}
+
+		internal static SettedString GetColumnUnFormatter(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_unFormatterKey))
+				return (SettedString)metadata.AdditionalValues[_unFormatterKey];
+			return null;
+		}
+
+		internal static JqGridColumnLabelOptions GetColumnLabelOptions(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_labelOptionsKey))
+				return (JqGridColumnLabelOptions)metadata.AdditionalValues[_labelOptionsKey];
+			return null;
+		}
+
+		internal static void SetColumnSearchable(this ModelMetadata metadata, bool? searchable)
+		{
+			metadata.AdditionalValues.Add(_searchableKey, searchable);
+		}
+
+		internal static bool? GetColumnSearchable(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_searchableKey))
+				return (bool?)metadata.AdditionalValues[_searchableKey];
+			return null;
+		}
+
+		internal static void SetColumnSearchOptions(this ModelMetadata metadata, JqGridColumnSearchOptions searchOptions)
+		{
+			metadata.AdditionalValues.Add(_searchOptionsKey, searchOptions);
+		}
+
+		internal static JqGridColumnSearchOptions GetColumnSearchOptions(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_searchOptionsKey))
+				return (JqGridColumnSearchOptions)metadata.AdditionalValues[_searchOptionsKey];
+			return null;
+		}
+
+		internal static void SetColumnSearchRules(this ModelMetadata metadata, JqGridColumnRules searchRules)
+		{
+			metadata.AdditionalValues.Add(_searchRulesKey, searchRules);
+		}
+
+		internal static JqGridColumnRules GetColumnSearchRules(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_searchRulesKey))
+				return (JqGridColumnRules)metadata.AdditionalValues[_searchRulesKey];
+			return null;
+		}
+
+		internal static void SetColumnSearchType(this ModelMetadata metadata, JqGridColumnSearchTypes searchType)
+		{
+			metadata.AdditionalValues.Add(_searchTypeKey, searchType);
+		}
+
+		internal static JqGridColumnSearchTypes GetColumnSearchType(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_searchTypeKey))
+				return (JqGridColumnSearchTypes)metadata.AdditionalValues[_searchTypeKey];
+			return JqGridColumnSearchTypes.Default;
+		}
+
+		internal static void SetColumnSortable(this ModelMetadata metadata, bool? sortable)
+		{
+			metadata.AdditionalValues.Add(_sortableKey, sortable);
+		}
+
+		internal static bool? GetColumnSortable(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_sortableKey))
+				return (bool?)metadata.AdditionalValues[_sortableKey];
+			return null;
+		}
+
+		internal static void SetColumnSortType(this ModelMetadata metadata, JqGridColumnSortTypes sortType)
+		{
+			metadata.AdditionalValues.Add(_sortTypeKey, sortType);
+		}
+
+		internal static JqGridColumnSortTypes GetColumnSortType(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_sortTypeKey))
+				return (JqGridColumnSortTypes)metadata.AdditionalValues[_sortTypeKey];
+			return JqGridColumnSortTypes.Default;
+		}
+
+		internal static void SetColumnSortFunction(this ModelMetadata metadata, SettedString sortFunction)
+		{
+			metadata.AdditionalValues.Add(_sortFunctionKey, sortFunction);
+		}
+
+		internal static SettedString GetColumnSortFunction(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_sortFunctionKey))
+				return (SettedString)metadata.AdditionalValues[_sortFunctionKey];
+			return null;
+		}
+
+		internal static void SetColumnIndex(this ModelMetadata metadata, SettedString index)
+		{
+			metadata.AdditionalValues.Add(_indexKey, index);
+		}
+
+		internal static SettedString GetColumnIndex(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_indexKey))
+				return (SettedString)metadata.AdditionalValues[_indexKey];
+			return null;
+		}
+
+		internal static void SetColumnInitialSortingOrder(this ModelMetadata metadata, JqGridSortingOrders initialSortingOrder)
+		{
+			metadata.AdditionalValues.Add(_initialSortingOrderKey, initialSortingOrder);
+		}
+
+		internal static JqGridSortingOrders GetColumnInitialSortingOrder(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_initialSortingOrderKey))
+				return (JqGridSortingOrders)metadata.AdditionalValues[_initialSortingOrderKey];
+			return JqGridSortingOrders.Default;
+		}
+
+		internal static void SetColumnSummaryType(this ModelMetadata metadata, JqGridColumnSummaryTypes type)
+		{
+			metadata.AdditionalValues.Add(_summaryTypeKey, type);
+		}
+
+		internal static JqGridColumnSummaryTypes? GetColumnSummaryType(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_summaryTypeKey))
+				return (JqGridColumnSummaryTypes)metadata.AdditionalValues[_summaryTypeKey];
+			return null;
+		}
+
+		internal static void SetColumnSummaryTemplate(this ModelMetadata metadata, SettedString template)
+		{
+			metadata.AdditionalValues.Add(_summaryTemplateKey, template);
+		}
+
+		internal static SettedString GetColumnSummaryTemplate(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_summaryTemplateKey))
+				return (SettedString)metadata.AdditionalValues[_summaryTemplateKey];
+			return null;
+		}
+
+		internal static void SetColumnSummaryFunction(this ModelMetadata metadata, string function)
+		{
+			metadata.AdditionalValues.Add(_summaryFunctionKey, function);
+		}
+
+		internal static string GetColumnSummaryFunction(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_summaryFunctionKey))
+				return (string)metadata.AdditionalValues[_summaryFunctionKey];
+			return null;
+		}
+
+		internal static void SetColumnJsonMapping(this ModelMetadata metadata, string jsonMapping)
+		{
+			metadata.AdditionalValues.Add(_jsonMappingKey, jsonMapping);
+		}
+
+		internal static string GetColumnJsonMapping(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_jsonMappingKey))
+				return (string)metadata.AdditionalValues[_jsonMappingKey];
+			return null;
+		}
+
+		internal static void SetColumnKey(this ModelMetadata metadata, bool? key)
+		{
+			metadata.AdditionalValues.Add(_keyKey, key);
+		}
+
+		internal static bool? GetColumnKey(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_keyKey))
+				return (bool?)metadata.AdditionalValues[_keyKey];
+			return null;
+		}
+
+		internal static void SetColumnXmlMapping(this ModelMetadata metadata, string xmlMapping)
+		{
+			metadata.AdditionalValues.Add(_xmlMappingKey, xmlMapping);
+		}
+
+		internal static string GetColumnXmlMapping(this ModelMetadata metadata)
+		{
+			if (metadata.AdditionalValues.ContainsKey(_xmlMappingKey))
+				return (string)metadata.AdditionalValues[_xmlMappingKey];
+			return String.Empty;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/IJqGridHelper.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/IJqGridHelper.cs
@@ -2,68 +2,68 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// An interface representing helper class for generating jqGrid HMTL and JavaScript.
-	/// </summary>
-	public interface IJqGridHelper
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the grid identifier.
-		/// </summary>
-		string Id { get; }
+    /// <summary>
+    /// An interface representing helper class for generating jqGrid HMTL and JavaScript.
+    /// </summary>
+    public interface IJqGridHelper
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the grid identifier.
+        /// </summary>
+        string Id { get; }
 
-		/// <summary>
-		/// Gets the grid pager identifier.
-		/// </summary>
-		string PagerId { get; }
+        /// <summary>
+        /// Gets the grid pager identifier.
+        /// </summary>
+        string PagerId { get; }
 
-		/// <summary>
-		/// Gets the filter grid (div) placeholder identifier.
-		/// </summary>
-		string FilterGridId { get; }
-		#endregion
+        /// <summary>
+        /// Gets the filter grid (div) placeholder identifier.
+        /// </summary>
+        string FilterGridId { get; }
+        #endregion
 
-		#region Methods
-		/// <summary>
-		/// Returns the HTML that is used to render the table placeholder for the grid. 
-		/// </summary>
-		/// <returns>The HTML that represents the table placeholder for jqGrid</returns>
-		MvcHtmlString GetTableHtml();
+        #region Methods
+        /// <summary>
+        /// Returns the HTML that is used to render the table placeholder for the grid. 
+        /// </summary>
+        /// <returns>The HTML that represents the table placeholder for jqGrid</returns>
+        MvcHtmlString GetTableHtml();
 
-		/// <summary>
-		/// Returns the HTML that is used to render the pager (div) placeholder for the grid. 
-		/// </summary>
-		/// <returns>The HTML that represents the pager (div) placeholder for jqGrid</returns>
-		MvcHtmlString GetPagerHtml();
+        /// <summary>
+        /// Returns the HTML that is used to render the pager (div) placeholder for the grid. 
+        /// </summary>
+        /// <returns>The HTML that represents the pager (div) placeholder for jqGrid</returns>
+        MvcHtmlString GetPagerHtml();
 
-		/// <summary>
-		/// Returns the HTML that is used to render the filter grid (div) placeholder for the grid. 
-		/// </summary>
-		/// <returns>The HTML that represents the filter grid (div) placeholder for jqGrid</returns>
-		MvcHtmlString GetFilterGridHtml();
+        /// <summary>
+        /// Returns the HTML that is used to render the filter grid (div) placeholder for the grid. 
+        /// </summary>
+        /// <returns>The HTML that represents the filter grid (div) placeholder for jqGrid</returns>
+        MvcHtmlString GetFilterGridHtml();
 
-		/// <summary>
-		/// Returns the HTML that is used to render the table placeholder for the grid with pager placeholder below it and filter grid (if enabled) placeholder above it.
-		/// </summary>
-		/// <returns>The HTML that represents the table placeholder for jqGrid with pager placeholder below i</returns>
-		MvcHtmlString GetHtml();
+        /// <summary>
+        /// Returns the HTML that is used to render the table placeholder for the grid with pager placeholder below it and filter grid (if enabled) placeholder above it.
+        /// </summary>
+        /// <returns>The HTML that represents the table placeholder for jqGrid with pager placeholder below i</returns>
+        MvcHtmlString GetHtml();
 
-		/// <summary>
-		/// Return the JavaScript that is used to initialize jqGrid with given options.
-		/// </summary>
-		/// <returns>The JavaScript that initializes jqGrid with give options</returns>
-		/// <exception cref="System.InvalidOperationException">
-		/// <list type="bullet">
-		/// <item><description>TreeGrid and data grouping are both enabled.</description></item>
-		/// <item><description>Rows numbers and data grouping are both enabled.</description></item>
-		/// <item><description>Dynamic scrolling and data grouping are both enabled.</description></item>
-		/// <item><description>TreeGrid and GridView are both enabled.</description></item>
-		/// <item><description>SubGrid and GridView are both enabled.</description></item>
-		/// <item><description>AfterInsertRow event and GridView are both enabled.</description></item>
-		/// </list> 
-		/// </exception>
-		MvcHtmlString GetJavaScript();
-		#endregion
-	}
+        /// <summary>
+        /// Return the JavaScript that is used to initialize jqGrid with given options.
+        /// </summary>
+        /// <returns>The JavaScript that initializes jqGrid with give options</returns>
+        /// <exception cref="System.InvalidOperationException">
+        /// <list type="bullet">
+        /// <item><description>TreeGrid and data grouping are both enabled.</description></item>
+        /// <item><description>Rows numbers and data grouping are both enabled.</description></item>
+        /// <item><description>Dynamic scrolling and data grouping are both enabled.</description></item>
+        /// <item><description>TreeGrid and GridView are both enabled.</description></item>
+        /// <item><description>SubGrid and GridView are both enabled.</description></item>
+        /// <item><description>AfterInsertRow event and GridView are both enabled.</description></item>
+        /// </list> 
+        /// </exception>
+        MvcHtmlString GetJavaScript();
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/IJqGridHelper.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/IJqGridHelper.cs
@@ -1,73 +1,69 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// An interface representing helper class for generating jqGrid HMTL and JavaScript.
-    /// </summary>
-    public interface IJqGridHelper
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the grid identifier.
-        /// </summary>
-        string Id { get; }
+	/// <summary>
+	/// An interface representing helper class for generating jqGrid HMTL and JavaScript.
+	/// </summary>
+	public interface IJqGridHelper
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the grid identifier.
+		/// </summary>
+		string Id { get; }
 
-        /// <summary>
-        /// Gets the grid pager identifier.
-        /// </summary>
-        string PagerId { get; }
+		/// <summary>
+		/// Gets the grid pager identifier.
+		/// </summary>
+		string PagerId { get; }
 
-        /// <summary>
-        /// Gets the filter grid (div) placeholder identifier.
-        /// </summary>
-        string FilterGridId { get; }
-        #endregion
+		/// <summary>
+		/// Gets the filter grid (div) placeholder identifier.
+		/// </summary>
+		string FilterGridId { get; }
+		#endregion
 
-        #region Methods
-        /// <summary>
-        /// Returns the HTML that is used to render the table placeholder for the grid. 
-        /// </summary>
-        /// <returns>The HTML that represents the table placeholder for jqGrid</returns>
-        MvcHtmlString GetTableHtml();
+		#region Methods
+		/// <summary>
+		/// Returns the HTML that is used to render the table placeholder for the grid. 
+		/// </summary>
+		/// <returns>The HTML that represents the table placeholder for jqGrid</returns>
+		MvcHtmlString GetTableHtml();
 
-        /// <summary>
-        /// Returns the HTML that is used to render the pager (div) placeholder for the grid. 
-        /// </summary>
-        /// <returns>The HTML that represents the pager (div) placeholder for jqGrid</returns>
-        MvcHtmlString GetPagerHtml();
+		/// <summary>
+		/// Returns the HTML that is used to render the pager (div) placeholder for the grid. 
+		/// </summary>
+		/// <returns>The HTML that represents the pager (div) placeholder for jqGrid</returns>
+		MvcHtmlString GetPagerHtml();
 
-        /// <summary>
-        /// Returns the HTML that is used to render the filter grid (div) placeholder for the grid. 
-        /// </summary>
-        /// <returns>The HTML that represents the filter grid (div) placeholder for jqGrid</returns>
-        MvcHtmlString GetFilterGridHtml();
+		/// <summary>
+		/// Returns the HTML that is used to render the filter grid (div) placeholder for the grid. 
+		/// </summary>
+		/// <returns>The HTML that represents the filter grid (div) placeholder for jqGrid</returns>
+		MvcHtmlString GetFilterGridHtml();
 
-        /// <summary>
-        /// Returns the HTML that is used to render the table placeholder for the grid with pager placeholder below it and filter grid (if enabled) placeholder above it.
-        /// </summary>
-        /// <returns>The HTML that represents the table placeholder for jqGrid with pager placeholder below i</returns>
-        MvcHtmlString GetHtml();
+		/// <summary>
+		/// Returns the HTML that is used to render the table placeholder for the grid with pager placeholder below it and filter grid (if enabled) placeholder above it.
+		/// </summary>
+		/// <returns>The HTML that represents the table placeholder for jqGrid with pager placeholder below i</returns>
+		MvcHtmlString GetHtml();
 
-        /// <summary>
-        /// Return the JavaScript that is used to initialize jqGrid with given options.
-        /// </summary>
-        /// <returns>The JavaScript that initializes jqGrid with give options</returns>
-        /// <exception cref="System.InvalidOperationException">
-        /// <list type="bullet">
-        /// <item><description>TreeGrid and data grouping are both enabled.</description></item>
-        /// <item><description>Rows numbers and data grouping are both enabled.</description></item>
-        /// <item><description>Dynamic scrolling and data grouping are both enabled.</description></item>
-        /// <item><description>TreeGrid and GridView are both enabled.</description></item>
-        /// <item><description>SubGrid and GridView are both enabled.</description></item>
-        /// <item><description>AfterInsertRow event and GridView are both enabled.</description></item>
-        /// </list> 
-        /// </exception>
-        MvcHtmlString GetJavaScript();
-        #endregion
-    }
+		/// <summary>
+		/// Return the JavaScript that is used to initialize jqGrid with given options.
+		/// </summary>
+		/// <returns>The JavaScript that initializes jqGrid with give options</returns>
+		/// <exception cref="System.InvalidOperationException">
+		/// <list type="bullet">
+		/// <item><description>TreeGrid and data grouping are both enabled.</description></item>
+		/// <item><description>Rows numbers and data grouping are both enabled.</description></item>
+		/// <item><description>Dynamic scrolling and data grouping are both enabled.</description></item>
+		/// <item><description>TreeGrid and GridView are both enabled.</description></item>
+		/// <item><description>SubGrid and GridView are both enabled.</description></item>
+		/// <item><description>AfterInsertRow event and GridView are both enabled.</description></item>
+		/// </list> 
+		/// </exception>
+		MvcHtmlString GetJavaScript();
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/IJqGridNavigatorPageableFormActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/IJqGridNavigatorPageableFormActionOptions.cs
@@ -1,25 +1,25 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines the properties for jqGrid Navigator pageable form editing action.
-	/// </summary>
-	public interface IJqGridNavigatorPageableFormActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the options for keyboard navigation.
-		/// </summary>
-		JqGridFormKeyboardNavigation NavigationKeys { get; set; }
+    /// <summary>
+    /// Defines the properties for jqGrid Navigator pageable form editing action.
+    /// </summary>
+    public interface IJqGridNavigatorPageableFormActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the options for keyboard navigation.
+        /// </summary>
+        JqGridFormKeyboardNavigation NavigationKeys { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the pager buttons should appear on the form.
-		/// </summary>
-		bool ViewPagerButtons { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the pager buttons should appear on the form.
+        /// </summary>
+        bool ViewPagerButtons { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
-		/// </summary>
-		bool RecreateForm { get; set; }
-		#endregion
-	}
+        /// <summary>
+        /// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
+        /// </summary>
+        bool RecreateForm { get; set; }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/IJqGridNavigatorPageableFormActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/IJqGridNavigatorPageableFormActionOptions.cs
@@ -1,30 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines the properties for jqGrid Navigator pageable form editing action.
-    /// </summary>
-    public interface IJqGridNavigatorPageableFormActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the options for keyboard navigation.
-        /// </summary>
-        JqGridFormKeyboardNavigation NavigationKeys { get; set; }
+	/// <summary>
+	/// Defines the properties for jqGrid Navigator pageable form editing action.
+	/// </summary>
+	public interface IJqGridNavigatorPageableFormActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the options for keyboard navigation.
+		/// </summary>
+		JqGridFormKeyboardNavigation NavigationKeys { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the pager buttons should appear on the form.
-        /// </summary>
-        bool ViewPagerButtons { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the pager buttons should appear on the form.
+		/// </summary>
+		bool ViewPagerButtons { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
-        /// </summary>
-        bool RecreateForm { get; set; }
-        #endregion
-    }
+		/// <summary>
+		/// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
+		/// </summary>
+		bool RecreateForm { get; set; }
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridAdjacencyTreeRecord.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridAdjacencyTreeRecord.cs
@@ -1,48 +1,45 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents TreeGrid record for jqGrid in adjacency model.
-    /// </summary>
-    public class JqGridAdjacencyTreeRecord : JqGridTreeRecord
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the id of parent of this record.
-        /// </summary>
-        public string ParentId { get; private set; }
-        #endregion
+	/// <summary>
+	/// Class which represents TreeGrid record for jqGrid in adjacency model.
+	/// </summary>
+	public class JqGridAdjacencyTreeRecord : JqGridTreeRecord
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the id of parent of this record.
+		/// </summary>
+		public string ParentId { get; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="values">The record cells values.</param>
-        /// <param name="level">The level of the record in the hierarchy.</param>
-        /// <param name="parentId">The id of parent of this record.</param>
-        public JqGridAdjacencyTreeRecord(string id, List<object> values, int level, string parentId)
-            : base(id, values, level)
-        {
-            ParentId = parentId;
-        }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="values">The record cells values.</param>
+		/// <param name="level">The level of the record in the hierarchy.</param>
+		/// <param name="parentId">The id of parent of this record.</param>
+		public JqGridAdjacencyTreeRecord(string id, List<object> values, int level, string parentId)
+			: base(id, values, level)
+		{
+			ParentId = parentId;
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="value">The record value.</param>
-        /// <param name="level">The level of the record in the hierarchy.</param>
-        /// <param name="parentId">The id of parent of this record.</param>
-        public JqGridAdjacencyTreeRecord(string id, object value, int level, string parentId)
-            : base(id, value, level)
-        {
-            ParentId = parentId;
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="value">The record value.</param>
+		/// <param name="level">The level of the record in the hierarchy.</param>
+		/// <param name="parentId">The id of parent of this record.</param>
+		public JqGridAdjacencyTreeRecord(string id, object value, int level, string parentId)
+			: base(id, value, level)
+		{
+			ParentId = parentId;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridAdjacencyTreeRecord.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridAdjacencyTreeRecord.cs
@@ -2,44 +2,44 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents TreeGrid record for jqGrid in adjacency model.
-	/// </summary>
-	public class JqGridAdjacencyTreeRecord : JqGridTreeRecord
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the id of parent of this record.
-		/// </summary>
-		public string ParentId { get; }
-		#endregion
+    /// <summary>
+    /// Class which represents TreeGrid record for jqGrid in adjacency model.
+    /// </summary>
+    public class JqGridAdjacencyTreeRecord : JqGridTreeRecord
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the id of parent of this record.
+        /// </summary>
+        public string ParentId { get; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="values">The record cells values.</param>
-		/// <param name="level">The level of the record in the hierarchy.</param>
-		/// <param name="parentId">The id of parent of this record.</param>
-		public JqGridAdjacencyTreeRecord(string id, List<object> values, int level, string parentId)
-			: base(id, values, level)
-		{
-			ParentId = parentId;
-		}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="values">The record cells values.</param>
+        /// <param name="level">The level of the record in the hierarchy.</param>
+        /// <param name="parentId">The id of parent of this record.</param>
+        public JqGridAdjacencyTreeRecord(string id, List<object> values, int level, string parentId)
+            : base(id, values, level)
+        {
+            ParentId = parentId;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="value">The record value.</param>
-		/// <param name="level">The level of the record in the hierarchy.</param>
-		/// <param name="parentId">The id of parent of this record.</param>
-		public JqGridAdjacencyTreeRecord(string id, object value, int level, string parentId)
-			: base(id, value, level)
-		{
-			ParentId = parentId;
-		}
-		#endregion
-	}
+        /// <summary>
+        /// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="value">The record value.</param>
+        /// <param name="level">The level of the record in the hierarchy.</param>
+        /// <param name="parentId">The id of parent of this record.</param>
+        public JqGridAdjacencyTreeRecord(string id, object value, int level, string parentId)
+            : base(id, value, level)
+        {
+            ParentId = parentId;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridAdjacencyTreeRecord`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridAdjacencyTreeRecord`1.cs
@@ -1,27 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents TreeGrid record for jqGrid in adjacency model.
-    /// </summary>
-    /// <typeparam name="TModel">Type of model for this grid</typeparam>
-    public class JqGridAdjacencyTreeRecord<TModel> : JqGridAdjacencyTreeRecord
-    {
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="value">The record value.</param>
-        /// <param name="level">The level of the record in the hierarchy.</param>
-        /// <param name="parentId">The id of parent of this record.</param>
-        public JqGridAdjacencyTreeRecord(string id, TModel value, int level, string parentId)
-            : base(id, value, level, parentId)
-        { }
-        #endregion
-    }
+	/// <summary>
+	/// Class which represents TreeGrid record for jqGrid in adjacency model.
+	/// </summary>
+	/// <typeparam name="TModel">Type of model for this grid</typeparam>
+	public class JqGridAdjacencyTreeRecord<TModel> : JqGridAdjacencyTreeRecord
+	{
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="value">The record value.</param>
+		/// <param name="level">The level of the record in the hierarchy.</param>
+		/// <param name="parentId">The id of parent of this record.</param>
+		public JqGridAdjacencyTreeRecord(string id, TModel value, int level, string parentId)
+			: base(id, value, level, parentId)
+		{ }
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridAdjacencyTreeRecord`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridAdjacencyTreeRecord`1.cs
@@ -1,22 +1,22 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents TreeGrid record for jqGrid in adjacency model.
-	/// </summary>
-	/// <typeparam name="TModel">Type of model for this grid</typeparam>
-	public class JqGridAdjacencyTreeRecord<TModel> : JqGridAdjacencyTreeRecord
-	{
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="value">The record value.</param>
-		/// <param name="level">The level of the record in the hierarchy.</param>
-		/// <param name="parentId">The id of parent of this record.</param>
-		public JqGridAdjacencyTreeRecord(string id, TModel value, int level, string parentId)
-			: base(id, value, level, parentId)
-		{ }
-		#endregion
-	}
+    /// <summary>
+    /// Class which represents TreeGrid record for jqGrid in adjacency model.
+    /// </summary>
+    /// <typeparam name="TModel">Type of model for this grid</typeparam>
+    public class JqGridAdjacencyTreeRecord<TModel> : JqGridAdjacencyTreeRecord
+    {
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridAdjacencyTreeRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="value">The record value.</param>
+        /// <param name="level">The level of the record in the hierarchy.</param>
+        /// <param name="parentId">The id of parent of this record.</param>
+        public JqGridAdjacencyTreeRecord(string id, TModel value, int level, string parentId)
+            : base(id, value, level, parentId)
+        { }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridAlignments.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridAlignments.cs
@@ -1,25 +1,25 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available alignments of various jqGrid elements
-	/// </summary>
-	public enum JqGridAlignments
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Align to left
-		/// </summary>
-		Left,
-		/// <summary>
-		/// Align center
-		/// </summary>
-		Center,
-		/// <summary>
-		/// Align to rigth
-		/// </summary>
-		Right
-	}
+    /// <summary>
+    /// Defines available alignments of various jqGrid elements
+    /// </summary>
+    public enum JqGridAlignments
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Align to left
+        /// </summary>
+        Left,
+        /// <summary>
+        /// Align center
+        /// </summary>z
+        Center,
+        /// <summary>
+        /// Align to rigth
+        /// </summary>
+        Right
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridAlignments.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridAlignments.cs
@@ -1,26 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available alignments of various jqGrid elements
-    /// </summary>
-    public enum JqGridAlignments
-    {
-        /// <summary>
-        /// Align to left
-        /// </summary>
-        Left,
-        /// <summary>
-        /// Align center
-        /// </summary>
-        Center,
-        /// <summary>
-        /// Align to rigth
-        /// </summary>
-        Right
-    }
+	/// <summary>
+	/// Defines available alignments of various jqGrid elements
+	/// </summary>
+	public enum JqGridAlignments
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Align to left
+		/// </summary>
+		Left,
+		/// <summary>
+		/// Align center
+		/// </summary>
+		Center,
+		/// <summary>
+		/// Align to rigth
+		/// </summary>
+		Right
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridBootstrap4IconSet.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridBootstrap4IconSet.cs
@@ -1,26 +1,26 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Icon set for Bootstrap 4 style
-	/// </summary>
-	public enum JqGridBootstrap4IconSet
-	{
-		/// <summary>
-		/// Use JqGrid default style
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Use Iconic pack
-		/// </summary>
-		Iconic,
-		/// <summary>
-		/// Use Octicons pack
-		/// </summary>
-		Octicons,
-		/// <summary>
-		/// Use FontAwesome pack
-		/// </summary>
-		/// <remarks>Available since Gurido JqGrid 5.3.1</remarks>
-		fontAwesome
-	}
+    /// <summary>
+    /// Icon set for Bootstrap 4 style
+    /// </summary>
+    public enum JqGridBootstrap4IconSet
+    {
+        /// <summary>
+        /// Use JqGrid default style
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Use Iconic pack
+        /// </summary>
+        Iconic,
+        /// <summary>
+        /// Use Octicons pack
+        /// </summary>
+        Octicons,
+        /// <summary>
+        /// Use FontAwesome pack
+        /// </summary>
+        /// <remarks>Available since Gurido JqGrid 5.3.1</remarks>
+        fontAwesome
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridBootstrap4IconSet.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridBootstrap4IconSet.cs
@@ -1,0 +1,26 @@
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
+{
+	/// <summary>
+	/// Icon set for Bootstrap 4 style
+	/// </summary>
+	public enum JqGridBootstrap4IconSet
+	{
+		/// <summary>
+		/// Use JqGrid default style
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Use Iconic pack
+		/// </summary>
+		Iconic,
+		/// <summary>
+		/// Use Octicons pack
+		/// </summary>
+		Octicons,
+		/// <summary>
+		/// Use FontAwesome pack
+		/// </summary>
+		/// <remarks>Available since Gurido JqGrid 5.3.1</remarks>
+		fontAwesome
+	}
+}

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridCellEditingSubmitModes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridCellEditingSubmitModes.cs
@@ -1,21 +1,21 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// jqGrid cell editing submit modes
-	/// </summary>
-	public enum JqGridCellEditingSubmitModes
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// The change is immediately saved to the server.
-		/// </summary>
-		remote,
-		/// <summary>
-		/// No ajax request is made and the content of the changed cell can be obtained via the JavaScript jqGrid method getChangedCells 
-		/// </summary>
-		clientArray
-	}
+    /// <summary>
+    /// jqGrid cell editing submit modes
+    /// </summary>
+    public enum JqGridCellEditingSubmitModes
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// The change is immediately saved to the server.
+        /// </summary>
+        remote,
+        /// <summary>
+        /// No ajax request is made and the content of the changed cell can be obtained via the JavaScript jqGrid method getChangedCells 
+        /// </summary>
+        clientArray
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridCellEditingSubmitModes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridCellEditingSubmitModes.cs
@@ -1,22 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jqGrid cell editing submit modes
-    /// </summary>
-    public enum JqGridCellEditingSubmitModes
-    {
-        /// <summary>
-        /// The change is immediately saved to the server.
-        /// </summary>
-        Remote,
-        /// <summary>
-        /// No ajax request is made and the content of the changed cell can be obtained via the JavaScript jqGrid method getChangedCells 
-        /// </summary>
-        ClientArray
-    }
+	/// <summary>
+	/// jqGrid cell editing submit modes
+	/// </summary>
+	public enum JqGridCellEditingSubmitModes
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// The change is immediately saved to the server.
+		/// </summary>
+		remote,
+		/// <summary>
+		/// No ajax request is made and the content of the changed cell can be obtained via the JavaScript jqGrid method getChangedCells 
+		/// </summary>
+		clientArray
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnDataEvent.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnDataEvent.cs
@@ -2,47 +2,47 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents data event for jqGrid editable or searchable column
-	/// </summary>
-	public class JqGridColumnDataEvent
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the type of the event.
-		/// </summary>
-		public string Type { get; }
+    /// <summary>
+    /// Class which represents data event for jqGrid editable or searchable column
+    /// </summary>
+    public class JqGridColumnDataEvent
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the type of the event.
+        /// </summary>
+        public string Type { get; }
 
-		/// <summary>
-		/// Gets the additional data for the event.
-		/// </summary>
-		public object Data { get; }
+        /// <summary>
+        /// Gets the additional data for the event.
+        /// </summary>
+        public object Data { get; }
 
-		/// <summary>
-		/// Gets the function which will be called on the event.
-		/// </summary>
-		public string Function { get; }
-		#endregion
+        /// <summary>
+        /// Gets the function which will be called on the event.
+        /// </summary>
+        public string Function { get; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnDataEvent class.
-		/// </summary>
-		/// <param name="type">The type of the event.</param>
-		/// <param name="function">The function which will be called on the event.</param>
-		/// <param name="data">The additional (optional) data for the event.</param>
-		public JqGridColumnDataEvent(string type, string function, object data = null)
-		{
-			if (string.IsNullOrWhiteSpace(type))
-				throw new ArgumentNullException(nameof(type));
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnDataEvent class.
+        /// </summary>
+        /// <param name="type">The type of the event.</param>
+        /// <param name="function">The function which will be called on the event.</param>
+        /// <param name="data">The additional (optional) data for the event.</param>
+        public JqGridColumnDataEvent(string type, string function, object data = null)
+        {
+            if (string.IsNullOrWhiteSpace(type))
+                throw new ArgumentNullException(nameof(type));
 
-			if (string.IsNullOrWhiteSpace(function))
-				throw new ArgumentNullException(nameof(function));
+            if (string.IsNullOrWhiteSpace(function))
+                throw new ArgumentNullException(nameof(function));
 
-			Type = type;
-			Function = function;
-			Data = data;
-		}
-		#endregion
-	}
+            Type = type;
+            Function = function;
+            Data = data;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnDataEvent.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnDataEvent.cs
@@ -1,51 +1,48 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents data event for jqGrid editable or searchable column
-    /// </summary>
-    public class JqGridColumnDataEvent
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the type of the event.
-        /// </summary>
-        public string Type { get; private set; }
+	/// <summary>
+	/// Class which represents data event for jqGrid editable or searchable column
+	/// </summary>
+	public class JqGridColumnDataEvent
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the type of the event.
+		/// </summary>
+		public string Type { get; }
 
-        /// <summary>
-        /// Gets the additional data for the event.
-        /// </summary>
-        public object Data { get; private set; }
+		/// <summary>
+		/// Gets the additional data for the event.
+		/// </summary>
+		public object Data { get; }
 
-        /// <summary>
-        /// Gets the function which will be called on the event.
-        /// </summary>
-        public string Function { get; private set; }
-        #endregion
+		/// <summary>
+		/// Gets the function which will be called on the event.
+		/// </summary>
+		public string Function { get; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnDataEvent class.
-        /// </summary>
-        /// <param name="type">The type of the event.</param>
-        /// <param name="function">The function which will be called on the event.</param>
-        /// <param name="data">The additional (optional) data for the event.</param>
-        public JqGridColumnDataEvent(string type, string function, object data = null)
-        {
-            if (String.IsNullOrWhiteSpace(type))
-                throw new ArgumentNullException("type");
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnDataEvent class.
+		/// </summary>
+		/// <param name="type">The type of the event.</param>
+		/// <param name="function">The function which will be called on the event.</param>
+		/// <param name="data">The additional (optional) data for the event.</param>
+		public JqGridColumnDataEvent(string type, string function, object data = null)
+		{
+			if (string.IsNullOrWhiteSpace(type))
+				throw new ArgumentNullException(nameof(type));
 
-            if (String.IsNullOrWhiteSpace(function))
-                throw new ArgumentNullException("function");
+			if (string.IsNullOrWhiteSpace(function))
+				throw new ArgumentNullException(nameof(function));
 
-            Type = type;
-            Function = function;
-            Data = data;
-        }
-        #endregion
-    }
+			Type = type;
+			Function = function;
+			Data = data;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnEditOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnEditOptions.cs
@@ -3,83 +3,121 @@ using System.Text;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid editable column
-    /// </summary>
-    public class JqGridColumnEditOptions : JqGridColumnElementOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the name of function which is used to create custom edit element
-        /// </summary>
-        public string CustomElementFunction { get; set; }
-        
-        /// <summary>
-        /// Gets or sets the name of function which should return the value from the custom element after the editing.
-        /// </summary>
-        public string CustomValueFunction { get; set; }
+	/// <inheritdoc />
+	/// <summary>
+	/// Class which represents options for jqGrid editable column
+	/// </summary>
+	public class JqGridColumnEditOptions : JqGridColumnElementOptions
+	{
 
-        /// <summary>
-        /// Gets or sets the value which defines if null value should be send to server if the field is empty.
-        /// </summary>
-        public bool NullIfEmpty { get; set; }
+		#region Fields
+		private string _customElementFunction;
+		private string _customValueFunction;
+		private string _postDataScript;
+		private object _postData;
 
-        /// <summary>
-        /// Gets or sets the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
-        /// </summary>
-        public object PostData { get; set; }
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select). This property takes precedence over PostData.
-        /// </summary>
-        public string PostDataScript { get; set; }
+		#region Properties
 
-        /// <summary>
-        /// Gets or sets the child property name if this element performs parent role in selects cascade.
-        /// </summary>
-        public string ChildName { get; set; }
+		internal bool IsCustomElementFunctionSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the name of function which is used to create custom edit element
+		/// </summary>
+		public string CustomElementFunction
+		{
+			get => _customElementFunction;
+			set
+			{
+				_customElementFunction = value;
+				IsCustomElementFunctionSetted = true;
+			}
+		}
 
-        internal IList<JqGridColumnDataEvent> InternalDataEvents { get; private set; }
-        #endregion
+		internal bool IsCustomValueFunctionSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the name of function which should return the value from the custom element after the editing.
+		/// </summary>
+		public string CustomValueFunction
+		{
+			get => _customValueFunction;
+			set
+			{
+				_customValueFunction = value;
+				IsCustomValueFunctionSetted = true;
+			}
+		}
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnEditOptions class.
-        /// </summary>
-        public JqGridColumnEditOptions()
-        {
-            BuildSelect = null;
-            DataEvents = null;
-            DataInit = null;
-            DataUrl = null;
-            DefaultValue = null;
-            HtmlAttributes = null;
-            CustomElementFunction = null;
-            CustomValueFunction = null;
-            NullIfEmpty = false;
-            PostData = null;
-            PostDataScript = null;
-        }
-        #endregion
+		/// <summary>
+		/// Gets or sets the value which defines if null value should be send to server if the field is empty.
+		/// </summary>
+		public bool? NullIfEmpty { get; set; }
 
-        #region Methods
-        internal void ConfigureSelectsCascadeParent()
-        {
-            //Here be dragons
-            StringBuilder changeDataEventBuilder = new StringBuilder();
-            changeDataEventBuilder.Append("function() {{ var gridInstance = $('#{0}'); ");
-            changeDataEventBuilder.AppendFormat("var parentElement = $(this); var inlineEditingChildElement = $('#' + parentElement.attr('id').substring(0, parentElement.attr('id').lastIndexOf('_' + parentElement.attr('name'))) + '_{0}'); var formEditingChildElement = $('#' + '{0}'); ", ChildName);
-            changeDataEventBuilder.Append("var childColumnModel = null; var columnsModels = gridInstance.jqGrid ('getGridParam', 'colModel'); ");
-            changeDataEventBuilder.AppendFormat("for (var i = 0; i < columnsModels.length; i++) {{{{ if (columnsModels[i].name === '{0}') {{{{ childColumnModel = columnsModels[i]; break; }}}} }}}} ", ChildName);
-            changeDataEventBuilder.Append("var editOptions = $.extend({{}}, childColumnModel.editoptions || {{}} , {{ id: childColumnModel.name, name: childColumnModel.name }}); editOptions.postData = {{ parentVal: parentElement.val() }}; var childElement = null; ");
-            changeDataEventBuilder.Append("if (inlineEditingChildElement.length === 1) {{ childElement = $.jgrid.createEl.call(gridInstance, childColumnModel.edittype, editOptions, '', true, $.extend({{}}, $.jgrid.ajaxOptions, gridInstance.jqGrid ('getGridParam', 'ajaxSelectOptions') || {{}})); $(childElement).addClass('editable'); inlineEditingChildElement.replaceWith(childElement); }} ");
-            changeDataEventBuilder.Append("else if (formEditingChildElement.length === 1) {{ childElement = $.jgrid.createEl.call(gridInstance, childColumnModel.edittype, editOptions, '', false, $.extend({{}}, $.jgrid.ajaxOptions, gridInstance.jqGrid ('getGridParam', 'ajaxSelectOptions') || {{}})); $(childElement).addClass('FormElement ui-widget-content ui-corner-all'); formEditingChildElement.replaceWith(childElement); }} ");
-            changeDataEventBuilder.Append("$.jgrid.bindEv.call(gridInstance, childElement, editOptions); $(childElement).change(); }}");
+		internal bool IsPostDataSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
+		/// </summary>
+		public object PostData
+		{
+			get => _postData;
+			set
+			{
+				_postData = value;
+				IsPostDataSetted = true;
+			}
+		}
 
-            if (InternalDataEvents == null)
-                InternalDataEvents = new List<JqGridColumnDataEvent>();
-            InternalDataEvents.Add(new JqGridColumnDataEvent("change", changeDataEventBuilder.ToString()));
-        }
-        #endregion
-    }
+		internal bool IsPostDataScriptsSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select). This property takes precedence over PostData.
+		/// </summary>
+		public string PostDataScript
+		{
+			get => _postDataScript;
+			set
+			{
+				_postDataScript = value;
+				IsPostDataScriptsSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the child property name if this element performs parent role in selects cascade.
+		/// </summary>
+		public string ChildName { get; set; }
+
+		internal IList<JqGridColumnDataEvent> InternalDataEvents { get; private set; }
+		#endregion
+
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnEditOptions class.
+		/// </summary>
+		public JqGridColumnEditOptions()
+		{
+			DataEvents = null;
+			HtmlAttributes = null;
+		}
+		#endregion
+
+		#region Methods
+		internal void ConfigureSelectsCascadeParent()
+		{
+			//Here be dragons
+			var changeDataEventBuilder = new StringBuilder();
+			changeDataEventBuilder.Append("function() {{ var gridInstance = $('#{0}'); ");
+			changeDataEventBuilder.AppendFormat("var parentElement = $(this); var inlineEditingChildElement = $('#' + parentElement.attr('id').substring(0, parentElement.attr('id').lastIndexOf('_' + parentElement.attr('name'))) + '_{0}'); var formEditingChildElement = $('#' + '{0}'); ", ChildName);
+			changeDataEventBuilder.Append("var childColumnModel = null; var columnsModels = gridInstance.jqGrid ('getGridParam', 'colModel'); ");
+			changeDataEventBuilder.AppendFormat("for (var i = 0; i < columnsModels.length; i++) {{{{ if (columnsModels[i].name === '{0}') {{{{ childColumnModel = columnsModels[i]; break; }}}} }}}} ", ChildName);
+			changeDataEventBuilder.Append("var editOptions = $.extend({{}}, childColumnModel.editoptions || {{}} , {{ id: childColumnModel.name, name: childColumnModel.name }}); editOptions.postData = {{ parentVal: parentElement.val() }}; var childElement = null; ");
+			changeDataEventBuilder.Append("if (inlineEditingChildElement.length === 1) {{ childElement = $.jgrid.createEl.call(gridInstance, childColumnModel.edittype, editOptions, '', true, $.extend({{}}, $.jgrid.ajaxOptions, gridInstance.jqGrid ('getGridParam', 'ajaxSelectOptions') || {{}})); $(childElement).addClass('editable'); inlineEditingChildElement.replaceWith(childElement); }} ");
+			changeDataEventBuilder.Append("else if (formEditingChildElement.length === 1) {{ childElement = $.jgrid.createEl.call(gridInstance, childColumnModel.edittype, editOptions, '', false, $.extend({{}}, $.jgrid.ajaxOptions, gridInstance.jqGrid ('getGridParam', 'ajaxSelectOptions') || {{}})); $(childElement).addClass('FormElement ui-widget-content ui-corner-all'); formEditingChildElement.replaceWith(childElement); }} ");
+			changeDataEventBuilder.Append("$.jgrid.bindEv.call(gridInstance, childElement, editOptions); $(childElement).change(); }}");
+
+			if (InternalDataEvents == null)
+				InternalDataEvents = new List<JqGridColumnDataEvent>();
+			InternalDataEvents.Add(new JqGridColumnDataEvent("change", changeDataEventBuilder.ToString()));
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnEditOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnEditOptions.cs
@@ -3,121 +3,121 @@ using System.Text;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <inheritdoc />
-	/// <summary>
-	/// Class which represents options for jqGrid editable column
-	/// </summary>
-	public class JqGridColumnEditOptions : JqGridColumnElementOptions
-	{
+    /// <inheritdoc />
+    /// <summary>
+    /// Class which represents options for jqGrid editable column
+    /// </summary>
+    public class JqGridColumnEditOptions : JqGridColumnElementOptions
+    {
 
-		#region Fields
-		private string _customElementFunction;
-		private string _customValueFunction;
-		private string _postDataScript;
-		private object _postData;
+        #region Fields
+        private string _customElementFunction;
+        private string _customValueFunction;
+        private string _postDataScript;
+        private object _postData;
 
-		#endregion
+        #endregion
 
-		#region Properties
+        #region Properties
 
-		internal bool IsCustomElementFunctionSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the name of function which is used to create custom edit element
-		/// </summary>
-		public string CustomElementFunction
-		{
-			get => _customElementFunction;
-			set
-			{
-				_customElementFunction = value;
-				IsCustomElementFunctionSetted = true;
-			}
-		}
+        internal bool IsCustomElementFunctionSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the name of function which is used to create custom edit element
+        /// </summary>
+        public string CustomElementFunction
+        {
+            get => _customElementFunction;
+            set
+            {
+                _customElementFunction = value;
+                IsCustomElementFunctionSetted = true;
+            }
+        }
 
-		internal bool IsCustomValueFunctionSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the name of function which should return the value from the custom element after the editing.
-		/// </summary>
-		public string CustomValueFunction
-		{
-			get => _customValueFunction;
-			set
-			{
-				_customValueFunction = value;
-				IsCustomValueFunctionSetted = true;
-			}
-		}
+        internal bool IsCustomValueFunctionSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the name of function which should return the value from the custom element after the editing.
+        /// </summary>
+        public string CustomValueFunction
+        {
+            get => _customValueFunction;
+            set
+            {
+                _customValueFunction = value;
+                IsCustomValueFunctionSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the value which defines if null value should be send to server if the field is empty.
-		/// </summary>
-		public bool? NullIfEmpty { get; set; }
+        /// <summary>z
+        /// Gets or sets the value which defines if null value should be send to server if the field is empty.
+        /// </summary>
+        public bool? NullIfEmpty { get; set; }
 
-		internal bool IsPostDataSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
-		/// </summary>
-		public object PostData
-		{
-			get => _postData;
-			set
-			{
-				_postData = value;
-				IsPostDataSetted = true;
-			}
-		}
+        internal bool IsPostDataSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
+        /// </summary>
+        public object PostData
+        {
+            get => _postData;
+            set
+            {
+                _postData = value;
+                IsPostDataSetted = true;
+            }
+        }
 
-		internal bool IsPostDataScriptsSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select). This property takes precedence over PostData.
-		/// </summary>
-		public string PostDataScript
-		{
-			get => _postDataScript;
-			set
-			{
-				_postDataScript = value;
-				IsPostDataScriptsSetted = true;
-			}
-		}
+        internal bool IsPostDataScriptsSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select). This property takes precedence over PostData.
+        /// </summary>
+        public string PostDataScript
+        {
+            get => _postDataScript;
+            set
+            {
+                _postDataScript = value;
+                IsPostDataScriptsSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the child property name if this element performs parent role in selects cascade.
-		/// </summary>
-		public string ChildName { get; set; }
+        /// <summary>
+        /// Gets or sets the child property name if this element performs parent role in selects cascade.
+        /// </summary>
+        public string ChildName { get; set; }
 
-		internal IList<JqGridColumnDataEvent> InternalDataEvents { get; private set; }
-		#endregion
+        internal IList<JqGridColumnDataEvent> InternalDataEvents { get; private set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnEditOptions class.
-		/// </summary>
-		public JqGridColumnEditOptions()
-		{
-			DataEvents = null;
-			HtmlAttributes = null;
-		}
-		#endregion
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnEditOptions class.
+        /// </summary>
+        public JqGridColumnEditOptions()
+        {
+            DataEvents = null;
+            HtmlAttributes = null;
+        }
+        #endregion
 
-		#region Methods
-		internal void ConfigureSelectsCascadeParent()
-		{
-			//Here be dragons
-			var changeDataEventBuilder = new StringBuilder();
-			changeDataEventBuilder.Append("function() {{ var gridInstance = $('#{0}'); ");
-			changeDataEventBuilder.AppendFormat("var parentElement = $(this); var inlineEditingChildElement = $('#' + parentElement.attr('id').substring(0, parentElement.attr('id').lastIndexOf('_' + parentElement.attr('name'))) + '_{0}'); var formEditingChildElement = $('#' + '{0}'); ", ChildName);
-			changeDataEventBuilder.Append("var childColumnModel = null; var columnsModels = gridInstance.jqGrid ('getGridParam', 'colModel'); ");
-			changeDataEventBuilder.AppendFormat("for (var i = 0; i < columnsModels.length; i++) {{{{ if (columnsModels[i].name === '{0}') {{{{ childColumnModel = columnsModels[i]; break; }}}} }}}} ", ChildName);
-			changeDataEventBuilder.Append("var editOptions = $.extend({{}}, childColumnModel.editoptions || {{}} , {{ id: childColumnModel.name, name: childColumnModel.name }}); editOptions.postData = {{ parentVal: parentElement.val() }}; var childElement = null; ");
-			changeDataEventBuilder.Append("if (inlineEditingChildElement.length === 1) {{ childElement = $.jgrid.createEl.call(gridInstance, childColumnModel.edittype, editOptions, '', true, $.extend({{}}, $.jgrid.ajaxOptions, gridInstance.jqGrid ('getGridParam', 'ajaxSelectOptions') || {{}})); $(childElement).addClass('editable'); inlineEditingChildElement.replaceWith(childElement); }} ");
-			changeDataEventBuilder.Append("else if (formEditingChildElement.length === 1) {{ childElement = $.jgrid.createEl.call(gridInstance, childColumnModel.edittype, editOptions, '', false, $.extend({{}}, $.jgrid.ajaxOptions, gridInstance.jqGrid ('getGridParam', 'ajaxSelectOptions') || {{}})); $(childElement).addClass('FormElement ui-widget-content ui-corner-all'); formEditingChildElement.replaceWith(childElement); }} ");
-			changeDataEventBuilder.Append("$.jgrid.bindEv.call(gridInstance, childElement, editOptions); $(childElement).change(); }}");
+        #region Methods
+        internal void ConfigureSelectsCascadeParent()
+        {
+            //Here be dragons
+            StringBuilder changeDataEventBuilder = new StringBuilder();
+            changeDataEventBuilder.Append("function() {{ var gridInstance = $('#{0}'); ");
+            changeDataEventBuilder.AppendFormat("var parentElement = $(this); var inlineEditingChildElement = $('#' + parentElement.attr('id').substring(0, parentElement.attr('id').lastIndexOf('_' + parentElement.attr('name'))) + '_{0}'); var formEditingChildElement = $('#' + '{0}'); ", ChildName);
+            changeDataEventBuilder.Append("var childColumnModel = null; var columnsModels = gridInstance.jqGrid ('getGridParam', 'colModel'); ");
+            changeDataEventBuilder.AppendFormat("for (var i = 0; i < columnsModels.length; i++) {{{{ if (columnsModels[i].name === '{0}') {{{{ childColumnModel = columnsModels[i]; break; }}}} }}}} ", ChildName);
+            changeDataEventBuilder.Append("var editOptions = $.extend({{}}, childColumnModel.editoptions || {{}} , {{ id: childColumnModel.name, name: childColumnModel.name }}); editOptions.postData = {{ parentVal: parentElement.val() }}; var childElement = null; ");
+            changeDataEventBuilder.Append("if (inlineEditingChildElement.length === 1) {{ childElement = $.jgrid.createEl.call(gridInstance, childColumnModel.edittype, editOptions, '', true, $.extend({{}}, $.jgrid.ajaxOptions, gridInstance.jqGrid ('getGridParam', 'ajaxSelectOptions') || {{}})); $(childElement).addClass('editable'); inlineEditingChildElement.replaceWith(childElement); }} ");
+            changeDataEventBuilder.Append("else if (formEditingChildElement.length === 1) {{ childElement = $.jgrid.createEl.call(gridInstance, childColumnModel.edittype, editOptions, '', false, $.extend({{}}, $.jgrid.ajaxOptions, gridInstance.jqGrid ('getGridParam', 'ajaxSelectOptions') || {{}})); $(childElement).addClass('FormElement ui-widget-content ui-corner-all'); formEditingChildElement.replaceWith(childElement); }} ");
+            changeDataEventBuilder.Append("$.jgrid.bindEv.call(gridInstance, childElement, editOptions); $(childElement).change(); }}");
 
-			if (InternalDataEvents == null)
-				InternalDataEvents = new List<JqGridColumnDataEvent>();
-			InternalDataEvents.Add(new JqGridColumnDataEvent("change", changeDataEventBuilder.ToString()));
-		}
-		#endregion
-	}
+            if (InternalDataEvents == null)
+                InternalDataEvents = new List<JqGridColumnDataEvent>();
+            InternalDataEvents.Add(new JqGridColumnDataEvent("change", changeDataEventBuilder.ToString()));
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnEditTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnEditTypes.cs
@@ -1,69 +1,68 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available types of editable fields for jqGrid
-    /// </summary>
-    public enum JqGridColumnEditTypes
-    {
-        /// <summary>
-        /// Input element of type text.
-        /// </summary>
-        Text,
-        /// <summary>
-        /// Input element of type textarea.
-        /// </summary>
-        TextArea,
-        /// <summary>
-        /// Select element
-        /// </summary>
-        Select,
-        /// <summary>
-        /// Input element of type checkbox
-        /// </summary>
-        CheckBox,
-        /// <summary>
-        /// Input element of type password
-        /// </summary>
-        Password,
-        /// <summary>
-        /// Input element of type button
-        /// </summary>
-        Button,
-        /// <summary>
-        /// Input element of type image
-        /// </summary>
-        Image,
-        /// <summary>
-        /// Input element of type file
-        /// </summary>
-        File,
-        /// <summary>
-        /// Custom editable element
-        /// </summary>
-        Custom,
-        /// <summary>
-        /// jQuery UI Autocomplete widget
-        /// </summary>
-        JQueryUIAutocomplete,
-        /// <summary>
-        /// jQuery UI Datepicker widget
-        /// </summary>
-        JQueryUIDatepicker,
-        /// <summary>
-        /// jQuery UI Spinner widget
-        /// </summary>
-        JQueryUISpinner,
-        /// <summary>
-        /// Select element performing parent role in selects cascade
-        /// </summary>
-        /// <remarks>
-        /// This value is only valid in case of form and inline editing.
-        /// </remarks>
-        SelectsCascadeParent
-    }
+	/// <summary>
+	/// Defines available types of editable fields for jqGrid
+	/// </summary>
+	public enum JqGridColumnEditTypes
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Input element of type text.
+		/// </summary>
+		Text,
+		/// <summary>
+		/// Input element of type textarea.
+		/// </summary>
+		TextArea,
+		/// <summary>
+		/// Select element
+		/// </summary>
+		Select,
+		/// <summary>
+		/// Input element of type checkbox
+		/// </summary>
+		CheckBox,
+		/// <summary>
+		/// Input element of type password
+		/// </summary>
+		Password,
+		/// <summary>
+		/// Input element of type button
+		/// </summary>
+		Button,
+		/// <summary>
+		/// Input element of type image
+		/// </summary>
+		Image,
+		/// <summary>
+		/// Input element of type file
+		/// </summary>
+		File,
+		/// <summary>
+		/// Custom editable element
+		/// </summary>
+		Custom,
+		/// <summary>
+		/// jQuery UI Autocomplete widget
+		/// </summary>
+		JQueryUIAutocomplete,
+		/// <summary>
+		/// jQuery UI Datepicker widget
+		/// </summary>
+		JQueryUIDatepicker,
+		/// <summary>
+		/// jQuery UI Spinner widget
+		/// </summary>
+		JQueryUISpinner,
+		/// <summary>
+		/// Select element performing parent role in selects cascade
+		/// </summary>
+		/// <remarks>
+		/// This value is only valid in case of form and inline editing.
+		/// </remarks>
+		SelectsCascadeParent
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnEditTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnEditTypes.cs
@@ -1,68 +1,68 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available types of editable fields for jqGrid
-	/// </summary>
-	public enum JqGridColumnEditTypes
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Input element of type text.
-		/// </summary>
-		Text,
-		/// <summary>
-		/// Input element of type textarea.
-		/// </summary>
-		TextArea,
-		/// <summary>
-		/// Select element
-		/// </summary>
-		Select,
-		/// <summary>
-		/// Input element of type checkbox
-		/// </summary>
-		CheckBox,
-		/// <summary>
-		/// Input element of type password
-		/// </summary>
-		Password,
-		/// <summary>
-		/// Input element of type button
-		/// </summary>
-		Button,
-		/// <summary>
-		/// Input element of type image
-		/// </summary>
-		Image,
-		/// <summary>
-		/// Input element of type file
-		/// </summary>
-		File,
-		/// <summary>
-		/// Custom editable element
-		/// </summary>
-		Custom,
-		/// <summary>
-		/// jQuery UI Autocomplete widget
-		/// </summary>
-		JQueryUIAutocomplete,
-		/// <summary>
-		/// jQuery UI Datepicker widget
-		/// </summary>
-		JQueryUIDatepicker,
-		/// <summary>
-		/// jQuery UI Spinner widget
-		/// </summary>
-		JQueryUISpinner,
-		/// <summary>
-		/// Select element performing parent role in selects cascade
-		/// </summary>
-		/// <remarks>
-		/// This value is only valid in case of form and inline editing.
-		/// </remarks>
-		SelectsCascadeParent
-	}
+    /// <summary>
+    /// Defines available types of editable fields for jqGrid
+    /// </summary>
+    public enum JqGridColumnEditTypes
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Input element of type text.
+        /// </summary>
+        Text,
+        /// <summary>
+        /// Input element of type textarea.
+        /// </summary>
+        TextArea,
+        /// <summary>
+        /// Select element
+        /// </summary>
+        Select,
+        /// <summary>
+        /// Input element of type checkbox
+        /// </summary>
+        CheckBox,
+        /// <summary>
+        /// Input element of type password
+        /// </summary>
+        Password,
+        /// <summary>
+        /// Input element of type button
+        /// </summary>
+        Button,
+        /// <summary>
+        /// Input element of type image
+        /// </summary>
+        Image,
+        /// <summary>
+        /// Input element of type file
+        /// </summary>
+        File,
+        /// <summary>
+        /// Custom editable element
+        /// </summary>
+        Custom,
+        /// <summary>
+        /// jQuery UI Autocomplete widget
+        /// </summary>
+        JQueryUIAutocomplete,
+        /// <summary>
+        /// jQuery UI Datepicker widget
+        /// </summary>
+        JQueryUIDatepicker,
+        /// <summary>
+        /// jQuery UI Spinner widget
+        /// </summary>
+        JQueryUISpinner,
+        /// <summary>
+        /// Select element performing parent role in selects cascade
+        /// </summary>
+        /// <remarks>
+        /// This value is only valid in case of form and inline editing.
+        /// </remarks>
+        SelectsCascadeParent
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnElementOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnElementOptions.cs
@@ -10,507 +10,507 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Base class which represents options for jqGrid editable or searchable column element
-	/// </summary>
-	public abstract class JqGridColumnElementOptions
-	{
-		#region Fields
-		private static readonly char[] _invalidDateFormatTokens = { 'N', 'S', 'w', 'W', 't', 'L', 'o' };
-		private const string _ignoredDateFormatTokensRegexExpression = "[aABgGhHisueIOPTZcr]";
-		private static readonly Regex _dateFormatTokensRegex = new Regex("d|j|l|z|F|m|n|Y|U", RegexOptions.Compiled);
-		private static readonly Dictionary<string, string> _dateFormatTokensReplecements = new Dictionary<string, string> { { "d", "dd" }, { "j", "d" }, { "l", "DD" }, { "z", "o" }, { "F", "MM" }, { "m", "mm" }, { "n", "m" }, { "Y", "yy" }, { "U", "@" } };
-
-		private static readonly IDictionary<JqGridCompatibilityModes, string> _jqueryUIDatepickerDaysNamesLocalizationOptions = new Dictionary<JqGridCompatibilityModes, string>
-		{
-			{ JqGridCompatibilityModes.JqGrid, "dayNames: $.jgrid.formatter.date.dayNames.slice(7), dayNamesMin: $.jgrid.formatter.date.dayNames.slice(0, 7), dayNamesShort: $.jgrid.formatter.date.dayNames.slice(0, 7), " },
-			{ JqGridCompatibilityModes.GuriddoJqGrid, "dayNames: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(7), dayNamesMin: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(0, 7), dayNamesShort: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(0, 7), " },
-			{ JqGridCompatibilityModes.FreeJqGrid, "dayNames: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(7), dayNamesMin: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(0, 7), dayNamesShort: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(0, 7), " }
-		};
-
-		private static readonly IDictionary<JqGridCompatibilityModes, string> _jqueryUIDatepickerMonthsNamesLocalizationOptions = new Dictionary<JqGridCompatibilityModes, string>
-		{
-			{ JqGridCompatibilityModes.JqGrid, "monthNames: $.jgrid.formatter.date.monthNames.slice(12), monthNamesShort: $.jgrid.formatter.date.monthNames.slice(0, 12), " },
-			{ JqGridCompatibilityModes.GuriddoJqGrid, "monthNames: $.jgrid.getRegional($({0})[0], 'formatter.date.monthNames').slice(12), monthNamesShort: $.jgrid.getRegional($({0})[0], 'formatter.date.monthNames').slice(0, 12), " },
-			{ JqGridCompatibilityModes.FreeJqGrid, "monthNames: $({0}).jqGrid('getGridRes', 'formatter.date.monthNames').slice(12), monthNamesShort: $({0}).jqGrid('getGridRes', 'formatter.date.monthNames').slice(0, 12), " }
-		};
-
-		//Backing fields
-		private string _buildSelect;
-		private string _dataInit;
-		private string _dataUrl;
-		private string _value;
-		private string _defaultValue;
-
-		#endregion
-
-		#region Properties
-		/// <summary>
-		/// Gets or sets the text to display after each date field (jQuery UI Datepicker widget).
-		/// </summary>
-		public string AppendText { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the first item will automatically be focused when the menu is shown (jQuery UI Autocomplete widget).
-		/// </summary>
-		public bool AutoFocus { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the input field should be automatically resize to accommodate dates in the current format (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool AutoSize { get; set; }
-
-		internal bool IsBuildSelectSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function which will build the select element in case where the server response can not build it (requires DataUrl property to be set).
-		/// </summary>
-		public string BuildSelect
-		{
-			get => _buildSelect;
-			set
-			{
-				_buildSelect = value;
-				IsBuildSelectSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the month should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ChangeMonth { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the year should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ChangeYear { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the input field should constrained to characters allowed by the current format (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ConstrainInput { get; set; }
-
-		/// <summary>
-		/// Gets or sets the culture to use for parsing and formatting the value when Globalize plugin is included (jQuery UI Spinner widget).
-		/// </summary>
-		public string Culture { get; set; }
-
-		/// <summary>
-		/// Gets or sets the list of events to apply to the element (jQuery UI widgets events can also be applied this way).
-		/// </summary>
-		public IList<JqGridColumnDataEvent> DataEvents { get; set; }
-
-		internal bool IsDataInitSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function which will be called once when the element is created. This property is ignored in case of jQuery UI widgets.
-		/// </summary>
-		public string DataInit
-		{
-			get => _dataInit;
-			set
-			{
-				_dataInit = value;
-				IsDataInitSetted = true;
-			}
-		}
-
-		internal Func<JqGridCompatibilityModes, string, string> JQueryUIWidgetDataInitRenderer { get; private set; }
-
-		internal bool IsDataUrlSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the URL to get the AJAX data for the select element (if type is JqGridColumnSearchTypes/JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if type is JqGridColumnSearchTypes/JqGridColumnEditTypes.Autocomplete).
-		/// </summary>
-		public string DataUrl
-		{
-			get => _dataUrl;
-			set
-			{
-				_dataUrl = value;
-				IsDataUrlSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the format for parsed and displayed dates (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>If the value for this property is not provided, but there is a JqGridColumnFormatterAttribute with JqGridColumnPredefinedFormatters.Date formatter the helper will try to provide the value based on JqGridColumnFormatterAttribute.OutputFormat.</remarks> 
-		public string DatePickerDateFormat { get; set; }
-
-		internal bool IsDefaultValueSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the default value in the search input element.
-		/// </summary>
-		public string DefaultValue
-		{
-			get => _defaultValue;
-			set
-			{
-				_defaultValue = value;
-				IsDefaultValueSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the delay in milliseconds between when a keystroke occurs and when a search is performed (jQuery UI Autocomplete widget).
-		/// </summary>
-		public int Delay { get; set; }
-
-		/// <summary>
-		/// Gets or sets the first day of the week: Sunday is 0, Monday is 1, etc. (jQuery UI Datepicker widget).
-		/// </summary>
-		public int FirstDay { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the current day link moves to the currently selected date instead of today. (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool GotoCurrent { get; set; }
-
-		/// <summary>
-		/// Gets or sets a dictionary where keys should be valid attributes for the element.
-		/// </summary>
-		public IDictionary<string, object> HtmlAttributes { get; set; }
-
-		/// <summary>
-		/// Gets or sets value controlling the number of steps taken when holding down a spin button (jQuery UI Spinner widget).
-		/// </summary>
-		public bool Incremental { get; set; }
-
-		/// <summary>
-		/// Gets or sets maximum allowed value (jQuery UI Spinner widget).
-		/// </summary>
-		public int? Max { get; set; }
-
-		/// <summary>
-		/// Gets or sets minimum allowed value (jQuery UI Spinner widget).
-		/// </summary>
-		public int? Min { get; set; }
-
-		/// <summary>
-		/// Gets or sets the maximum selectable date. (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
-		public string MaxDate { get; set; }
-
-		/// <summary>
-		/// Gets or sets the minimum selectable date. (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
-		public string MinDate { get; set; }
-
-		/// <summary>
-		/// Gets or sets the minimum number of characters a user must type before a search is performed (jQuery UI Autocomplete widget).
-		/// </summary>
-		public int MinLength { get; set; }
-
-		/// <summary>
-		/// Gets or sets the format of numbers passed to Globalize plugin if it is included (jQuery UI Spinner widget).
-		/// </summary>
-		public string NumberFormat { get; set; }
-
-		/// <summary>
-		/// Gets or sets the number of months to show at once (jQuery UI Datepicker widget).
-		/// </summary>
-		public int NumberOfMonths { get; set; }
-
-		/// <summary>
-		/// Gets or sets the number of steps to take when paging via the pageUp/pageDown JavaScript methods (jQuery UI Spinner widget).
-		/// </summary>
-		public int Page { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating whether days in other months shown before or after the current month are selectable, this only applies if the ShowOtherMonths is set to true. (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool SelectOtherMonths { get; set; }
-
-		/// <summary>
-		/// Gets or sets the cutoff year for determining the century for a date (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>This string must be a relative number of years from the current year, e.g., "+3" or "-5".</remarks> 
-		public string ShortYearCutoff { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines position to display the current month in, if the ShowOtherMonths is set to true (jQuery UI Datepicker widget).
-		/// </summary>
-		public int ShowCurrentAtPos { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating whether to show the month after the year in the header (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ShowMonthAfterYear { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating whether to display dates in other months (non-selectable) at the start or end of the current month, to make these days selectable set the SelectOtherMonths to true (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ShowOtherMonths { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating whether to add column with the week of the year (jQuery UI Datepicker widget).
-		/// </summary>
-		public bool ShowWeek { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines how many months to move when clicking the previous/next links (jQuery UI Datepicker widget).
-		/// </summary>
-		public int StepMonths { get; set; }
-
-		/// <summary>
-		/// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget down button.
-		/// </summary>
-		public string SpinnerDownIcon { get; set; }
-
-		/// <summary>
-		/// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget up button.
-		/// </summary>
-		public string SpinnerUpIcon { get; set; }
-
-		/// <summary>
-		/// Gets or sets the size of the step to take when spinning via buttons or via the stepUp/stepDown JavaScript methods (jQuery UI Spinner widget).
-		/// </summary>
-		public int Step { get; set; }
-
-		internal bool IsValueSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the set of value:label pairs for select element (takes precedence over ValueDictionary property).
-		/// </summary>
-		public string Value
-		{
-			get => _value;
-			set
-			{
-				_value = value;
-				IsValueSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element.
-		/// </summary>
-		public IDictionary<string, string> ValueDictionary { get; set; }
-
-		/// <summary>
-		/// Gets or sets the range of years displayed in the year dropdown (jQuery UI Datepicker widget).
-		/// </summary>
-		/// <remarks>This string must be either relative to today's year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). Note that this option only affects what appears in the dropdown, to restrict which dates may be selected use the MinDate and/or MaxDate.</remarks> 
-		public string YearRange { get; set; }
-
-		/// <summary>
-		/// Gets or sets the additional text to display after the year in the month headers (jQuery UI Datepicker widget).
-		/// </summary>
-		public string YearSuffix { get; set; }
-		#endregion
-
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnElementOptions class.
-		/// </summary>
-		protected JqGridColumnElementOptions()
-		{
-			AppendText = null;
-			AutoFocus = false;
-			AutoSize = false;
-			ChangeMonth = false;
-			ChangeYear = false;
-			ConstrainInput = true;
-			Culture = null;
-			DatePickerDateFormat = JQueryUIWidgetsDefaults.DatepickerDateFormat;
-			Delay = 300;
-			FirstDay = 0;
-			GotoCurrent = false;
-			Incremental = true;
-			JQueryUIWidgetDataInitRenderer = null;
-			Max = null;
-			Min = null;
-			MinLength = 1;
-			NumberFormat = null;
-			NumberOfMonths = 1;
-			Page = 10;
-			SelectOtherMonths = false;
-			ShortYearCutoff = JQueryUIWidgetsDefaults.DatepickerShortYearCutoff;
-			ShowCurrentAtPos = 0;
-			ShowMonthAfterYear = false;
-			ShowOtherMonths = false;
-			ShowWeek = false;
-			SpinnerDownIcon = JQueryUIWidgetsDefaults.SpinnerDownIcon;
-			SpinnerUpIcon = JQueryUIWidgetsDefaults.SpinnerUpIcon;
-			Step = 1;
-			StepMonths = 1;
-			YearRange = JQueryUIWidgetsDefaults.DatepickerYearRange;
-			YearSuffix = string.Empty;
-		}
-		#endregion
-
-		#region Methods
-		private string JQueryUIAutocompleteDataInitRenderer(string dataUrl)
-		{
-			var dataInitBuilder = new StringBuilder(100 + DataUrl.Length);
-			dataInitBuilder.AppendFormat("function(element) {{ setTimeout(function() {{ $(element).autocomplete({{ source: '{0}', ", dataUrl);
-
-			if (AutoFocus)
-				dataInitBuilder.Append("autoFocus: true, ");
-
-			if (Delay != 300)
-				dataInitBuilder.AppendFormat("delay: {0}, ", Delay);
-
-			if (MinLength != 1)
-				dataInitBuilder.AppendFormat("minLength: {0}, ", MinLength);
-
-			dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
-			dataInitBuilder.Append(" }); }, 0); }");
-
-			return dataInitBuilder.ToString();
-		}
-
-		internal void ConfigureJQueryUIAutocomplete()
-		{
-			var dataUrl = DataUrl;
-			JQueryUIWidgetDataInitRenderer = (compatibilityMode, gridSelector) => JQueryUIAutocompleteDataInitRenderer(dataUrl);
-
-			DataUrl = string.Empty;
-			DataInit = null;
-		}
-
-		private string JQueryUIDatepickerDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector, ModelMetadata propertyMetadata)
-		{
-			var dataInitBuilder = new StringBuilder(80);
-			dataInitBuilder.Append("function(element) { setTimeout(function() { $(element).datepicker({ ");
-
-			if (!string.IsNullOrEmpty(AppendText))
-				dataInitBuilder.AppendFormat("appendText: '{0}', ", AppendText);
-
-			if (AutoSize)
-				dataInitBuilder.Append("autoSize: true, ");
-
-			if (ChangeMonth)
-				dataInitBuilder.Append("changeMonth: true, ");
-
-			if (ChangeYear)
-				dataInitBuilder.Append("changeYear: true, ");
-
-			if (!ConstrainInput)
-				dataInitBuilder.Append("constrainInput: true, ");
-
-			if (DatePickerDateFormat == JQueryUIWidgetsDefaults.DatepickerDateFormat)
-			{
-				var customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
-				var formatterAttribute = customAttributes.OfType<JqGridColumnFormatterAttribute>().FirstOrDefault();
-
-				if (formatterAttribute != null && formatterAttribute.Formatter == JqGridColumnPredefinedFormatters.Date && formatterAttribute.OutputFormat != JqGridOptionsDefaults.FormatterOutputFormat && formatterAttribute.OutputFormat.IndexOfAny(_invalidDateFormatTokens) == -1)
-				{
-					DatePickerDateFormat = Regex.Replace(formatterAttribute.OutputFormat, _ignoredDateFormatTokensRegexExpression, string.Empty);
-					DatePickerDateFormat = _dateFormatTokensRegex.Replace(DatePickerDateFormat, match => _dateFormatTokensReplecements[match.Value]);
-				}
-			}
-			dataInitBuilder.AppendFormat("dateFormat: '{0}', ", DatePickerDateFormat);
-			dataInitBuilder.AppendFormat(_jqueryUIDatepickerDaysNamesLocalizationOptions[compatibilityMode], gridSelector);
-
-			if (FirstDay != 0)
-				dataInitBuilder.AppendFormat("firstDay: {0}, ", FirstDay);
-
-			if (GotoCurrent)
-				dataInitBuilder.Append("gotoCurrent: true, ");
-
-			if (!string.IsNullOrEmpty(MaxDate))
-				dataInitBuilder.AppendFormat("maxDate: '{0}', ", MaxDate);
-
-			if (!string.IsNullOrEmpty(MinDate))
-				dataInitBuilder.AppendFormat("minDate: '{0}', ", MinDate);
-
-			dataInitBuilder.AppendFormat(_jqueryUIDatepickerMonthsNamesLocalizationOptions[compatibilityMode], gridSelector);
-
-			if (NumberOfMonths != 1)
-				dataInitBuilder.AppendFormat("numberOfMonths: {0}, ", NumberOfMonths);
-
-			if (SelectOtherMonths)
-				dataInitBuilder.Append("selectOtherMonths: true, ");
-
-			if (ShortYearCutoff != JQueryUIWidgetsDefaults.DatepickerShortYearCutoff)
-				dataInitBuilder.AppendFormat("shortYearCutoff: '{0}', ", ShortYearCutoff);
-
-			if (ShowCurrentAtPos != 0)
-				dataInitBuilder.AppendFormat("showCurrentAtPos: {0}, ", ShowCurrentAtPos);
-
-			if (ShowMonthAfterYear)
-				dataInitBuilder.Append("showMonthAfterYear: true, ");
-
-			if (ShowOtherMonths)
-				dataInitBuilder.Append("showOtherMonths: true, ");
-
-			if (ShowWeek)
-				dataInitBuilder.Append("showWeek: true, ");
-
-			if (StepMonths != 1)
-				dataInitBuilder.AppendFormat("stepMonths: {0}, ", StepMonths);
-
-			if (YearRange != JQueryUIWidgetsDefaults.DatepickerYearRange)
-				dataInitBuilder.AppendFormat("yearRange: '{0}', ", YearRange);
-
-			if (!string.IsNullOrEmpty(YearSuffix))
-				dataInitBuilder.AppendFormat("yearSuffix: '{0}', ", YearSuffix);
-
-			dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
-			dataInitBuilder.Append(" }); }, 0); }");
-
-			return dataInitBuilder.ToString();
-		}
-
-		internal void ConfigureJQueryUIDatepicker(ModelMetadata propertyMetadata)
-		{
-			JQueryUIWidgetDataInitRenderer = (compatibilityMode, gridSelector) => JQueryUIDatepickerDataInitRenderer(compatibilityMode, gridSelector, propertyMetadata);
-
-			DataInit = null;
-		}
-
-		private string JQueryUISpinnerDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector)
-		{
-			var dataInitBuilder = new StringBuilder(80);
-			dataInitBuilder.Append("function(element) { setTimeout(function() { $(element).spinner({ ");
-
-			if (!string.IsNullOrEmpty(Culture))
-				dataInitBuilder.AppendFormat("culture: '{0}', ", Culture);
-
-			if (SpinnerDownIcon != JQueryUIWidgetsDefaults.SpinnerDownIcon || SpinnerUpIcon != JQueryUIWidgetsDefaults.SpinnerUpIcon)
-			{
-				dataInitBuilder.Append("icons: { ");
-
-				if (SpinnerDownIcon != JQueryUIWidgetsDefaults.SpinnerDownIcon)
-					dataInitBuilder.AppendFormat("down: '{0}', ", SpinnerDownIcon);
-
-				if (SpinnerUpIcon != JQueryUIWidgetsDefaults.SpinnerUpIcon)
-					dataInitBuilder.AppendFormat("up: '{0}', ", SpinnerUpIcon);
-
-				dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
-				dataInitBuilder.Append(" }, ");
-			}
-
-			if (!Incremental)
-				dataInitBuilder.Append("incremental: false, ");
-
-			if (Max.HasValue)
-				dataInitBuilder.AppendFormat("max: {0}, ", Max.Value);
-
-			if (Min.HasValue)
-				dataInitBuilder.AppendFormat("min: {0}, ", Min.Value);
-
-			if (!string.IsNullOrEmpty(NumberFormat))
-				dataInitBuilder.AppendFormat("numberFormat: '{0}', ", NumberFormat);
-
-			if (Page != 10)
-				dataInitBuilder.AppendFormat("page: {0}, ", Page);
-
-			if (Step != 1)
-				dataInitBuilder.AppendFormat("step: {0}, ", Step);
-
-			dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
-			dataInitBuilder.Append(dataInitBuilder[dataInitBuilder.Length - 1] == '(' ? "); }, 0); }" : " }); }, 0); }");
-
-			return dataInitBuilder.ToString();
-		}
-
-		internal void ConfigureJQueryUISpinner()
-		{
-			JQueryUIWidgetDataInitRenderer = JQueryUISpinnerDataInitRenderer;
-
-			DataInit = null;
-		}
-		#endregion
-	}
+    /// <summary>
+    /// Base class which represents options for jqGrid editable or searchable column element
+    /// </summary>
+    public abstract class JqGridColumnElementOptions
+    {
+        #region Fields
+        private static readonly char[] _invalidDateFormatTokens = { 'N', 'S', 'w', 'W', 't', 'L', 'o' };
+        private const string _ignoredDateFormatTokensRegexExpression = "[aABgGhHisueIOPTZcr]";
+        private static readonly Regex _dateFormatTokensRegex = new Regex("d|j|l|z|F|m|n|Y|U", RegexOptions.Compiled);
+        private static readonly Dictionary<string, string> _dateFormatTokensReplecements = new Dictionary<string, string> { { "d", "dd" }, { "j", "d" }, { "l", "DD" }, { "z", "o" }, { "F", "MM" }, { "m", "mm" }, { "n", "m" }, { "Y", "yy" }, { "U", "@" } };
+
+        private static readonly IDictionary<JqGridCompatibilityModes, string> _jqueryUIDatepickerDaysNamesLocalizationOptions = new Dictionary<JqGridCompatibilityModes, string>
+        {
+            { JqGridCompatibilityModes.JqGrid, "dayNames: $.jgrid.formatter.date.dayNames.slice(7), dayNamesMin: $.jgrid.formatter.date.dayNames.slice(0, 7), dayNamesShort: $.jgrid.formatter.date.dayNames.slice(0, 7), " },
+            { JqGridCompatibilityModes.GuriddoJqGrid, "dayNames: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(7), dayNamesMin: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(0, 7), dayNamesShort: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(0, 7), " },
+            { JqGridCompatibilityModes.FreeJqGrid, "dayNames: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(7), dayNamesMin: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(0, 7), dayNamesShort: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(0, 7), " }
+        };
+
+        private static readonly IDictionary<JqGridCompatibilityModes, string> _jqueryUIDatepickerMonthsNamesLocalizationOptions = new Dictionary<JqGridCompatibilityModes, string>
+        {
+            { JqGridCompatibilityModes.JqGrid, "monthNames: $.jgrid.formatter.date.monthNames.slice(12), monthNamesShort: $.jgrid.formatter.date.monthNames.slice(0, 12), " },
+            { JqGridCompatibilityModes.GuriddoJqGrid, "monthNames: $.jgrid.getRegional($({0})[0], 'formatter.date.monthNames').slice(12), monthNamesShort: $.jgrid.getRegional($({0})[0], 'formatter.date.monthNames').slice(0, 12), " },
+            { JqGridCompatibilityModes.FreeJqGrid, "monthNames: $({0}).jqGrid('getGridRes', 'formatter.date.monthNames').slice(12), monthNamesShort: $({0}).jqGrid('getGridRes', 'formatter.date.monthNames').slice(0, 12), " }
+        };
+
+        //Backing fields
+        private string _buildSelect;
+        private string _dataInit;
+        private string _dataUrl;
+        private string _value;
+        private string _defaultValue;
+
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// Gets or sets the text to display after each date field (jQuery UI Datepicker widget).
+        /// </summary>
+        public string AppendText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the first item will automatically be focused when the menu is shown (jQuery UI Autocomplete widget).
+        /// </summary>
+        public bool AutoFocus { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the input field should be automatically resize to accommodate dates in the current format (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool AutoSize { get; set; }
+
+        internal bool IsBuildSelectSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function which will build the select element in case where the server response can not build it (requires DataUrl property to be set).
+        /// </summary>
+        public string BuildSelect
+        {
+            get => _buildSelect;
+            set
+            {
+                _buildSelect = value;
+                IsBuildSelectSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the month should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ChangeMonth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the year should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ChangeYear { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the input field should constrained to characters allowed by the current format (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ConstrainInput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the culture to use for parsing and formatting the value when Globalize plugin is included (jQuery UI Spinner widget).
+        /// </summary>
+        public string Culture { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of events to apply to the element (jQuery UI widgets events can also be applied this way).
+        /// </summary>
+        public IList<JqGridColumnDataEvent> DataEvents { get; set; }
+
+        internal bool IsDataInitSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function which will be called once when the element is created. This property is ignored in case of jQuery UI widgets.
+        /// </summary>
+        public string DataInit
+        {
+            get => _dataInit;
+            set
+            {
+                _dataInit = value;
+                IsDataInitSetted = true;
+            }
+        }
+
+        internal Func<JqGridCompatibilityModes, string, string> JQueryUIWidgetDataInitRenderer { get; private set; }
+
+        internal bool IsDataUrlSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the URL to get the AJAX data for the select element (if type is JqGridColumnSearchTypes/JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if type is JqGridColumnSearchTypes/JqGridColumnEditTypes.Autocomplete).
+        /// </summary>
+        public string DataUrl
+        {
+            get => _dataUrl;
+            set
+            {
+                _dataUrl = value;
+                IsDataUrlSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the format for parsed and displayed dates (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>If the value for this property is not provided, but there is a JqGridColumnFormatterAttribute with JqGridColumnPredefinedFormatters.Date formatter the helper will try to provide the value based on JqGridColumnFormatterAttribute.OutputFormat.</remarks> 
+        public string DatePickerDateFormat { get; set; }
+
+        internal bool IsDefaultValueSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the default value in the search input element.
+        /// </summary>
+        public string DefaultValue
+        {
+            get => _defaultValue;
+            set
+            {
+                _defaultValue = value;
+                IsDefaultValueSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the delay in milliseconds between when a keystroke occurs and when a search is performed (jQuery UI Autocomplete widget).
+        /// </summary>
+        public int Delay { get; set; }
+
+        /// <summary>
+        /// Gets or sets the first day of the week: Sunday is 0, Monday is 1, etc. (jQuery UI Datepicker widget).
+        /// </summary>
+        public int FirstDay { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the current day link moves to the currently selected date instead of today. (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool GotoCurrent { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary where keys should be valid attributes for the element.
+        /// </summary>
+        public IDictionary<string, object> HtmlAttributes { get; set; }
+
+        /// <summary>
+        /// Gets or sets value controlling the number of steps taken when holding down a spin button (jQuery UI Spinner widget).
+        /// </summary>
+        public bool Incremental { get; set; }
+
+        /// <summary>
+        /// Gets or sets maximum allowed value (jQuery UI Spinner widget).
+        /// </summary>
+        public int? Max { get; set; }
+
+        /// <summary>
+        /// Gets or sets minimum allowed value (jQuery UI Spinner widget).
+        /// </summary>
+        public int? Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum selectable date. (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
+        public string MaxDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum selectable date. (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
+        public string MinDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum number of characters a user must type before a search is performed (jQuery UI Autocomplete widget).
+        /// </summary>
+        public int MinLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format of numbers passed to Globalize plugin if it is included (jQuery UI Spinner widget).
+        /// </summary>
+        public string NumberFormat { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of months to show at once (jQuery UI Datepicker widget).
+        /// </summary>
+        public int NumberOfMonths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of steps to take when paging via the pageUp/pageDown JavaScript methods (jQuery UI Spinner widget).
+        /// </summary>
+        public int Page { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether days in other months shown before or after the current month are selectable, this only applies if the ShowOtherMonths is set to true. (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool SelectOtherMonths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cutoff year for determining the century for a date (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>This string must be a relative number of years from the current year, e.g., "+3" or "-5".</remarks> 
+        public string ShortYearCutoff { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines position to display the current month in, if the ShowOtherMonths is set to true (jQuery UI Datepicker widget).
+        /// </summary>
+        public int ShowCurrentAtPos { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to show the month after the year in the header (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ShowMonthAfterYear { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to display dates in other months (non-selectable) at the start or end of the current month, to make these days selectable set the SelectOtherMonths to true (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ShowOtherMonths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to add column with the week of the year (jQuery UI Datepicker widget).
+        /// </summary>
+        public bool ShowWeek { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines how many months to move when clicking the previous/next links (jQuery UI Datepicker widget).
+        /// </summary>
+        public int StepMonths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget down button.
+        /// </summary>
+        public string SpinnerDownIcon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget up button.
+        /// </summary>
+        public string SpinnerUpIcon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the step to take when spinning via buttons or via the stepUp/stepDown JavaScript methods (jQuery UI Spinner widget).
+        /// </summary>
+        public int Step { get; set; }
+
+        internal bool IsValueSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the set of value:label pairs for select element (takes precedence over ValueDictionary property).
+        /// </summary>
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                IsValueSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element.
+        /// </summary>
+        public IDictionary<string, string> ValueDictionary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the range of years displayed in the year dropdown (jQuery UI Datepicker widget).
+        /// </summary>
+        /// <remarks>This string must be either relative to today's year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). Note that this option only affects what appears in the dropdown, to restrict which dates may be selected use the MinDate and/or MaxDate.</remarks> 
+        public string YearRange { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional text to display after the year in the month headers (jQuery UI Datepicker widget).
+        /// </summary>
+        public string YearSuffix { get; set; }
+        #endregion
+
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnElementOptions class.
+        /// </summary>
+        protected JqGridColumnElementOptions()
+        {
+            AppendText = null;
+            AutoFocus = false;
+            AutoSize = false;
+            ChangeMonth = false;
+            ChangeYear = false;
+            ConstrainInput = true;
+            Culture = null;
+            DatePickerDateFormat = JQueryUIWidgetsDefaults.DatepickerDateFormat;
+            Delay = 300;
+            FirstDay = 0;
+            GotoCurrent = false;
+            Incremental = true;
+            JQueryUIWidgetDataInitRenderer = null;
+            Max = null;
+            Min = null;
+            MinLength = 1;
+            NumberFormat = null;
+            NumberOfMonths = 1;
+            Page = 10;
+            SelectOtherMonths = false;
+            ShortYearCutoff = JQueryUIWidgetsDefaults.DatepickerShortYearCutoff;
+            ShowCurrentAtPos = 0;
+            ShowMonthAfterYear = false;
+            ShowOtherMonths = false;
+            ShowWeek = false;
+            SpinnerDownIcon = JQueryUIWidgetsDefaults.SpinnerDownIcon;
+            SpinnerUpIcon = JQueryUIWidgetsDefaults.SpinnerUpIcon;
+            Step = 1;
+            StepMonths = 1;
+            YearRange = JQueryUIWidgetsDefaults.DatepickerYearRange;
+            YearSuffix = string.Empty;
+        }
+        #endregion
+
+        #region Methods
+        private string JQueryUIAutocompleteDataInitRenderer(string dataUrl)
+        {
+            StringBuilder dataInitBuilder = new StringBuilder(100 + DataUrl.Length);
+            dataInitBuilder.AppendFormat("function(element) {{ setTimeout(function() {{ $(element).autocomplete({{ source: '{0}', ", dataUrl);
+
+            if (AutoFocus)
+                dataInitBuilder.Append("autoFocus: true, ");
+
+            if (Delay != 300)
+                dataInitBuilder.AppendFormat("delay: {0}, ", Delay);
+
+            if (MinLength != 1)
+                dataInitBuilder.AppendFormat("minLength: {0}, ", MinLength);
+
+            dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
+            dataInitBuilder.Append(" }); }, 0); }");
+
+            return dataInitBuilder.ToString();
+        }
+
+        internal void ConfigureJQueryUIAutocomplete()
+        {
+            string dataUrl = DataUrl;
+            JQueryUIWidgetDataInitRenderer = (compatibilityMode, gridSelector) => JQueryUIAutocompleteDataInitRenderer(dataUrl);
+
+            DataUrl = string.Empty;
+            DataInit = null;
+        }
+
+        private string JQueryUIDatepickerDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector, ModelMetadata propertyMetadata)
+        {
+            StringBuilder dataInitBuilder = new StringBuilder(80);
+            dataInitBuilder.Append("function(element) { setTimeout(function() { $(element).datepicker({ ");
+
+            if (!string.IsNullOrEmpty(AppendText))
+                dataInitBuilder.AppendFormat("appendText: '{0}', ", AppendText);
+
+            if (AutoSize)
+                dataInitBuilder.Append("autoSize: true, ");
+
+            if (ChangeMonth)
+                dataInitBuilder.Append("changeMonth: true, ");
+
+            if (ChangeYear)
+                dataInitBuilder.Append("changeYear: true, ");
+
+            if (!ConstrainInput)
+                dataInitBuilder.Append("constrainInput: true, ");
+
+            if (DatePickerDateFormat == JQueryUIWidgetsDefaults.DatepickerDateFormat)
+            {
+                IEnumerable<object> customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
+                JqGridColumnFormatterAttribute formatterAttribute = customAttributes.OfType<JqGridColumnFormatterAttribute>().FirstOrDefault();
+
+                if (formatterAttribute != null && formatterAttribute.Formatter == JqGridColumnPredefinedFormatters.Date && formatterAttribute.OutputFormat != JqGridOptionsDefaults.FormatterOutputFormat && formatterAttribute.OutputFormat.IndexOfAny(_invalidDateFormatTokens) == -1)
+                {
+                    DatePickerDateFormat = Regex.Replace(formatterAttribute.OutputFormat, _ignoredDateFormatTokensRegexExpression, string.Empty);
+                    DatePickerDateFormat = _dateFormatTokensRegex.Replace(DatePickerDateFormat, match => _dateFormatTokensReplecements[match.Value]);
+                }
+            }
+            dataInitBuilder.AppendFormat("dateFormat: '{0}', ", DatePickerDateFormat);
+            dataInitBuilder.AppendFormat(_jqueryUIDatepickerDaysNamesLocalizationOptions[compatibilityMode], gridSelector);
+
+            if (FirstDay != 0)
+                dataInitBuilder.AppendFormat("firstDay: {0}, ", FirstDay);
+
+            if (GotoCurrent)
+                dataInitBuilder.Append("gotoCurrent: true, ");
+
+            if (!string.IsNullOrEmpty(MaxDate))
+                dataInitBuilder.AppendFormat("maxDate: '{0}', ", MaxDate);
+
+            if (!string.IsNullOrEmpty(MinDate))
+                dataInitBuilder.AppendFormat("minDate: '{0}', ", MinDate);
+
+            dataInitBuilder.AppendFormat(_jqueryUIDatepickerMonthsNamesLocalizationOptions[compatibilityMode], gridSelector);
+
+            if (NumberOfMonths != 1)
+                dataInitBuilder.AppendFormat("numberOfMonths: {0}, ", NumberOfMonths);
+
+            if (SelectOtherMonths)
+                dataInitBuilder.Append("selectOtherMonths: true, ");
+
+            if (ShortYearCutoff != JQueryUIWidgetsDefaults.DatepickerShortYearCutoff)
+                dataInitBuilder.AppendFormat("shortYearCutoff: '{0}', ", ShortYearCutoff);
+
+            if (ShowCurrentAtPos != 0)
+                dataInitBuilder.AppendFormat("showCurrentAtPos: {0}, ", ShowCurrentAtPos);
+
+            if (ShowMonthAfterYear)
+                dataInitBuilder.Append("showMonthAfterYear: true, ");
+
+            if (ShowOtherMonths)
+                dataInitBuilder.Append("showOtherMonths: true, ");
+
+            if (ShowWeek)
+                dataInitBuilder.Append("showWeek: true, ");
+
+            if (StepMonths != 1)
+                dataInitBuilder.AppendFormat("stepMonths: {0}, ", StepMonths);
+
+            if (YearRange != JQueryUIWidgetsDefaults.DatepickerYearRange)
+                dataInitBuilder.AppendFormat("yearRange: '{0}', ", YearRange);
+
+            if (!string.IsNullOrEmpty(YearSuffix))
+                dataInitBuilder.AppendFormat("yearSuffix: '{0}', ", YearSuffix);
+
+            dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
+            dataInitBuilder.Append(" }); }, 0); }");
+
+            return dataInitBuilder.ToString();
+        }
+
+        internal void ConfigureJQueryUIDatepicker(ModelMetadata propertyMetadata)
+        {
+            JQueryUIWidgetDataInitRenderer = (compatibilityMode, gridSelector) => JQueryUIDatepickerDataInitRenderer(compatibilityMode, gridSelector, propertyMetadata);
+
+            DataInit = null;
+        }
+
+        private string JQueryUISpinnerDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector)
+        {
+            StringBuilder dataInitBuilder = new StringBuilder(80);
+            dataInitBuilder.Append("function(element) { setTimeout(function() { $(element).spinner({ ");
+
+            if (!string.IsNullOrEmpty(Culture))
+                dataInitBuilder.AppendFormat("culture: '{0}', ", Culture);
+
+            if (SpinnerDownIcon != JQueryUIWidgetsDefaults.SpinnerDownIcon || SpinnerUpIcon != JQueryUIWidgetsDefaults.SpinnerUpIcon)
+            {
+                dataInitBuilder.Append("icons: { ");
+
+                if (SpinnerDownIcon != JQueryUIWidgetsDefaults.SpinnerDownIcon)
+                    dataInitBuilder.AppendFormat("down: '{0}', ", SpinnerDownIcon);
+
+                if (SpinnerUpIcon != JQueryUIWidgetsDefaults.SpinnerUpIcon)
+                    dataInitBuilder.AppendFormat("up: '{0}', ", SpinnerUpIcon);
+
+                dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
+                dataInitBuilder.Append(" }, ");
+            }
+
+            if (!Incremental)
+                dataInitBuilder.Append("incremental: false, ");
+
+            if (Max.HasValue)
+                dataInitBuilder.AppendFormat("max: {0}, ", Max.Value);
+
+            if (Min.HasValue)
+                dataInitBuilder.AppendFormat("min: {0}, ", Min.Value);
+
+            if (!string.IsNullOrEmpty(NumberFormat))
+                dataInitBuilder.AppendFormat("numberFormat: '{0}', ", NumberFormat);
+
+            if (Page != 10)
+                dataInitBuilder.AppendFormat("page: {0}, ", Page);
+
+            if (Step != 1)
+                dataInitBuilder.AppendFormat("step: {0}, ", Step);
+
+            dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
+            dataInitBuilder.Append(dataInitBuilder[dataInitBuilder.Length - 1] == '(' ? "); }, 0); }" : " }); }, 0); }");
+
+            return dataInitBuilder.ToString();
+        }
+
+        internal void ConfigureJQueryUISpinner()
+        {
+            JQueryUIWidgetDataInitRenderer = JQueryUISpinnerDataInitRenderer;
+
+            DataInit = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnElementOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnElementOptions.cs
@@ -6,462 +6,511 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web.Mvc;
+// ReSharper disable InconsistentNaming
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Base class which represents options for jqGrid editable or searchable column element
-    /// </summary>
-    public abstract class JqGridColumnElementOptions
-    {
-        #region Fields
-        private static char[] _invalidDateFormatTokens = new char[] { 'N', 'S', 'w', 'W', 't', 'L', 'o' };
-        private const string _ignoredDateFormatTokensRegexExpression = "[aABgGhHisueIOPTZcr]";
-        private static Regex _dateFormatTokensRegex = new Regex("d|j|l|z|F|m|n|Y|U", RegexOptions.Compiled);
-        private static Dictionary<string, string> _dateFormatTokensReplecements = new Dictionary<string, string> { { "d", "dd" }, { "j", "d" }, { "l", "DD" }, { "z", "o" }, { "F", "MM" }, { "m", "mm" }, { "n", "m" }, { "Y", "yy" }, { "U", "@" } };
-        private static DateTime _unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-        private readonly static IDictionary<JqGridCompatibilityModes, string> _jqueryUIDatepickerDaysNamesLocalizationOptions = new Dictionary<JqGridCompatibilityModes, string>
-        {
-            { JqGridCompatibilityModes.JqGrid, "dayNames: $.jgrid.formatter.date.dayNames.slice(7), dayNamesMin: $.jgrid.formatter.date.dayNames.slice(0, 7), dayNamesShort: $.jgrid.formatter.date.dayNames.slice(0, 7), " },
-            { JqGridCompatibilityModes.GuriddoJqGrid, "dayNames: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(7), dayNamesMin: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(0, 7), dayNamesShort: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(0, 7), " },
-            { JqGridCompatibilityModes.FreeJqGrid, "dayNames: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(7), dayNamesMin: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(0, 7), dayNamesShort: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(0, 7), " }
-        };
-
-        private readonly static IDictionary<JqGridCompatibilityModes, string> _jqueryUIDatepickerMonthsNamesLocalizationOptions = new Dictionary<JqGridCompatibilityModes, string>
-        {
-            { JqGridCompatibilityModes.JqGrid, "monthNames: $.jgrid.formatter.date.monthNames.slice(12), monthNamesShort: $.jgrid.formatter.date.monthNames.slice(0, 12), " },
-            { JqGridCompatibilityModes.GuriddoJqGrid, "monthNames: $.jgrid.getRegional($({0})[0], 'formatter.date.monthNames').slice(12), monthNamesShort: $.jgrid.getRegional($({0})[0], 'formatter.date.monthNames').slice(0, 12), " },
-            { JqGridCompatibilityModes.FreeJqGrid, "monthNames: $({0}).jqGrid('getGridRes', 'formatter.date.monthNames').slice(12), monthNamesShort: $({0}).jqGrid('getGridRes', 'formatter.date.monthNames').slice(0, 12), " }
-        };
-        #endregion
-
-        #region Properties
-        /// <summary>
-        /// Gets or sets the text to display after each date field (jQuery UI Datepicker widget).
-        /// </summary>
-        public string AppendText { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the first item will automatically be focused when the menu is shown (jQuery UI Autocomplete widget).
-        /// </summary>
-        public bool AutoFocus { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the input field should be automatically resize to accommodate dates in the current format (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool AutoSize { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function which will build the select element in case where the server response can not build it (requires DataUrl property to be set).
-        /// </summary>
-        public string BuildSelect { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the month should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ChangeMonth { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the year should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ChangeYear { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the input field should constrained to characters allowed by the current format (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ConstrainInput { get; set; }
-
-        /// <summary>
-        /// Gets or sets the culture to use for parsing and formatting the value when Globalize plugin is included (jQuery UI Spinner widget).
-        /// </summary>
-        public string Culture { get; set; }
-
-        /// <summary>
-        /// Gets or sets the list of events to apply to the element (jQuery UI widgets events can also be applied this way).
-        /// </summary>
-        public IList<JqGridColumnDataEvent> DataEvents { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function which will be called once when the element is created. This property is ignored in case of jQuery UI widgets.
-        /// </summary>
-        public string DataInit { get; set; }
-
-        internal Func<JqGridCompatibilityModes, string, string> JQueryUIWidgetDataInitRenderer { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the URL to get the AJAX data for the select element (if type is JqGridColumnSearchTypes/JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if type is JqGridColumnSearchTypes/JqGridColumnEditTypes.Autocomplete).
-        /// </summary>
-        public string DataUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the format for parsed and displayed dates (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>If the value for this property is not provided, but there is a JqGridColumnFormatterAttribute with JqGridColumnPredefinedFormatters.Date formatter the helper will try to provide the value based on JqGridColumnFormatterAttribute.OutputFormat.</remarks> 
-        public string DatePickerDateFormat { get; set; }
-
-        /// <summary>
-        /// Gets or sets the default value in the search input element.
-        /// </summary>
-        public string DefaultValue { get; set; }
-
-        /// <summary>
-        /// Gets or sets the delay in milliseconds between when a keystroke occurs and when a search is performed (jQuery UI Autocomplete widget).
-        /// </summary>
-        public int Delay { get; set; }
-
-        /// <summary>
-        /// Gets or sets the first day of the week: Sunday is 0, Monday is 1, etc. (jQuery UI Datepicker widget).
-        /// </summary>
-        public int FirstDay { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the current day link moves to the currently selected date instead of today. (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool GotoCurrent { get; set; }
-
-        /// <summary>
-        /// Gets or sets a dictionary where keys should be valid attributes for the element.
-        /// </summary>
-        public IDictionary<string, object> HtmlAttributes { get; set; }
-
-        /// <summary>
-        /// Gets or sets value controlling the number of steps taken when holding down a spin button (jQuery UI Spinner widget).
-        /// </summary>
-        public bool Incremental { get; set; }
-
-        /// <summary>
-        /// Gets or sets maximum allowed value (jQuery UI Spinner widget).
-        /// </summary>
-        public int? Max { get; set; }
-
-        /// <summary>
-        /// Gets or sets minimum allowed value (jQuery UI Spinner widget).
-        /// </summary>
-        public int? Min { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum selectable date. (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
-        public string MaxDate { get; set; }
-
-        /// <summary>
-        /// Gets or sets the minimum selectable date. (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
-        public string MinDate { get; set; }
-
-        /// <summary>
-        /// Gets or sets the minimum number of characters a user must type before a search is performed (jQuery UI Autocomplete widget).
-        /// </summary>
-        public int MinLength { get; set; }
-
-        /// <summary>
-        /// Gets or sets the format of numbers passed to Globalize plugin if it is included (jQuery UI Spinner widget).
-        /// </summary>
-        public string NumberFormat { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of months to show at once (jQuery UI Datepicker widget).
-        /// </summary>
-        public int NumberOfMonths { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of steps to take when paging via the pageUp/pageDown JavaScript methods (jQuery UI Spinner widget).
-        /// </summary>
-        public int Page { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating whether days in other months shown before or after the current month are selectable, this only applies if the ShowOtherMonths is set to true. (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool SelectOtherMonths { get; set; }
-
-        /// <summary>
-        /// Gets or sets the cutoff year for determining the century for a date (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>This string must be a relative number of years from the current year, e.g., "+3" or "-5".</remarks> 
-        public string ShortYearCutoff { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines position to display the current month in, if the ShowOtherMonths is set to true (jQuery UI Datepicker widget).
-        /// </summary>
-        public int ShowCurrentAtPos { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating whether to show the month after the year in the header (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ShowMonthAfterYear { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating whether to display dates in other months (non-selectable) at the start or end of the current month, to make these days selectable set the SelectOtherMonths to true (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ShowOtherMonths { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating whether to add column with the week of the year (jQuery UI Datepicker widget).
-        /// </summary>
-        public bool ShowWeek { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines how many months to move when clicking the previous/next links (jQuery UI Datepicker widget).
-        /// </summary>
-        public int StepMonths { get; set; }
-
-        /// <summary>
-        /// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget down button.
-        /// </summary>
-        public string SpinnerDownIcon { get; set; }
-
-        /// <summary>
-        /// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget up button.
-        /// </summary>
-        public string SpinnerUpIcon { get; set; }
-
-        /// <summary>
-        /// Gets or sets the size of the step to take when spinning via buttons or via the stepUp/stepDown JavaScript methods (jQuery UI Spinner widget).
-        /// </summary>
-        public int Step { get; set; }
-
-        /// <summary>
-        /// Gets or sets the set of value:label pairs for select element (takes precedence over ValueDictionary property).
-        /// </summary>
-        public string Value { get; set; }
-
-        /// <summary>
-        /// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element.
-        /// </summary>
-        public IDictionary<string, string> ValueDictionary { get; set; }
-
-        /// <summary>
-        /// Gets or sets the range of years displayed in the year dropdown (jQuery UI Datepicker widget).
-        /// </summary>
-        /// <remarks>This string must be either relative to today's year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). Note that this option only affects what appears in the dropdown, to restrict which dates may be selected use the MinDate and/or MaxDate.</remarks> 
-        public string YearRange { get; set; }
-
-        /// <summary>
-        /// Gets or sets the additional text to display after the year in the month headers (jQuery UI Datepicker widget).
-        /// </summary>
-        public string YearSuffix { get; set; }
-        #endregion
-
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnElementOptions class.
-        /// </summary>
-        public JqGridColumnElementOptions()
-        {
-            AppendText = null;
-            AutoFocus = false;
-            AutoSize = false;
-            ChangeMonth = false;
-            ChangeYear = false;
-            ConstrainInput = true;
-            Culture = null;
-            DataInit = null;
-            DatePickerDateFormat = JQueryUIWidgetsDefaults.DatepickerDateFormat;
-            Delay = 300;
-            FirstDay = 0;
-            GotoCurrent = false;
-            Incremental = true;
-            JQueryUIWidgetDataInitRenderer = null;
-            Max = null;
-            Min = null;
-            MinLength = 1;
-            NumberFormat = null;
-            NumberOfMonths = 1;
-            Page = 10;
-            SelectOtherMonths = false;
-            ShortYearCutoff = JQueryUIWidgetsDefaults.DatepickerShortYearCutoff;
-            ShowCurrentAtPos = 0;
-            ShowMonthAfterYear = false;
-            ShowOtherMonths = false;
-            ShowWeek = false;
-            SpinnerDownIcon = JQueryUIWidgetsDefaults.SpinnerDownIcon;
-            SpinnerUpIcon = JQueryUIWidgetsDefaults.SpinnerUpIcon;
-            Step = 1;
-            StepMonths = 1;
-            YearRange = JQueryUIWidgetsDefaults.DatepickerYearRange;
-            YearSuffix = String.Empty;
-        }
-        #endregion
-
-        #region Methods
-        private string JQueryUIAutocompleteDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector, string dataUrl)
-        {
-            StringBuilder dataInitBuilder = new StringBuilder(100 + DataUrl.Length);
-            dataInitBuilder.AppendFormat("function(element) {{ setTimeout(function() {{ $(element).autocomplete({{ source: '{0}', ", dataUrl);
-
-            if (AutoFocus)
-                dataInitBuilder.Append("autoFocus: true, ");
-
-            if (Delay != 300)
-                dataInitBuilder.AppendFormat("delay: {0}, ", Delay);
-
-            if (MinLength != 1)
-                dataInitBuilder.AppendFormat("minLength: {0}, ", MinLength);
-
-            dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
-            dataInitBuilder.Append(" }); }, 0); }");
-
-            return dataInitBuilder.ToString();
-        }
-
-        internal void ConfigureJQueryUIAutocomplete()
-        {
-            string dataUrl = DataUrl;
-            JQueryUIWidgetDataInitRenderer = (JqGridCompatibilityModes compatibilityMode, string gridSelector) => { return JQueryUIAutocompleteDataInitRenderer(compatibilityMode, gridSelector, dataUrl); };
-
-            DataUrl = String.Empty;
-            DataInit = null;
-        }
-
-        private string JQueryUIDatepickerDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector, ModelMetadata propertyMetadata)
-        {
-            StringBuilder dataInitBuilder = new StringBuilder(80);
-            dataInitBuilder.Append("function(element) { setTimeout(function() { $(element).datepicker({ ");
-
-            if (!String.IsNullOrEmpty(AppendText))
-                dataInitBuilder.AppendFormat("appendText: '{0}', ", AppendText);
-
-            if (AutoSize)
-                dataInitBuilder.Append("autoSize: true, ");
-
-            if (ChangeMonth)
-                dataInitBuilder.Append("changeMonth: true, ");
-
-            if (ChangeYear)
-                dataInitBuilder.Append("changeYear: true, ");
-
-            if (!ConstrainInput)
-                dataInitBuilder.Append("constrainInput: true, ");
-
-            if (DatePickerDateFormat == JQueryUIWidgetsDefaults.DatepickerDateFormat)
-            {
-                IEnumerable<object> customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
-                JqGridColumnFormatterAttribute formatterAttribute = customAttributes.OfType<JqGridColumnFormatterAttribute>().FirstOrDefault();
-
-                if (formatterAttribute != null && formatterAttribute.Formatter == JqGridColumnPredefinedFormatters.Date && formatterAttribute.OutputFormat != JqGridOptionsDefaults.FormatterOutputFormat && formatterAttribute.OutputFormat.IndexOfAny(_invalidDateFormatTokens) == -1)
-                {
-                    DatePickerDateFormat = Regex.Replace(formatterAttribute.OutputFormat, _ignoredDateFormatTokensRegexExpression, String.Empty);
-                    DatePickerDateFormat = _dateFormatTokensRegex.Replace(DatePickerDateFormat, match => { return _dateFormatTokensReplecements[match.Value]; });
-                }
-            }
-            dataInitBuilder.AppendFormat("dateFormat: '{0}', ", DatePickerDateFormat);
-            dataInitBuilder.AppendFormat(_jqueryUIDatepickerDaysNamesLocalizationOptions[compatibilityMode], gridSelector);
-
-            if (FirstDay != 0)
-                dataInitBuilder.AppendFormat("firstDay: {0}, ", FirstDay);
-
-            if (GotoCurrent)
-                dataInitBuilder.Append("gotoCurrent: true, ");
-
-            if (!String.IsNullOrEmpty(MaxDate))
-                dataInitBuilder.AppendFormat("maxDate: '{0}', ", MaxDate);
-
-            if (!String.IsNullOrEmpty(MinDate))
-                dataInitBuilder.AppendFormat("minDate: '{0}', ", MinDate);
-
-            dataInitBuilder.AppendFormat(_jqueryUIDatepickerMonthsNamesLocalizationOptions[compatibilityMode], gridSelector);
-
-            if (NumberOfMonths != 1)
-                dataInitBuilder.AppendFormat("numberOfMonths: {0}, ", NumberOfMonths);
-
-            if (SelectOtherMonths)
-                dataInitBuilder.Append("selectOtherMonths: true, ");
-
-            if (ShortYearCutoff != JQueryUIWidgetsDefaults.DatepickerShortYearCutoff)
-                dataInitBuilder.AppendFormat("shortYearCutoff: '{0}', ", ShortYearCutoff);
-
-            if (ShowCurrentAtPos != 0)
-                dataInitBuilder.AppendFormat("showCurrentAtPos: {0}, ", ShowCurrentAtPos);
-
-            if (ShowMonthAfterYear)
-                dataInitBuilder.Append("showMonthAfterYear: true, ");
-
-            if (ShowOtherMonths)
-                dataInitBuilder.Append("showOtherMonths: true, ");
-
-            if (ShowWeek)
-                dataInitBuilder.Append("showWeek: true, ");
-
-            if (StepMonths != 1)
-                dataInitBuilder.AppendFormat("stepMonths: {0}, ", StepMonths);
-
-            if (YearRange != JQueryUIWidgetsDefaults.DatepickerYearRange)
-                dataInitBuilder.AppendFormat("yearRange: '{0}', ", YearRange);
-
-            if (!String.IsNullOrEmpty(YearSuffix))
-                dataInitBuilder.AppendFormat("yearSuffix: '{0}', ", YearSuffix);
-
-            dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
-            dataInitBuilder.Append(" }); }, 0); }");
-
-            return dataInitBuilder.ToString();
-        }
-
-        internal void ConfigureJQueryUIDatepicker(ModelMetadata propertyMetadata)
-        {
-            JQueryUIWidgetDataInitRenderer = (JqGridCompatibilityModes compatibilityMode, string gridSelector) => { return JQueryUIDatepickerDataInitRenderer(compatibilityMode, gridSelector, propertyMetadata); };
-
-            DataInit = null;
-        }
-
-        private string JQueryUISpinnerDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector)
-        {
-            StringBuilder dataInitBuilder = new StringBuilder(80);
-            dataInitBuilder.Append("function(element) { setTimeout(function() { $(element).spinner({ ");
-
-            if (!String.IsNullOrEmpty(Culture))
-                dataInitBuilder.AppendFormat("culture: '{0}', ", Culture);
-
-            if (SpinnerDownIcon != JQueryUIWidgetsDefaults.SpinnerDownIcon || SpinnerUpIcon != JQueryUIWidgetsDefaults.SpinnerUpIcon)
-            {
-                dataInitBuilder.Append("icons: { ");
-
-                if (SpinnerDownIcon != JQueryUIWidgetsDefaults.SpinnerDownIcon)
-                    dataInitBuilder.AppendFormat("down: '{0}', ", SpinnerDownIcon);
-
-                if (SpinnerUpIcon != JQueryUIWidgetsDefaults.SpinnerUpIcon)
-                    dataInitBuilder.AppendFormat("up: '{0}', ", SpinnerUpIcon);
-
-                dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
-                dataInitBuilder.Append(" }, ");
-            }
-
-            if (!Incremental)
-                dataInitBuilder.Append("incremental: false, ");
-
-            if (Max.HasValue)
-                dataInitBuilder.AppendFormat("max: {0}, ", Max.Value);
-
-            if (Min.HasValue)
-                dataInitBuilder.AppendFormat("min: {0}, ", Min.Value);
-
-            if (!String.IsNullOrEmpty(NumberFormat))
-                dataInitBuilder.AppendFormat("numberFormat: '{0}', ", NumberFormat);
-
-            if (Page != 10)
-                dataInitBuilder.AppendFormat("page: {0}, ", Page);
-
-            if (Step != 1)
-                dataInitBuilder.AppendFormat("step: {0}, ", Step);
-
-            dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
-            if (dataInitBuilder[dataInitBuilder.Length - 1] == '(')
-                dataInitBuilder.Append("); }, 0); }");
-            else
-                dataInitBuilder.Append(" }); }, 0); }");
-
-            return dataInitBuilder.ToString();
-        }
-
-        internal void ConfigureJQueryUISpinner()
-        {
-            JQueryUIWidgetDataInitRenderer = JQueryUISpinnerDataInitRenderer;
-
-            DataInit = null;
-        }
-        #endregion
-    }
+	/// <summary>
+	/// Base class which represents options for jqGrid editable or searchable column element
+	/// </summary>
+	public abstract class JqGridColumnElementOptions
+	{
+		#region Fields
+		private static readonly char[] _invalidDateFormatTokens = { 'N', 'S', 'w', 'W', 't', 'L', 'o' };
+		private const string _ignoredDateFormatTokensRegexExpression = "[aABgGhHisueIOPTZcr]";
+		private static readonly Regex _dateFormatTokensRegex = new Regex("d|j|l|z|F|m|n|Y|U", RegexOptions.Compiled);
+		private static readonly Dictionary<string, string> _dateFormatTokensReplecements = new Dictionary<string, string> { { "d", "dd" }, { "j", "d" }, { "l", "DD" }, { "z", "o" }, { "F", "MM" }, { "m", "mm" }, { "n", "m" }, { "Y", "yy" }, { "U", "@" } };
+
+		private static readonly IDictionary<JqGridCompatibilityModes, string> _jqueryUIDatepickerDaysNamesLocalizationOptions = new Dictionary<JqGridCompatibilityModes, string>
+		{
+			{ JqGridCompatibilityModes.JqGrid, "dayNames: $.jgrid.formatter.date.dayNames.slice(7), dayNamesMin: $.jgrid.formatter.date.dayNames.slice(0, 7), dayNamesShort: $.jgrid.formatter.date.dayNames.slice(0, 7), " },
+			{ JqGridCompatibilityModes.GuriddoJqGrid, "dayNames: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(7), dayNamesMin: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(0, 7), dayNamesShort: $.jgrid.getRegional($({0})[0], 'formatter.date.dayNames').slice(0, 7), " },
+			{ JqGridCompatibilityModes.FreeJqGrid, "dayNames: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(7), dayNamesMin: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(0, 7), dayNamesShort: $({0}).jqGrid('getGridRes', 'formatter.date.dayNames').slice(0, 7), " }
+		};
+
+		private static readonly IDictionary<JqGridCompatibilityModes, string> _jqueryUIDatepickerMonthsNamesLocalizationOptions = new Dictionary<JqGridCompatibilityModes, string>
+		{
+			{ JqGridCompatibilityModes.JqGrid, "monthNames: $.jgrid.formatter.date.monthNames.slice(12), monthNamesShort: $.jgrid.formatter.date.monthNames.slice(0, 12), " },
+			{ JqGridCompatibilityModes.GuriddoJqGrid, "monthNames: $.jgrid.getRegional($({0})[0], 'formatter.date.monthNames').slice(12), monthNamesShort: $.jgrid.getRegional($({0})[0], 'formatter.date.monthNames').slice(0, 12), " },
+			{ JqGridCompatibilityModes.FreeJqGrid, "monthNames: $({0}).jqGrid('getGridRes', 'formatter.date.monthNames').slice(12), monthNamesShort: $({0}).jqGrid('getGridRes', 'formatter.date.monthNames').slice(0, 12), " }
+		};
+
+		//Backing fields
+		private string _buildSelect;
+		private string _dataInit;
+		private string _dataUrl;
+		private string _value;
+		private string _defaultValue;
+
+		#endregion
+
+		#region Properties
+		/// <summary>
+		/// Gets or sets the text to display after each date field (jQuery UI Datepicker widget).
+		/// </summary>
+		public string AppendText { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the first item will automatically be focused when the menu is shown (jQuery UI Autocomplete widget).
+		/// </summary>
+		public bool AutoFocus { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the input field should be automatically resize to accommodate dates in the current format (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool AutoSize { get; set; }
+
+		internal bool IsBuildSelectSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function which will build the select element in case where the server response can not build it (requires DataUrl property to be set).
+		/// </summary>
+		public string BuildSelect
+		{
+			get => _buildSelect;
+			set
+			{
+				_buildSelect = value;
+				IsBuildSelectSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value indicating if the month should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ChangeMonth { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the year should be rendered as a dropdown instead of text (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ChangeYear { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the input field should constrained to characters allowed by the current format (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ConstrainInput { get; set; }
+
+		/// <summary>
+		/// Gets or sets the culture to use for parsing and formatting the value when Globalize plugin is included (jQuery UI Spinner widget).
+		/// </summary>
+		public string Culture { get; set; }
+
+		/// <summary>
+		/// Gets or sets the list of events to apply to the element (jQuery UI widgets events can also be applied this way).
+		/// </summary>
+		public IList<JqGridColumnDataEvent> DataEvents { get; set; }
+
+		internal bool IsDataInitSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function which will be called once when the element is created. This property is ignored in case of jQuery UI widgets.
+		/// </summary>
+		public string DataInit
+		{
+			get => _dataInit;
+			set
+			{
+				_dataInit = value;
+				IsDataInitSetted = true;
+			}
+		}
+
+		internal Func<JqGridCompatibilityModes, string, string> JQueryUIWidgetDataInitRenderer { get; private set; }
+
+		internal bool IsDataUrlSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the URL to get the AJAX data for the select element (if type is JqGridColumnSearchTypes/JqGridColumnEditTypes.Select) or jQuery UI Autocomplete widget (if type is JqGridColumnSearchTypes/JqGridColumnEditTypes.Autocomplete).
+		/// </summary>
+		public string DataUrl
+		{
+			get => _dataUrl;
+			set
+			{
+				_dataUrl = value;
+				IsDataUrlSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the format for parsed and displayed dates (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>If the value for this property is not provided, but there is a JqGridColumnFormatterAttribute with JqGridColumnPredefinedFormatters.Date formatter the helper will try to provide the value based on JqGridColumnFormatterAttribute.OutputFormat.</remarks> 
+		public string DatePickerDateFormat { get; set; }
+
+		internal bool IsDefaultValueSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the default value in the search input element.
+		/// </summary>
+		public string DefaultValue
+		{
+			get => _defaultValue;
+			set
+			{
+				_defaultValue = value;
+				IsDefaultValueSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the delay in milliseconds between when a keystroke occurs and when a search is performed (jQuery UI Autocomplete widget).
+		/// </summary>
+		public int Delay { get; set; }
+
+		/// <summary>
+		/// Gets or sets the first day of the week: Sunday is 0, Monday is 1, etc. (jQuery UI Datepicker widget).
+		/// </summary>
+		public int FirstDay { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the current day link moves to the currently selected date instead of today. (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool GotoCurrent { get; set; }
+
+		/// <summary>
+		/// Gets or sets a dictionary where keys should be valid attributes for the element.
+		/// </summary>
+		public IDictionary<string, object> HtmlAttributes { get; set; }
+
+		/// <summary>
+		/// Gets or sets value controlling the number of steps taken when holding down a spin button (jQuery UI Spinner widget).
+		/// </summary>
+		public bool Incremental { get; set; }
+
+		/// <summary>
+		/// Gets or sets maximum allowed value (jQuery UI Spinner widget).
+		/// </summary>
+		public int? Max { get; set; }
+
+		/// <summary>
+		/// Gets or sets minimum allowed value (jQuery UI Spinner widget).
+		/// </summary>
+		public int? Min { get; set; }
+
+		/// <summary>
+		/// Gets or sets the maximum selectable date. (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
+		public string MaxDate { get; set; }
+
+		/// <summary>
+		/// Gets or sets the minimum selectable date. (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>This string must be in the format defined by the DateFormat property, or a relative date. Relative dates must contain value and period pairs; valid periods are "y" for years, "m" for months, "w" for weeks, and "d" for days. For example, "+1m +7d" represents one month and seven days from today.</remarks> 
+		public string MinDate { get; set; }
+
+		/// <summary>
+		/// Gets or sets the minimum number of characters a user must type before a search is performed (jQuery UI Autocomplete widget).
+		/// </summary>
+		public int MinLength { get; set; }
+
+		/// <summary>
+		/// Gets or sets the format of numbers passed to Globalize plugin if it is included (jQuery UI Spinner widget).
+		/// </summary>
+		public string NumberFormat { get; set; }
+
+		/// <summary>
+		/// Gets or sets the number of months to show at once (jQuery UI Datepicker widget).
+		/// </summary>
+		public int NumberOfMonths { get; set; }
+
+		/// <summary>
+		/// Gets or sets the number of steps to take when paging via the pageUp/pageDown JavaScript methods (jQuery UI Spinner widget).
+		/// </summary>
+		public int Page { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating whether days in other months shown before or after the current month are selectable, this only applies if the ShowOtherMonths is set to true. (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool SelectOtherMonths { get; set; }
+
+		/// <summary>
+		/// Gets or sets the cutoff year for determining the century for a date (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>This string must be a relative number of years from the current year, e.g., "+3" or "-5".</remarks> 
+		public string ShortYearCutoff { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines position to display the current month in, if the ShowOtherMonths is set to true (jQuery UI Datepicker widget).
+		/// </summary>
+		public int ShowCurrentAtPos { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating whether to show the month after the year in the header (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ShowMonthAfterYear { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating whether to display dates in other months (non-selectable) at the start or end of the current month, to make these days selectable set the SelectOtherMonths to true (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ShowOtherMonths { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating whether to add column with the week of the year (jQuery UI Datepicker widget).
+		/// </summary>
+		public bool ShowWeek { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines how many months to move when clicking the previous/next links (jQuery UI Datepicker widget).
+		/// </summary>
+		public int StepMonths { get; set; }
+
+		/// <summary>
+		/// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget down button.
+		/// </summary>
+		public string SpinnerDownIcon { get; set; }
+
+		/// <summary>
+		/// Gets or sets the icon class (form UI theme icons) for jQuery UI Spinner widget up button.
+		/// </summary>
+		public string SpinnerUpIcon { get; set; }
+
+		/// <summary>
+		/// Gets or sets the size of the step to take when spinning via buttons or via the stepUp/stepDown JavaScript methods (jQuery UI Spinner widget).
+		/// </summary>
+		public int Step { get; set; }
+
+		internal bool IsValueSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the set of value:label pairs for select element (takes precedence over ValueDictionary property).
+		/// </summary>
+		public string Value
+		{
+			get => _value;
+			set
+			{
+				_value = value;
+				IsValueSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element.
+		/// </summary>
+		public IDictionary<string, string> ValueDictionary { get; set; }
+
+		/// <summary>
+		/// Gets or sets the range of years displayed in the year dropdown (jQuery UI Datepicker widget).
+		/// </summary>
+		/// <remarks>This string must be either relative to today's year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). Note that this option only affects what appears in the dropdown, to restrict which dates may be selected use the MinDate and/or MaxDate.</remarks> 
+		public string YearRange { get; set; }
+
+		/// <summary>
+		/// Gets or sets the additional text to display after the year in the month headers (jQuery UI Datepicker widget).
+		/// </summary>
+		public string YearSuffix { get; set; }
+		#endregion
+
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnElementOptions class.
+		/// </summary>
+		protected JqGridColumnElementOptions()
+		{
+			AppendText = null;
+			AutoFocus = false;
+			AutoSize = false;
+			ChangeMonth = false;
+			ChangeYear = false;
+			ConstrainInput = true;
+			Culture = null;
+			DatePickerDateFormat = JQueryUIWidgetsDefaults.DatepickerDateFormat;
+			Delay = 300;
+			FirstDay = 0;
+			GotoCurrent = false;
+			Incremental = true;
+			JQueryUIWidgetDataInitRenderer = null;
+			Max = null;
+			Min = null;
+			MinLength = 1;
+			NumberFormat = null;
+			NumberOfMonths = 1;
+			Page = 10;
+			SelectOtherMonths = false;
+			ShortYearCutoff = JQueryUIWidgetsDefaults.DatepickerShortYearCutoff;
+			ShowCurrentAtPos = 0;
+			ShowMonthAfterYear = false;
+			ShowOtherMonths = false;
+			ShowWeek = false;
+			SpinnerDownIcon = JQueryUIWidgetsDefaults.SpinnerDownIcon;
+			SpinnerUpIcon = JQueryUIWidgetsDefaults.SpinnerUpIcon;
+			Step = 1;
+			StepMonths = 1;
+			YearRange = JQueryUIWidgetsDefaults.DatepickerYearRange;
+			YearSuffix = string.Empty;
+		}
+		#endregion
+
+		#region Methods
+		private string JQueryUIAutocompleteDataInitRenderer(string dataUrl)
+		{
+			var dataInitBuilder = new StringBuilder(100 + DataUrl.Length);
+			dataInitBuilder.AppendFormat("function(element) {{ setTimeout(function() {{ $(element).autocomplete({{ source: '{0}', ", dataUrl);
+
+			if (AutoFocus)
+				dataInitBuilder.Append("autoFocus: true, ");
+
+			if (Delay != 300)
+				dataInitBuilder.AppendFormat("delay: {0}, ", Delay);
+
+			if (MinLength != 1)
+				dataInitBuilder.AppendFormat("minLength: {0}, ", MinLength);
+
+			dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
+			dataInitBuilder.Append(" }); }, 0); }");
+
+			return dataInitBuilder.ToString();
+		}
+
+		internal void ConfigureJQueryUIAutocomplete()
+		{
+			var dataUrl = DataUrl;
+			JQueryUIWidgetDataInitRenderer = (compatibilityMode, gridSelector) => JQueryUIAutocompleteDataInitRenderer(dataUrl);
+
+			DataUrl = string.Empty;
+			DataInit = null;
+		}
+
+		private string JQueryUIDatepickerDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector, ModelMetadata propertyMetadata)
+		{
+			var dataInitBuilder = new StringBuilder(80);
+			dataInitBuilder.Append("function(element) { setTimeout(function() { $(element).datepicker({ ");
+
+			if (!string.IsNullOrEmpty(AppendText))
+				dataInitBuilder.AppendFormat("appendText: '{0}', ", AppendText);
+
+			if (AutoSize)
+				dataInitBuilder.Append("autoSize: true, ");
+
+			if (ChangeMonth)
+				dataInitBuilder.Append("changeMonth: true, ");
+
+			if (ChangeYear)
+				dataInitBuilder.Append("changeYear: true, ");
+
+			if (!ConstrainInput)
+				dataInitBuilder.Append("constrainInput: true, ");
+
+			if (DatePickerDateFormat == JQueryUIWidgetsDefaults.DatepickerDateFormat)
+			{
+				var customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
+				var formatterAttribute = customAttributes.OfType<JqGridColumnFormatterAttribute>().FirstOrDefault();
+
+				if (formatterAttribute != null && formatterAttribute.Formatter == JqGridColumnPredefinedFormatters.Date && formatterAttribute.OutputFormat != JqGridOptionsDefaults.FormatterOutputFormat && formatterAttribute.OutputFormat.IndexOfAny(_invalidDateFormatTokens) == -1)
+				{
+					DatePickerDateFormat = Regex.Replace(formatterAttribute.OutputFormat, _ignoredDateFormatTokensRegexExpression, string.Empty);
+					DatePickerDateFormat = _dateFormatTokensRegex.Replace(DatePickerDateFormat, match => _dateFormatTokensReplecements[match.Value]);
+				}
+			}
+			dataInitBuilder.AppendFormat("dateFormat: '{0}', ", DatePickerDateFormat);
+			dataInitBuilder.AppendFormat(_jqueryUIDatepickerDaysNamesLocalizationOptions[compatibilityMode], gridSelector);
+
+			if (FirstDay != 0)
+				dataInitBuilder.AppendFormat("firstDay: {0}, ", FirstDay);
+
+			if (GotoCurrent)
+				dataInitBuilder.Append("gotoCurrent: true, ");
+
+			if (!string.IsNullOrEmpty(MaxDate))
+				dataInitBuilder.AppendFormat("maxDate: '{0}', ", MaxDate);
+
+			if (!string.IsNullOrEmpty(MinDate))
+				dataInitBuilder.AppendFormat("minDate: '{0}', ", MinDate);
+
+			dataInitBuilder.AppendFormat(_jqueryUIDatepickerMonthsNamesLocalizationOptions[compatibilityMode], gridSelector);
+
+			if (NumberOfMonths != 1)
+				dataInitBuilder.AppendFormat("numberOfMonths: {0}, ", NumberOfMonths);
+
+			if (SelectOtherMonths)
+				dataInitBuilder.Append("selectOtherMonths: true, ");
+
+			if (ShortYearCutoff != JQueryUIWidgetsDefaults.DatepickerShortYearCutoff)
+				dataInitBuilder.AppendFormat("shortYearCutoff: '{0}', ", ShortYearCutoff);
+
+			if (ShowCurrentAtPos != 0)
+				dataInitBuilder.AppendFormat("showCurrentAtPos: {0}, ", ShowCurrentAtPos);
+
+			if (ShowMonthAfterYear)
+				dataInitBuilder.Append("showMonthAfterYear: true, ");
+
+			if (ShowOtherMonths)
+				dataInitBuilder.Append("showOtherMonths: true, ");
+
+			if (ShowWeek)
+				dataInitBuilder.Append("showWeek: true, ");
+
+			if (StepMonths != 1)
+				dataInitBuilder.AppendFormat("stepMonths: {0}, ", StepMonths);
+
+			if (YearRange != JQueryUIWidgetsDefaults.DatepickerYearRange)
+				dataInitBuilder.AppendFormat("yearRange: '{0}', ", YearRange);
+
+			if (!string.IsNullOrEmpty(YearSuffix))
+				dataInitBuilder.AppendFormat("yearSuffix: '{0}', ", YearSuffix);
+
+			dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
+			dataInitBuilder.Append(" }); }, 0); }");
+
+			return dataInitBuilder.ToString();
+		}
+
+		internal void ConfigureJQueryUIDatepicker(ModelMetadata propertyMetadata)
+		{
+			JQueryUIWidgetDataInitRenderer = (compatibilityMode, gridSelector) => JQueryUIDatepickerDataInitRenderer(compatibilityMode, gridSelector, propertyMetadata);
+
+			DataInit = null;
+		}
+
+		private string JQueryUISpinnerDataInitRenderer(JqGridCompatibilityModes compatibilityMode, string gridSelector)
+		{
+			var dataInitBuilder = new StringBuilder(80);
+			dataInitBuilder.Append("function(element) { setTimeout(function() { $(element).spinner({ ");
+
+			if (!string.IsNullOrEmpty(Culture))
+				dataInitBuilder.AppendFormat("culture: '{0}', ", Culture);
+
+			if (SpinnerDownIcon != JQueryUIWidgetsDefaults.SpinnerDownIcon || SpinnerUpIcon != JQueryUIWidgetsDefaults.SpinnerUpIcon)
+			{
+				dataInitBuilder.Append("icons: { ");
+
+				if (SpinnerDownIcon != JQueryUIWidgetsDefaults.SpinnerDownIcon)
+					dataInitBuilder.AppendFormat("down: '{0}', ", SpinnerDownIcon);
+
+				if (SpinnerUpIcon != JQueryUIWidgetsDefaults.SpinnerUpIcon)
+					dataInitBuilder.AppendFormat("up: '{0}', ", SpinnerUpIcon);
+
+				dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
+				dataInitBuilder.Append(" }, ");
+			}
+
+			if (!Incremental)
+				dataInitBuilder.Append("incremental: false, ");
+
+			if (Max.HasValue)
+				dataInitBuilder.AppendFormat("max: {0}, ", Max.Value);
+
+			if (Min.HasValue)
+				dataInitBuilder.AppendFormat("min: {0}, ", Min.Value);
+
+			if (!string.IsNullOrEmpty(NumberFormat))
+				dataInitBuilder.AppendFormat("numberFormat: '{0}', ", NumberFormat);
+
+			if (Page != 10)
+				dataInitBuilder.AppendFormat("page: {0}, ", Page);
+
+			if (Step != 1)
+				dataInitBuilder.AppendFormat("step: {0}, ", Step);
+
+			dataInitBuilder.Remove(dataInitBuilder.Length - 2, 2);
+			dataInitBuilder.Append(dataInitBuilder[dataInitBuilder.Length - 1] == '(' ? "); }, 0); }" : " }); }, 0); }");
+
+			return dataInitBuilder.ToString();
+		}
+
+		internal void ConfigureJQueryUISpinner()
+		{
+			JQueryUIWidgetDataInitRenderer = JQueryUISpinnerDataInitRenderer;
+
+			DataInit = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnFormOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnFormOptions.cs
@@ -1,40 +1,69 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents additional column options for jqGrid form editing.
-    /// </summary>
-    public class JqGridColumnFormOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the column position of the element (with the label) in the form (one-based).
-        /// </summary>
-        public int? ColumnPosition { get; set; }
+	/// <summary>
+	/// Class which represents additional column options for jqGrid form editing.
+	/// </summary>
+	public class JqGridColumnFormOptions
+	{
+		#region Fields
+		private string _elementPrefix;
+		private string _elementSuffix;
+		private string _label;
 
-        /// <summary>
-        /// Gets or sets the text or HTML content to appear before the input element.
-        /// </summary>
-        public string ElementPrefix { get; set; }
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the text or HTML content to appear after the input element.
-        /// </summary>
-        public string ElementSuffix { get; set; }
+		#region Properties
+		/// <summary>
+		/// Gets or sets the column position of the element (with the label) in the form (one-based).
+		/// </summary>
+		public int? ColumnPosition { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text which will replace the name from ColumnNames as label in the form.
-        /// </summary>
-        public string Label { get; set; }
+		internal bool IsElementPrefixSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the text or HTML content to appear before the input element.
+		/// </summary>
+		public string ElementPrefix
+		{
+			get => _elementPrefix;
+			set
+			{
+				_elementPrefix = value;
+				IsElementPrefixSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the row position of the element (with the label) in the form (one-based).
-        /// </summary>
-        public int? RowPosition { get; set; }
-        #endregion
-    }
+		internal bool IsElementSuffixSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the text or HTML content to appear after the input element.
+		/// </summary>
+		public string ElementSuffix
+		{
+			get => _elementSuffix;
+			set
+			{
+				_elementSuffix = value;
+				IsElementSuffixSetted = true;
+			}
+		}
+
+		internal bool IsLabelSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the text which will replace the name from ColumnNames as label in the form.
+		/// </summary>
+		public string Label
+		{
+			get => _label;
+			set
+			{
+				_label = value;
+				IsLabelSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the row position of the element (with the label) in the form (one-based).
+		/// </summary>
+		public int? RowPosition { get; set; }
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnFormOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnFormOptions.cs
@@ -1,69 +1,69 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents additional column options for jqGrid form editing.
-	/// </summary>
-	public class JqGridColumnFormOptions
-	{
-		#region Fields
-		private string _elementPrefix;
-		private string _elementSuffix;
-		private string _label;
+    /// <summary>
+    /// Class which represents additional column options for jqGrid form editing.
+    /// </summary>
+    public class JqGridColumnFormOptions
+    {
+        #region Fields
+        private string _elementPrefix;
+        private string _elementSuffix;
+        private string _label;
 
-		#endregion
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets the column position of the element (with the label) in the form (one-based).
-		/// </summary>
-		public int? ColumnPosition { get; set; }
+        #region Properties
+        /// <summary>
+        /// Gets or sets the column position of the element (with the label) in the form (one-based).
+        /// </summary>
+        public int? ColumnPosition { get; set; }
 
-		internal bool IsElementPrefixSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the text or HTML content to appear before the input element.
-		/// </summary>
-		public string ElementPrefix
-		{
-			get => _elementPrefix;
-			set
-			{
-				_elementPrefix = value;
-				IsElementPrefixSetted = true;
-			}
-		}
+        internal bool IsElementPrefixSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the text or HTML content to appear before the input element.
+        /// </summary>
+        public string ElementPrefix
+        {
+            get => _elementPrefix;
+            set
+            {
+                _elementPrefix = value;
+                IsElementPrefixSetted = true;
+            }
+        }
 
-		internal bool IsElementSuffixSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the text or HTML content to appear after the input element.
-		/// </summary>
-		public string ElementSuffix
-		{
-			get => _elementSuffix;
-			set
-			{
-				_elementSuffix = value;
-				IsElementSuffixSetted = true;
-			}
-		}
+        internal bool IsElementSuffixSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the text or HTML content to appear after the input element.
+        /// </summary>
+        public string ElementSuffix
+        {
+            get => _elementSuffix;
+            set
+            {
+                _elementSuffix = value;
+                IsElementSuffixSetted = true;
+            }
+        }
 
-		internal bool IsLabelSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the text which will replace the name from ColumnNames as label in the form.
-		/// </summary>
-		public string Label
-		{
-			get => _label;
-			set
-			{
-				_label = value;
-				IsLabelSetted = true;
-			}
-		}
+        internal bool IsLabelSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the text which will replace the name from ColumnNames as label in the form.
+        /// </summary>
+        public string Label
+        {
+            get => _label;
+            set
+            {
+                _label = value;
+                IsLabelSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the row position of the element (with the label) in the form (one-based).
-		/// </summary>
-		public int? RowPosition { get; set; }
-		#endregion
-	}
+        /// <summary>
+        /// Gets or sets the row position of the element (with the label) in the form (one-based).
+        /// </summary>
+        public int? RowPosition { get; set; }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnFormatterOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnFormatterOptions.cs
@@ -1,189 +1,267 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for predefined formatter.
-    /// </summary>
-    public class JqGridColumnFormatterOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the decimal places.
-        /// </summary>
-        public int DecimalPlaces { get; set; }
+	/// <summary>
+	/// Class which represents options for predefined formatter.
+	/// </summary>
+	public class JqGridColumnFormatterOptions
+	{
+		#region Fields
+		private int? _decimalPlaces;
+		private string _decimalSeparator;
+		private string _defaultValue;
+		private string _prefix;
+		private string _suffix;
+		private string _sourceFormat;
+		private string _outputFormat;
+		private string _baseLinkUrl;
+		private string _showAction;
+		private string _addParam;
+		private string _target;
+		private string _idName;
+		private string _thousandsSeparator;
 
-        /// <summary>
-        /// Gets or sets the decimal separator.
-        /// </summary>
-        public string DecimalSeparator { get; set; }
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the default value.
-        /// </summary>
-        public string DefaultValue { get; set; }
+		#region Properties
 
-        /// <summary>
-        /// Gets or sets the value indicating if checkbox is disabled.
-        /// </summary>
-        public bool Disabled { get; set; }
+		/// <summary>
+		/// Gets or sets the decimal places.
+		/// </summary>
+		public int? DecimalPlaces
+		{
+			get => _decimalPlaces;
+			set => _decimalPlaces = value < 0 ? null : value;
+		}
 
-        /// <summary>
-        /// Gets or sets the currency prefix.
-        /// </summary>
-        public string Prefix { get; set; }
+		internal bool IsDecimalSeparatorSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the decimal separator.
+		/// </summary>
+		public string DecimalSeparator
+		{
+			get => _decimalSeparator;
+			set
+			{
+				_decimalSeparator = value;
+				IsDecimalSeparatorSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the currency suffix.
-        /// </summary>
-        public string Suffix { get; set; }
+		internal bool IsDefaultValueSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the default value.
+		/// </summary>
+		public string DefaultValue
+		{
+			get => _defaultValue;
+			set
+			{
+				_defaultValue = value;
+				IsDefaultValueSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the date source format.
-        /// </summary>
-        public string SourceFormat { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if checkbox is disabled.
+		/// </summary>
+		public bool? Disabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets the date output format.
-        /// </summary>
-        public string OutputFormat { get; set; }
+		internal bool IsPrefixSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the currency prefix.
+		/// </summary>
+		public string Prefix
+		{
+			get => _prefix;
+			set
+			{
+				_prefix = value;
+				IsPrefixSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the link for showlink formatter.
-        /// </summary>
-        public string BaseLinkUrl { get; set; }
+		internal bool IsSuffixSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the currency suffix.
+		/// </summary>
+		public string Suffix
+		{
+			get => _suffix;
+			set
+			{
+				_suffix = value;
+				IsSuffixSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the additional value which is added after the BaseLinkUrl.
-        /// </summary>
-        public string ShowAction { get; set; }
+		internal bool IsSourceFormatSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the date source format.
+		/// </summary>
+		public string SourceFormat
+		{
+			get => _sourceFormat;
+			set
+			{
+				_sourceFormat = value;
+				IsSourceFormatSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the additional parameter which can be added after the IdName property.
-        /// </summary>
-        public string AddParam { get; set; }
+		internal bool IsOutputFormatSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the date output format.
+		/// </summary>
+		public string OutputFormat
+		{
+			get => _outputFormat;
+			set
+			{
+				_outputFormat = value;
+				IsOutputFormatSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the target.
-        /// </summary>
-        public string Target { get; set; }
+		internal bool IsBaseLinkUrlSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the link for showlink formatter.
+		/// </summary>
+		public string BaseLinkUrl
+		{
+			get => _baseLinkUrl;
+			set
+			{
+				_baseLinkUrl = value;
+				IsBaseLinkUrlSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the first parameter that is added after the ShowAction.
-        /// </summary>
-        public string IdName { get; set; }
+		internal bool IsShowActionSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the additional value which is added after the BaseLinkUrl.
+		/// </summary>
+		public string ShowAction
+		{
+			get => _showAction;
+			set
+			{
+				_showAction = value;
+				IsShowActionSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the thousands separator.
-        /// </summary>
-        public string ThousandsSeparator { get; set; }
+		internal bool IsAddParamSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the additional parameter which can be added after the IdName property.
+		/// </summary>
+		public string AddParam
+		{
+			get => _addParam;
+			set
+			{
+				_addParam = value;
+				IsAddParamSetted = true;
+			}
+		}
 
-        internal bool EditButton { get; set; }
-        
-        internal bool DeleteButton { get; set; }
-        
-        internal bool UseFormEditing { get; set; }
-        
-        internal JqGridInlineNavigatorActionOptions InlineEditingOptions { get; set; }
-        
-        internal JqGridNavigatorEditActionOptions FormEditingOptions { get; set; }
-        
-        internal JqGridNavigatorDeleteActionOptions DeleteOptions { get; set; }
-        #endregion
+		internal bool IsTargetSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the target.
+		/// </summary>
+		public string Target
+		{
+			get => _target;
+			set
+			{
+				_target = value;
+				IsTargetSetted = true;
+			}
+		}
 
-        #region Constructors
-        /// <summary>
-        /// Initializes new instance of JqGridColumnFormatterOptions class.
-        /// </summary>
-        public JqGridColumnFormatterOptions()
-        {
-            DecimalPlaces = 0;
-            DecimalSeparator = String.Empty;
-            DefaultValue = String.Empty;
-            Disabled = true;
-            ThousandsSeparator = String.Empty;
-            Prefix = String.Empty;
-            Suffix = String.Empty;
-            SourceFormat = String.Empty;
-            OutputFormat = String.Empty;
-            BaseLinkUrl = String.Empty;
-            ShowAction = String.Empty;
-            AddParam = String.Empty;
-            Target = String.Empty;
-            IdName = String.Empty;
-            EditButton = true;
-            DeleteButton = true;
-            UseFormEditing = false;
-            InlineEditingOptions = null;
-            FormEditingOptions = null;
-            DeleteOptions = null;
-        }
+		internal bool IsIdNameSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the first parameter that is added after the ShowAction.
+		/// </summary>
+		public string IdName
+		{
+			get => _idName;
+			set
+			{
+				_idName = value;
+				IsIdNameSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Initializes new instance of JqGridColumnFormatterOptions class.
-        /// </summary>
-        /// <param name="formatter">Predefined formatter</param>
-        public JqGridColumnFormatterOptions(string formatter)
-            : this()
-        {
-            switch (formatter)
-            {
-                case JqGridColumnPredefinedFormatters.Integer:
-                    DefaultValue = JqGridOptionsDefaults.IntegerFormatterDefaultValue;
-                    ThousandsSeparator = JqGridOptionsDefaults.FormatterThousandsSeparator;
-                    break;
-                case JqGridColumnPredefinedFormatters.Number:
-                    DecimalPlaces = JqGridOptionsDefaults.FormatterDecimalPlaces;
-                    DecimalSeparator = JqGridOptionsDefaults.FormatterDecimalSeparator;
-                    DefaultValue = JqGridOptionsDefaults.NumberFormatterDefaultValue;
-                    ThousandsSeparator = JqGridOptionsDefaults.FormatterThousandsSeparator;
-                    break;
-                case JqGridColumnPredefinedFormatters.Currency:
-                    DecimalPlaces = JqGridOptionsDefaults.FormatterDecimalPlaces;
-                    DecimalSeparator = JqGridOptionsDefaults.FormatterDecimalSeparator;
-                    DefaultValue = JqGridOptionsDefaults.CurrencyFormatterDefaultValue;
-                    ThousandsSeparator = JqGridOptionsDefaults.FormatterThousandsSeparator;
-                    break;
-                case JqGridColumnPredefinedFormatters.Date:
-                    SourceFormat = JqGridOptionsDefaults.FormatterSourceFormat;
-                    OutputFormat = JqGridOptionsDefaults.FormatterOutputFormat;
-                    break;
-                case JqGridColumnPredefinedFormatters.ShowLink:
-                    IdName = JqGridOptionsDefaults.FormatterIdName;
-                    break;
-            }
-        }
-        #endregion
+		internal bool IsThousandsSeparatorSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the thousands separator.
+		/// </summary>
+		public string ThousandsSeparator
+		{
+			get => _thousandsSeparator;
+			set
+			{
+				_thousandsSeparator = value;
+				IsThousandsSeparatorSetted = true;
+			}
+		}
 
-        #region Methods
-        internal bool IsDefault(string formatter)
-        {
-            switch (formatter)
-            {
-                case JqGridColumnPredefinedFormatters.Integer:
-                    return ((DefaultValue == JqGridOptionsDefaults.IntegerFormatterDefaultValue) && (ThousandsSeparator == JqGridOptionsDefaults.FormatterThousandsSeparator));
-                case JqGridColumnPredefinedFormatters.Number:
-                    return ((DecimalPlaces == JqGridOptionsDefaults.FormatterDecimalPlaces) && (DecimalSeparator == JqGridOptionsDefaults.FormatterDecimalSeparator) && (DefaultValue == JqGridOptionsDefaults.NumberFormatterDefaultValue) && (ThousandsSeparator == JqGridOptionsDefaults.FormatterThousandsSeparator));
-                case JqGridColumnPredefinedFormatters.Currency:
-                    return ((DecimalPlaces == JqGridOptionsDefaults.FormatterDecimalPlaces) && (DecimalSeparator == JqGridOptionsDefaults.FormatterDecimalSeparator) && (DefaultValue == JqGridOptionsDefaults.CurrencyFormatterDefaultValue) && String.IsNullOrWhiteSpace(Prefix) && String.IsNullOrWhiteSpace(Suffix) && (ThousandsSeparator == JqGridOptionsDefaults.FormatterThousandsSeparator));
-                case JqGridColumnPredefinedFormatters.Date:
-                    return ((SourceFormat == JqGridOptionsDefaults.FormatterSourceFormat) && (OutputFormat == JqGridOptionsDefaults.FormatterOutputFormat));
-                case JqGridColumnPredefinedFormatters.Link:
-                    return String.IsNullOrWhiteSpace(Target);
-                case JqGridColumnPredefinedFormatters.ShowLink:
-                    return (String.IsNullOrWhiteSpace(BaseLinkUrl) && String.IsNullOrWhiteSpace(ShowAction) && String.IsNullOrWhiteSpace(AddParam) && String.IsNullOrWhiteSpace(Target) && (IdName == JqGridOptionsDefaults.FormatterIdName));
-                case JqGridColumnPredefinedFormatters.CheckBox:
-                    return Disabled;
-                case JqGridColumnPredefinedFormatters.Actions:
-                    return (EditButton && DeleteButton && !UseFormEditing && (InlineEditingOptions == null) && (FormEditingOptions == null) && (DeleteOptions == null));
-                default:
-                    return true;
-            }
-        }
-        #endregion
-    }
+		internal bool EditButton { get; set; }
+
+		internal bool DeleteButton { get; set; }
+
+		internal bool UseFormEditing { get; set; }
+
+		internal JqGridInlineNavigatorActionOptions InlineEditingOptions { get; set; }
+
+		internal JqGridNavigatorEditActionOptions FormEditingOptions { get; set; }
+
+		internal JqGridNavigatorDeleteActionOptions DeleteOptions { get; set; }
+		#endregion
+
+		#region Constructors
+		/// <summary>
+		/// Initializes new instance of JqGridColumnFormatterOptions class.
+		/// </summary>
+		public JqGridColumnFormatterOptions()
+		{
+
+			EditButton = true;
+			DeleteButton = true;
+			UseFormEditing = false;
+			InlineEditingOptions = null;
+			FormEditingOptions = null;
+			DeleteOptions = null;
+		}
+		#endregion
+
+		#region Methods
+		internal bool IsDefault(string formatter)
+		{
+			switch (formatter)
+			{
+				case JqGridColumnPredefinedFormatters.Integer:
+					return !IsDefaultValueSetted && !IsThousandsSeparatorSetted;
+				case JqGridColumnPredefinedFormatters.Number:
+					return !DecimalPlaces.HasValue && !IsDecimalSeparatorSetted && !IsDefaultValueSetted && !IsThousandsSeparatorSetted;
+				case JqGridColumnPredefinedFormatters.Currency:
+					return !DecimalPlaces.HasValue && !IsDecimalSeparatorSetted && !IsDefaultValueSetted && !IsPrefixSetted && !IsSuffixSetted && !IsThousandsSeparatorSetted;
+				case JqGridColumnPredefinedFormatters.Date:
+					return !IsSourceFormatSetted && !IsOutputFormatSetted;
+				case JqGridColumnPredefinedFormatters.Link:
+					return string.IsNullOrWhiteSpace(Target);
+				case JqGridColumnPredefinedFormatters.ShowLink:
+					return !IsBaseLinkUrlSetted && !IsShowActionSetted && !IsAddParamSetted && !IsTargetSetted && !IsIdNameSetted;
+				case JqGridColumnPredefinedFormatters.CheckBox:
+					return !Disabled.HasValue;
+				case JqGridColumnPredefinedFormatters.Actions:
+					return EditButton && DeleteButton && !UseFormEditing && InlineEditingOptions == null && FormEditingOptions == null && DeleteOptions == null;
+				default:
+					return true;
+			}
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnFormatterOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnFormatterOptions.cs
@@ -2,266 +2,266 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for predefined formatter.
-	/// </summary>
-	public class JqGridColumnFormatterOptions
-	{
-		#region Fields
-		private int? _decimalPlaces;
-		private string _decimalSeparator;
-		private string _defaultValue;
-		private string _prefix;
-		private string _suffix;
-		private string _sourceFormat;
-		private string _outputFormat;
-		private string _baseLinkUrl;
-		private string _showAction;
-		private string _addParam;
-		private string _target;
-		private string _idName;
-		private string _thousandsSeparator;
+    /// <summary>
+    /// Class which represents options for predefined formatter.
+    /// </summary>
+    public class JqGridColumnFormatterOptions
+    {
+        #region Fields
+        private int? _decimalPlaces;
+        private string _decimalSeparator;
+        private string _defaultValue;
+        private string _prefix;
+        private string _suffix;
+        private string _sourceFormat;
+        private string _outputFormat;
+        private string _baseLinkUrl;
+        private string _showAction;
+        private string _addParam;
+        private string _target;
+        private string _idName;
+        private string _thousandsSeparator;
 
-		#endregion
+        #endregion
 
-		#region Properties
+        #region Properties
 
-		/// <summary>
-		/// Gets or sets the decimal places.
-		/// </summary>
-		public int? DecimalPlaces
-		{
-			get => _decimalPlaces;
-			set => _decimalPlaces = value < 0 ? null : value;
-		}
+        /// <summary>
+        /// Gets or sets the decimal places.
+        /// </summary>
+        public int? DecimalPlaces
+        {
+            get => _decimalPlaces;
+            set => _decimalPlaces = value < 0 ? null : value;
+        }
 
-		internal bool IsDecimalSeparatorSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the decimal separator.
-		/// </summary>
-		public string DecimalSeparator
-		{
-			get => _decimalSeparator;
-			set
-			{
-				_decimalSeparator = value;
-				IsDecimalSeparatorSetted = true;
-			}
-		}
+        internal bool IsDecimalSeparatorSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the decimal separator.
+        /// </summary>
+        public string DecimalSeparator
+        {
+            get => _decimalSeparator;
+            set
+            {
+                _decimalSeparator = value;
+                IsDecimalSeparatorSetted = true;
+            }
+        }
 
-		internal bool IsDefaultValueSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the default value.
-		/// </summary>
-		public string DefaultValue
-		{
-			get => _defaultValue;
-			set
-			{
-				_defaultValue = value;
-				IsDefaultValueSetted = true;
-			}
-		}
+        internal bool IsDefaultValueSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the default value.
+        /// </summary>
+        public string DefaultValue
+        {
+            get => _defaultValue;
+            set
+            {
+                _defaultValue = value;
+                IsDefaultValueSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the value indicating if checkbox is disabled.
-		/// </summary>
-		public bool? Disabled { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if checkbox is disabled.
+        /// </summary>
+        public bool? Disabled { get; set; }
 
-		internal bool IsPrefixSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the currency prefix.
-		/// </summary>
-		public string Prefix
-		{
-			get => _prefix;
-			set
-			{
-				_prefix = value;
-				IsPrefixSetted = true;
-			}
-		}
+        internal bool IsPrefixSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the currency prefix.
+        /// </summary>
+        public string Prefix
+        {
+            get => _prefix;
+            set
+            {
+                _prefix = value;
+                IsPrefixSetted = true;
+            }
+        }
 
-		internal bool IsSuffixSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the currency suffix.
-		/// </summary>
-		public string Suffix
-		{
-			get => _suffix;
-			set
-			{
-				_suffix = value;
-				IsSuffixSetted = true;
-			}
-		}
+        internal bool IsSuffixSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the currency suffix.
+        /// </summary>
+        public string Suffix
+        {
+            get => _suffix;
+            set
+            {
+                _suffix = value;
+                IsSuffixSetted = true;
+            }
+        }
 
-		internal bool IsSourceFormatSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the date source format.
-		/// </summary>
-		public string SourceFormat
-		{
-			get => _sourceFormat;
-			set
-			{
-				_sourceFormat = value;
-				IsSourceFormatSetted = true;
-			}
-		}
+        internal bool IsSourceFormatSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the date source format.
+        /// </summary>
+        public string SourceFormat
+        {
+            get => _sourceFormat;
+            set
+            {
+                _sourceFormat = value;
+                IsSourceFormatSetted = true;
+            }
+        }
 
-		internal bool IsOutputFormatSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the date output format.
-		/// </summary>
-		public string OutputFormat
-		{
-			get => _outputFormat;
-			set
-			{
-				_outputFormat = value;
-				IsOutputFormatSetted = true;
-			}
-		}
+        internal bool IsOutputFormatSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the date output format.
+        /// </summary>
+        public string OutputFormat
+        {
+            get => _outputFormat;
+            set
+            {
+                _outputFormat = value;
+                IsOutputFormatSetted = true;
+            }
+        }
 
-		internal bool IsBaseLinkUrlSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the link for showlink formatter.
-		/// </summary>
-		public string BaseLinkUrl
-		{
-			get => _baseLinkUrl;
-			set
-			{
-				_baseLinkUrl = value;
-				IsBaseLinkUrlSetted = true;
-			}
-		}
+        internal bool IsBaseLinkUrlSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the link for showlink formatter.
+        /// </summary>
+        public string BaseLinkUrl
+        {
+            get => _baseLinkUrl;
+            set
+            {
+                _baseLinkUrl = value;
+                IsBaseLinkUrlSetted = true;
+            }
+        }
 
-		internal bool IsShowActionSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the additional value which is added after the BaseLinkUrl.
-		/// </summary>
-		public string ShowAction
-		{
-			get => _showAction;
-			set
-			{
-				_showAction = value;
-				IsShowActionSetted = true;
-			}
-		}
+        internal bool IsShowActionSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the additional value which is added after the BaseLinkUrl.
+        /// </summary>
+        public string ShowAction
+        {
+            get => _showAction;
+            set
+            {
+                _showAction = value;
+                IsShowActionSetted = true;
+            }
+        }
 
-		internal bool IsAddParamSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the additional parameter which can be added after the IdName property.
-		/// </summary>
-		public string AddParam
-		{
-			get => _addParam;
-			set
-			{
-				_addParam = value;
-				IsAddParamSetted = true;
-			}
-		}
+        internal bool IsAddParamSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the additional parameter which can be added after the IdName property.
+        /// </summary>
+        public string AddParam
+        {
+            get => _addParam;
+            set
+            {
+                _addParam = value;
+                IsAddParamSetted = true;
+            }
+        }
 
-		internal bool IsTargetSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the target.
-		/// </summary>
-		public string Target
-		{
-			get => _target;
-			set
-			{
-				_target = value;
-				IsTargetSetted = true;
-			}
-		}
+        internal bool IsTargetSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the target.
+        /// </summary>
+        public string Target
+        {
+            get => _target;
+            set
+            {
+                _target = value;
+                IsTargetSetted = true;
+            }
+        }
 
-		internal bool IsIdNameSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the first parameter that is added after the ShowAction.
-		/// </summary>
-		public string IdName
-		{
-			get => _idName;
-			set
-			{
-				_idName = value;
-				IsIdNameSetted = true;
-			}
-		}
+        internal bool IsIdNameSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the first parameter that is added after the ShowAction.
+        /// </summary>
+        public string IdName
+        {
+            get => _idName;
+            set
+            {
+                _idName = value;
+                IsIdNameSetted = true;
+            }
+        }
 
-		internal bool IsThousandsSeparatorSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the thousands separator.
-		/// </summary>
-		public string ThousandsSeparator
-		{
-			get => _thousandsSeparator;
-			set
-			{
-				_thousandsSeparator = value;
-				IsThousandsSeparatorSetted = true;
-			}
-		}
+        internal bool IsThousandsSeparatorSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the thousands separator.
+        /// </summary>
+        public string ThousandsSeparator
+        {
+            get => _thousandsSeparator;
+            set
+            {
+                _thousandsSeparator = value;
+                IsThousandsSeparatorSetted = true;
+            }
+        }
 
-		internal bool EditButton { get; set; }
+        internal bool EditButton { get; set; }
 
-		internal bool DeleteButton { get; set; }
+        internal bool DeleteButton { get; set; }
 
-		internal bool UseFormEditing { get; set; }
+        internal bool UseFormEditing { get; set; }
 
-		internal JqGridInlineNavigatorActionOptions InlineEditingOptions { get; set; }
+        internal JqGridInlineNavigatorActionOptions InlineEditingOptions { get; set; }
 
-		internal JqGridNavigatorEditActionOptions FormEditingOptions { get; set; }
+        internal JqGridNavigatorEditActionOptions FormEditingOptions { get; set; }
 
-		internal JqGridNavigatorDeleteActionOptions DeleteOptions { get; set; }
-		#endregion
+        internal JqGridNavigatorDeleteActionOptions DeleteOptions { get; set; }
+        #endregion
 
-		#region Constructors
-		/// <summary>
-		/// Initializes new instance of JqGridColumnFormatterOptions class.
-		/// </summary>
-		public JqGridColumnFormatterOptions()
-		{
+        #region Constructors
+        /// <summary>
+        /// Initializes new instance of JqGridColumnFormatterOptions class.
+        /// </summary>
+        public JqGridColumnFormatterOptions()
+        {
 
-			EditButton = true;
-			DeleteButton = true;
-			UseFormEditing = false;
-			InlineEditingOptions = null;
-			FormEditingOptions = null;
-			DeleteOptions = null;
-		}
-		#endregion
+            EditButton = true;
+            DeleteButton = true;
+            UseFormEditing = false;
+            InlineEditingOptions = null;
+            FormEditingOptions = null;
+            DeleteOptions = null;
+        }
+        #endregion
 
-		#region Methods
-		internal bool IsDefault(string formatter)
-		{
-			switch (formatter)
-			{
-				case JqGridColumnPredefinedFormatters.Integer:
-					return !IsDefaultValueSetted && !IsThousandsSeparatorSetted;
-				case JqGridColumnPredefinedFormatters.Number:
-					return !DecimalPlaces.HasValue && !IsDecimalSeparatorSetted && !IsDefaultValueSetted && !IsThousandsSeparatorSetted;
-				case JqGridColumnPredefinedFormatters.Currency:
-					return !DecimalPlaces.HasValue && !IsDecimalSeparatorSetted && !IsDefaultValueSetted && !IsPrefixSetted && !IsSuffixSetted && !IsThousandsSeparatorSetted;
-				case JqGridColumnPredefinedFormatters.Date:
-					return !IsSourceFormatSetted && !IsOutputFormatSetted;
-				case JqGridColumnPredefinedFormatters.Link:
-					return string.IsNullOrWhiteSpace(Target);
-				case JqGridColumnPredefinedFormatters.ShowLink:
-					return !IsBaseLinkUrlSetted && !IsShowActionSetted && !IsAddParamSetted && !IsTargetSetted && !IsIdNameSetted;
-				case JqGridColumnPredefinedFormatters.CheckBox:
-					return !Disabled.HasValue;
-				case JqGridColumnPredefinedFormatters.Actions:
-					return EditButton && DeleteButton && !UseFormEditing && InlineEditingOptions == null && FormEditingOptions == null && DeleteOptions == null;
-				default:
-					return true;
-			}
-		}
-		#endregion
-	}
+        #region Methods
+        internal bool IsDefault(string formatter)
+        {
+            switch (formatter)
+            {
+                case JqGridColumnPredefinedFormatters.Integer:
+                    return !IsDefaultValueSetted && !IsThousandsSeparatorSetted;
+                case JqGridColumnPredefinedFormatters.Number:
+                    return !DecimalPlaces.HasValue && !IsDecimalSeparatorSetted && !IsDefaultValueSetted && !IsThousandsSeparatorSetted;
+                case JqGridColumnPredefinedFormatters.Currency:
+                    return !DecimalPlaces.HasValue && !IsDecimalSeparatorSetted && !IsDefaultValueSetted && !IsPrefixSetted && !IsSuffixSetted && !IsThousandsSeparatorSetted;
+                case JqGridColumnPredefinedFormatters.Date:
+                    return !IsSourceFormatSetted && !IsOutputFormatSetted;
+                case JqGridColumnPredefinedFormatters.Link:
+                    return string.IsNullOrWhiteSpace(Target);
+                case JqGridColumnPredefinedFormatters.ShowLink:
+                    return !IsBaseLinkUrlSetted && !IsShowActionSetted && !IsAddParamSetted && !IsTargetSetted && !IsIdNameSetted;
+                case JqGridColumnPredefinedFormatters.CheckBox:
+                    return !Disabled.HasValue;
+                case JqGridColumnPredefinedFormatters.Actions:
+                    return EditButton && DeleteButton && !UseFormEditing && InlineEditingOptions == null && FormEditingOptions == null && DeleteOptions == null;
+                default:
+                    return true;
+            }
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnLabelOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnLabelOptions.cs
@@ -2,26 +2,26 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	internal class JqGridColumnLabelOptions
-	{
-		#region Properties
-		internal string Label { get; set; }
+    internal class JqGridColumnLabelOptions
+    {
+        #region Properties
+        internal string Label { get; set; }
 
-		internal string Class { get; set; }
+        internal string Class { get; set; }
 
-		internal IDictionary<string, object> CssStyles { get; set; }
+        internal IDictionary<string, object> CssStyles { get; set; }
 
-		internal IDictionary<string, object> HtmlAttributes { get; set; }
-		#endregion
+        internal IDictionary<string, object> HtmlAttributes { get; set; }
+        #endregion
 
-		#region Constructor
-		internal JqGridColumnLabelOptions()
-		{
-			Label = string.Empty;
-			Class = string.Empty;
-			CssStyles = null;
-			HtmlAttributes = null;
-		}
-		#endregion
-	}
+        #region Constructor
+        internal JqGridColumnLabelOptions()
+        {
+            Label = string.Empty;
+            Class = string.Empty;
+            CssStyles = null;
+            HtmlAttributes = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnLabelOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnLabelOptions.cs
@@ -1,30 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    internal class JqGridColumnLabelOptions
-    {
-        #region Properties
-        internal string Label { get; set; }
+	internal class JqGridColumnLabelOptions
+	{
+		#region Properties
+		internal string Label { get; set; }
 
-        internal string Class { get; set; }
+		internal string Class { get; set; }
 
-        internal IDictionary<string, object> CssStyles { get; set; }
+		internal IDictionary<string, object> CssStyles { get; set; }
 
-        internal IDictionary<string, object> HtmlAttributes { get; set; }
-        #endregion
+		internal IDictionary<string, object> HtmlAttributes { get; set; }
+		#endregion
 
-        #region Constructor
-        internal JqGridColumnLabelOptions()
-        {
-            Label = String.Empty;
-            Class = String.Empty;
-            CssStyles = null;
-            HtmlAttributes = null;
-        }
-        #endregion
-    }
+		#region Constructor
+		internal JqGridColumnLabelOptions()
+		{
+			Label = string.Empty;
+			Class = string.Empty;
+			CssStyles = null;
+			HtmlAttributes = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnModel.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnModel.cs
@@ -1,344 +1,308 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Runtime.Serialization;
 using System.Web.Mvc;
 using Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations;
 using System.ComponentModel.DataAnnotations;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jqGrid column parameters description.
-    /// </summary>
-    public class JqGridColumnModel
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the alignment of the cell in the body layer (default JqGridAligns.Left)
-        /// </summary>
-        public JqGridAlignments Alignment { get; set; }
+	/// <summary>
+	/// jqGrid column parameters description.
+	/// </summary>
+	public class JqGridColumnModel
+	{
+		#region Properties
 
-        /// <summary>
-        /// Gets or sets the function which can add attributes to the cell during the creation of the data (dynamically).
-        /// </summary>
-        public string CellAttributes { get; set; }
+		/// <summary>
+		/// Gets or sets the alignment of the cell in the body layer (default JqGridAligns.Left)
+		/// </summary>
+		public JqGridAlignments Alignment { get; set; } = JqGridAlignments.Default;
 
-        /// <summary>
-        /// Gets or sets additional CSS classes for the column (separated by space).
-        /// </summary>
-        public string Classes { get; set; }
+		/// <summary>
+		/// Gets or sets the function which can add attributes to the cell during the creation of the data (dynamically).
+		/// </summary>
+		public SettedString CellAttributes { get; set; }
 
-        /// <summary>
-        /// Gets or sets the expected date format for this column in case of date validation (default ISO date). 
-        /// </summary>
-        public string DateFormat { get; set; }
+		/// <summary>
+		/// Gets or sets additional CSS classes for the column (separated by space).
+		/// </summary>
+		public SettedString Classes { get; set; }
 
-        /// <summary>
-        /// Gets or set the value defining if this column can be edited.
-        /// </summary>
-        public bool Editable { get; set; }
+		/// <summary>
+		/// Gets or sets the expected date format for this column in case of date validation (default ISO date). 
+		/// </summary>
+		public SettedString DateFormat { get; set; }
 
-        /// <summary>
-        /// Gets or sets the options for editable column.
-        /// </summary>
-        public JqGridColumnEditOptions EditOptions { get; set; }
+		/// <summary>
+		/// Gets or set the value defining if this column can be edited.
+		/// </summary>
+		public bool? Editable { get; set; }
 
-        /// <summary>
-        /// Gets or sets the rules for editable column.
-        /// </summary>
-        public JqGridColumnRules EditRules { get; set; }
+		/// <summary>
+		/// Gets or sets the options for editable column.
+		/// </summary>
+		public JqGridColumnEditOptions EditOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type for editable column.
-        /// </summary>
-        public JqGridColumnEditTypes EditType { get; set; }
+		/// <summary>
+		/// Gets or sets the rules for editable column.
+		/// </summary>
+		public JqGridColumnRules EditRules { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if internal recalculation of the width of the column is disabled (default false).
-        /// </summary>
-        public bool Fixed { get; set; }
+		/// <summary>
+		/// Gets or sets the type for editable column.
+		/// </summary>
+		public JqGridColumnEditTypes EditType { get; set; } = JqGridColumnEditTypes.Default;
 
-        /// <summary>
-        /// Gets or sets the value which defines if column shouldn't scroll out of view when user is moving horizontally across the grid.
-        /// </summary>
-        public bool Frozen { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if internal recalculation of the width of the column is disabled (default false).
+		/// </summary>
+		public bool? Fixed { get; set; }
 
-        /// <summary>
-        /// Gets or sets the predefined formatter type ('' delimited string) or custom JavaScript formatting function name.
-        /// </summary>
-        public string Formatter { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if column shouldn't scroll out of view when user is moving horizontally across the grid.
+		/// </summary>
+		public bool? Frozen { get; set; }
 
-        /// <summary>
-        /// Gets or sets the options for predefined formatter (every predefined formatter uses only a subset of all options), which are overwriting the defaults from the language file.
-        /// </summary>
-        public JqGridColumnFormatterOptions FormatterOptions { get; set; }
+		/// <summary>
+		/// Gets or sets the predefined formatter type ('' delimited string) or custom JavaScript formatting function name.
+		/// </summary>
+		public SettedString Formatter { get; set; }
 
-        /// <summary>
-        /// Get or sets additional, used in form editing, options for editable column.
-        /// </summary>
-        public JqGridColumnFormOptions FormOptions { get; set; }
+		/// <summary>
+		/// Gets or sets the options for predefined formatter (every predefined formatter uses only a subset of all options), which are overwriting the defaults from the language file.
+		/// </summary>
+		public JqGridColumnFormatterOptions FormatterOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if this column is hidden at initialization (default false).
-        /// </summary>
-        public bool Hidden { get; set; }
+		/// <summary>
+		/// Get or sets additional, used in form editing, options for editable column.
+		/// </summary>
+		public JqGridColumnFormOptions FormOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if this column will appear in the modal dialog where users can choose which columns to show or hide.
-        /// </summary>
-        public bool HideInDialog { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if this column is hidden at initialization (default false).
+		/// </summary>
+		public bool? Hidden { get; set; }
 
-        /// <summary>
-        /// Gets or sets the sorting order for first column sorting.
-        /// </summary>
-        public JqGridSortingOrders InitialSortingOrder { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if this column will appear in the modal dialog where users can choose which columns to show or hide.
+		/// </summary>
+		public bool? HideInDialog { get; set; }
 
-        /// <summary>
-        /// Gets or sets the JSON mapping for the column in the incoming JSON string.
-        /// </summary>
-        public string JsonMapping { get; set; }
+		/// <summary>
+		/// Gets or sets the sorting order for first column sorting.
+		/// </summary>
+		public JqGridSortingOrders InitialSortingOrder { get; set; } = JqGridSortingOrders.Default;
 
-        /// <summary>
-        /// Defines if this column value should be used as unique row id (in case there is no id from the server). 
-        /// </summary>
-        public bool Key { get; set; }
+		/// <summary>
+		/// Gets or sets the JSON mapping for the column in the incoming JSON string.
+		/// </summary>
+		public string JsonMapping { get; set; }
 
-        internal JqGridColumnLabelOptions LabelOptions { get; set; }
+		/// <summary>
+		/// Defines if this column value should be used as unique row id (in case there is no id from the server). 
+		/// </summary>
+		public bool? Key { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if column can be resized (default true).
-        /// </summary>
-        public bool Resizable { get; set; }
+		internal JqGridColumnLabelOptions LabelOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value defining if this column can be searched.
-        /// </summary>
-        public bool Searchable { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if column can be resized (default true).
+		/// </summary>
+		public bool? Resizable { get; set; }
 
-        /// <summary>
-        /// Gets or sets the options for searchable column.
-        /// </summary>
-        public JqGridColumnSearchOptions SearchOptions { get; set; }
+		/// <summary>
+		/// Gets or sets the value defining if this column can be searched.
+		/// </summary>
+		public bool? Searchable { get; set; }
 
-        /// <summary>
-        /// Gets or sets the additional conditions for validating user input in search field.
-        /// </summary>
-        public JqGridColumnRules SearchRules { get; set; }
+		/// <summary>
+		/// Gets or sets the options for searchable column.
+		/// </summary>
+		public JqGridColumnSearchOptions SearchOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type of the search field for the column.
-        /// </summary>
-        public JqGridColumnSearchTypes SearchType { get; set; }
+		/// <summary>
+		/// Gets or sets the additional conditions for validating user input in search field.
+		/// </summary>
+		public JqGridColumnRules SearchRules { get; set; }
 
-        /// <summary>
-        /// Gets or sets the grouping summary type.
-        /// </summary>
-        public JqGridColumnSummaryTypes? SummaryType { get; set; }
+		/// <summary>
+		/// Gets or sets the type of the search field for the column.
+		/// </summary>
+		public JqGridColumnSearchTypes SearchType { get; set; } = JqGridColumnSearchTypes.Default;
 
-        /// <summary>
-        /// Gets or sets the grouping summary template.
-        /// </summary>
-        public string SummaryTemplate { get; set; }
+		/// <summary>
+		/// Gets or sets the grouping summary type.
+		/// </summary>
+		public JqGridColumnSummaryTypes? SummaryType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the grouping summary function for custom type.
-        /// </summary>
-        public string SummaryFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the grouping summary template.
+		/// </summary>
+		public SettedString SummaryTemplate { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value defining if this column can be sorted.
-        /// </summary>
-        public bool Sortable { get; set; }
+		/// <summary>
+		/// Gets or sets the grouping summary function for custom type.
+		/// </summary>
+		public string SummaryFunction { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type of the column for appropriate sorting when datatype is local.
-        /// </summary>
-        public JqGridColumnSortTypes SortType { get; set; }
+		/// <summary>
+		/// Gets or sets the value defining if this column can be sorted.
+		/// </summary>
+		public bool? Sortable { get; set; }
 
-        /// <summary>
-        /// Gets or sets the custom sorting function when the SortType is set to JqGridColumnSortTypes.Function.
-        /// </summary>
-        public string SortFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the type of the column for appropriate sorting when datatype is local.
+		/// </summary>
+		public JqGridColumnSortTypes SortType { get; set; } = JqGridColumnSortTypes.Default;
 
-        /// <summary>
-        /// Gets or sets the index name for sorting and searching (default String.Empty)
-        /// </summary>
-        public string Index { get; set; }
+		/// <summary>
+		/// Gets or sets the custom sorting function when the SortType is set to JqGridColumnSortTypes.Function.
+		/// </summary>
+		public SettedString SortFunction { get; set; }
 
-        /// <summary>
-        /// Gets the unique name for the column.
-        /// </summary>
-        public string Name { get; private set; }
+		/// <summary>
+		/// Gets or sets the index name for sorting and searching (default String.Empty)
+		/// </summary>
+		public SettedString Index { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if the title should be displayed in the column when user hovers a cell with the mouse.
-        /// </summary>
-        public bool Title { get; set; }
+		/// <summary>
+		/// Gets the unique name for the column.
+		/// </summary>
+		public string Name { get; }
 
-        /// <summary>
-        /// Gets or sets the custom function to "unformat" a value of the cell when used in editing or client-side sorting
-        /// </summary>
-        public string UnFormatter { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if the title should be displayed in the column when user hovers a cell with the mouse.
+		/// </summary>
+		public bool? Title { get; set; }
 
-        /// <summary>
-        /// Gets or sets the initial width in pixels of the column (default 150).
-        /// </summary>
-        public int Width { get; set; }
+		/// <summary>
+		/// Gets or sets the custom function to "unformat" a value of the cell when used in editing or client-side sorting
+		/// </summary>
+		public SettedString UnFormatter { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if the column should appear in view form.
-        /// </summary>
-        public bool Viewable { get; set; }
+		/// <summary>
+		/// Gets or sets the initial width in pixels of the column (default 150).
+		/// </summary>
+		public int? Width { get; set; }
 
-        /// <summary>
-        /// Gets or sets the XML mapping for the column in the incomming XML file.
-        /// </summary>
-        public string XmlMapping { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the value which defines if the column should appear in view form.
+		/// </summary>
+		public bool? Viewable { get; set; }
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnModel class.
-        /// </summary>
-        /// <param name="name">The unique name for the column.</param>
-        public JqGridColumnModel(string name)
-        {
-            Alignment = JqGridAlignments.Left;
-            CellAttributes = null;
-            DateFormat = JqGridOptionsDefaults.DateFormat;
-            Editable = false;
-            EditOptions = null;
-            EditRules = null;
-            EditType = JqGridColumnEditTypes.Text;
-            Fixed = false;
-            FormOptions = null;
-            Formatter = String.Empty;
-            FormatterOptions = null;
-            InitialSortingOrder = JqGridSortingOrders.Asc;
-            Hidden = false;
-            HideInDialog = false;
-            Index = String.Empty;
-            JsonMapping = null;
-            Key = false;
-            LabelOptions = null;
-            Name = name;
-            Resizable = true;
-            Searchable = true;
-            SearchOptions = null;
-            SearchRules = null;
-            SearchType = JqGridColumnSearchTypes.Text;
-            SummaryType = null;
-            SummaryTemplate = "{0}";
-            SummaryFunction = null;
-            Sortable = true;
-            SortType = JqGridColumnSortTypes.Text;
-            SortFunction = String.Empty;
-            Title = true;
-            UnFormatter = String.Empty;
-            Width = 150;
-            Viewable = true;
-            XmlMapping = null;
-        }
+		/// <summary>
+		/// Gets or sets the XML mapping for the column in the incomming XML file.
+		/// </summary>
+		public string XmlMapping { get; set; }
+		#endregion
 
-        internal JqGridColumnModel(ModelMetadata propertyMetadata)
-            : this(propertyMetadata.PropertyName)
-        {
-            IEnumerable<object> customAttributes  = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnModel class.
+		/// </summary>
+		/// <param name="name">The unique name for the column.</param>
+		public JqGridColumnModel(string name)
+		{
+			Name = name;
+		}
 
-            TimestampAttribute timeStampAttribute = customAttributes.OfType<TimestampAttribute>().FirstOrDefault();
-            if (timeStampAttribute != null)
-            {
-                Editable = true;
-                Hidden = true;
-            }
-            else
-            {
-                RangeAttribute rangeAttribute = customAttributes.OfType<RangeAttribute>().FirstOrDefault();
+		internal JqGridColumnModel(ModelMetadata propertyMetadata)
+			: this(propertyMetadata.PropertyName)
+		{
+			var customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
 
-                Alignment = propertyMetadata.GetColumnAlignment();
-                CellAttributes = propertyMetadata.GetColumnCellAttributes();
-                Classes = propertyMetadata.GetColumnClasses();
-                DateFormat = propertyMetadata.GetColumnDateFormat();
-                Fixed = propertyMetadata.GetColumnFixed();
-                Frozen = propertyMetadata.GetColumnFrozen();
-                Key = propertyMetadata.GetColumnKey();
-                Resizable = propertyMetadata.GetColumnResizable();
-                Title = propertyMetadata.GetColumnTitle();
-                Width = propertyMetadata.GetColumnWidth();
-                Viewable = propertyMetadata.GetColumnViewable();
+			var timeStampAttribute = customAttributes.OfType<TimestampAttribute>().FirstOrDefault();
+			if (timeStampAttribute != null)
+			{
+				Editable = true;
+				Hidden = true;
+			}
+			else
+			{
+				var rangeAttribute = customAttributes.OfType<RangeAttribute>().FirstOrDefault();
 
-                Editable = propertyMetadata.GetColumnEditable();
-                EditOptions = propertyMetadata.GetColumnEditOptions();
-                if (EditOptions != null)
-                {
-                    StringLengthAttribute stringLengthAttribute = customAttributes.OfType<StringLengthAttribute>().FirstOrDefault();
-                    if (stringLengthAttribute != null)
-                    {
-                        if (EditOptions.HtmlAttributes == null)
-                            EditOptions.HtmlAttributes = new Dictionary<string, object>();
+				Alignment = propertyMetadata.GetColumnAlignment();
+				CellAttributes = propertyMetadata.GetColumnCellAttributes();
+				Classes = propertyMetadata.GetColumnClasses();
+				DateFormat = propertyMetadata.GetColumnDateFormat();
+				Fixed = propertyMetadata.GetColumnFixed();
+				Frozen = propertyMetadata.GetColumnFrozen();
+				Key = propertyMetadata.GetColumnKey();
+				Resizable = propertyMetadata.GetColumnResizable();
+				Title = propertyMetadata.GetColumnTitle();
+				Width = propertyMetadata.GetColumnWidth();
+				Viewable = propertyMetadata.GetColumnViewable();
 
-                        if (EditOptions.HtmlAttributes.ContainsKey("maxlength"))
-                            EditOptions.HtmlAttributes["maxlength"] = stringLengthAttribute.MaximumLength;
-                        else
-                            EditOptions.HtmlAttributes.Add("maxlength", stringLengthAttribute.MaximumLength);
-                    }
-                }
-                EditRules = propertyMetadata.GetColumnEditRules();
-                if (EditRules != null)
-                {
-                    RequiredAttribute requiredAttribute = customAttributes.OfType<RequiredAttribute>().FirstOrDefault();
-                    if (requiredAttribute != null)
-                        EditRules.Required = true;
+				Editable = propertyMetadata.GetColumnEditable();
+				EditOptions = propertyMetadata.GetColumnEditOptions();
+				if (EditOptions != null)
+				{
+					var stringLengthAttribute = customAttributes.OfType<StringLengthAttribute>().FirstOrDefault();
+					if (stringLengthAttribute != null)
+					{
+						if (EditOptions.HtmlAttributes == null)
+							EditOptions.HtmlAttributes = new Dictionary<string, object>();
 
-                    if (rangeAttribute != null)
-                    {
-                        EditRules.MaxValue = Convert.ToDouble(rangeAttribute.Maximum);
-                        EditRules.MinValue = Convert.ToDouble(rangeAttribute.Minimum);
-                    }
-                }
-                EditType = propertyMetadata.GetColumnEditType();
+						if (EditOptions.HtmlAttributes.ContainsKey("maxlength"))
+							EditOptions.HtmlAttributes["maxlength"] = stringLengthAttribute.MaximumLength;
+						else
+							EditOptions.HtmlAttributes.Add("maxlength", stringLengthAttribute.MaximumLength);
+					}
+				}
+				EditRules = propertyMetadata.GetColumnEditRules();
+				if (EditRules != null)
+				{
+					var requiredAttribute = customAttributes.OfType<RequiredAttribute>().FirstOrDefault();
+					if (requiredAttribute != null)
+						EditRules.Required = true;
 
-                Formatter = propertyMetadata.GetColumnFormatter();
-                FormatterOptions = propertyMetadata.GetColumnFormatterOptions();
-                UnFormatter = propertyMetadata.GetColumnUnFormatter();
+					if (rangeAttribute != null)
+					{
+						EditRules.MaxValue = Convert.ToDouble(rangeAttribute.Maximum);
+						EditRules.MinValue = Convert.ToDouble(rangeAttribute.Minimum);
+					}
+				}
+				EditType = propertyMetadata.GetColumnEditType();
 
-                FormOptions = propertyMetadata.GetColumnFormOptions();
+				Formatter = propertyMetadata.GetColumnFormatter();
+				FormatterOptions = propertyMetadata.GetColumnFormatterOptions();
+				UnFormatter = propertyMetadata.GetColumnUnFormatter();
 
-                LabelOptions = propertyMetadata.GetColumnLabelOptions();
+				FormOptions = propertyMetadata.GetColumnFormOptions();
 
-                Searchable = propertyMetadata.GetColumnSearchable();
-                SearchOptions = propertyMetadata.GetColumnSearchOptions();
-                SearchRules = propertyMetadata.GetColumnSearchRules();
-                if (SearchRules != null && rangeAttribute != null)
-                {
-                    SearchRules.MaxValue = Convert.ToDouble(rangeAttribute.Maximum);
-                    SearchRules.MinValue = Convert.ToDouble(rangeAttribute.Minimum);
-                }
-                SearchType = propertyMetadata.GetColumnSearchType();
+				LabelOptions = propertyMetadata.GetColumnLabelOptions();
 
-                InitialSortingOrder = propertyMetadata.GetColumnInitialSortingOrder();
-                Sortable = propertyMetadata.GetColumnSortable();
-                SortType = propertyMetadata.GetColumnSortType();
-                SortFunction = propertyMetadata.GetColumnSortFunction();
-                Index = propertyMetadata.GetColumnIndex();
+				Searchable = propertyMetadata.GetColumnSearchable();
+				SearchOptions = propertyMetadata.GetColumnSearchOptions();
+				SearchRules = propertyMetadata.GetColumnSearchRules();
+				if (SearchRules != null && rangeAttribute != null)
+				{
+					SearchRules.MaxValue = Convert.ToDouble(rangeAttribute.Maximum);
+					SearchRules.MinValue = Convert.ToDouble(rangeAttribute.Minimum);
+				}
+				SearchType = propertyMetadata.GetColumnSearchType();
 
-                SummaryType = propertyMetadata.GetColumnSummaryType();
-                SummaryTemplate = propertyMetadata.GetColumnSummaryTemplate();
-                SummaryFunction = propertyMetadata.GetColumnSummaryFunction();
+				InitialSortingOrder = propertyMetadata.GetColumnInitialSortingOrder();
+				Sortable = propertyMetadata.GetColumnSortable();
+				SortType = propertyMetadata.GetColumnSortType();
+				SortFunction = propertyMetadata.GetColumnSortFunction();
+				Index = propertyMetadata.GetColumnIndex();
 
-                if (!String.IsNullOrWhiteSpace(propertyMetadata.TemplateHint) && propertyMetadata.TemplateHint.Equals("HiddenInput"))
-                    Hidden = true;
-                else
-                    Hidden = false;
-                HideInDialog = propertyMetadata.GetColumnHideInDialog();
-            }
+				SummaryType = propertyMetadata.GetColumnSummaryType();
+				SummaryTemplate = propertyMetadata.GetColumnSummaryTemplate();
+				SummaryFunction = propertyMetadata.GetColumnSummaryFunction();
 
-            JsonMapping = propertyMetadata.GetColumnJsonMapping();
-            XmlMapping = propertyMetadata.GetColumnXmlMapping();
-        }
-        #endregion
-    }
+				if (!string.IsNullOrWhiteSpace(propertyMetadata.TemplateHint) && propertyMetadata.TemplateHint.Equals("HiddenInput"))
+					Hidden = true;
+				else
+					Hidden = false;
+				HideInDialog = propertyMetadata.GetColumnHideInDialog();
+			}
+
+			JsonMapping = propertyMetadata.GetColumnJsonMapping();
+			XmlMapping = propertyMetadata.GetColumnXmlMapping();
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnModel.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnModel.cs
@@ -7,302 +7,302 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// jqGrid column parameters description.
-	/// </summary>
-	public class JqGridColumnModel
-	{
-		#region Properties
+    /// <summary>
+    /// jqGrid column parameters description.
+    /// </summary>
+    public class JqGridColumnModel
+    {
+        #region Properties
 
-		/// <summary>
-		/// Gets or sets the alignment of the cell in the body layer (default JqGridAligns.Left)
-		/// </summary>
-		public JqGridAlignments Alignment { get; set; } = JqGridAlignments.Default;
+        /// <summary>
+        /// Gets or sets the alignment of the cell in the body layer (default JqGridAligns.Left)
+        /// </summary>
+        public JqGridAlignments Alignment { get; set; } = JqGridAlignments.Default;
 
-		/// <summary>
-		/// Gets or sets the function which can add attributes to the cell during the creation of the data (dynamically).
-		/// </summary>
-		public SettedString CellAttributes { get; set; }
+        /// <summary>
+        /// Gets or sets the function which can add attributes to the cell during the creation of the data (dynamically).
+        /// </summary>
+        public SettedString CellAttributes { get; set; }
 
-		/// <summary>
-		/// Gets or sets additional CSS classes for the column (separated by space).
-		/// </summary>
-		public SettedString Classes { get; set; }
+        /// <summary>
+        /// Gets or sets additional CSS classes for the column (separated by space).
+        /// </summary>
+        public SettedString Classes { get; set; }
 
-		/// <summary>
-		/// Gets or sets the expected date format for this column in case of date validation (default ISO date). 
-		/// </summary>
-		public SettedString DateFormat { get; set; }
+        /// <summary>
+        /// Gets or sets the expected date format for this column in case of date validation (default ISO date). 
+        /// </summary>
+        public SettedString DateFormat { get; set; }
 
-		/// <summary>
-		/// Gets or set the value defining if this column can be edited.
-		/// </summary>
-		public bool? Editable { get; set; }
+        /// <summary>
+        /// Gets or set the value defining if this column can be edited.
+        /// </summary>
+        public bool? Editable { get; set; }
 
-		/// <summary>
-		/// Gets or sets the options for editable column.
-		/// </summary>
-		public JqGridColumnEditOptions EditOptions { get; set; }
+        /// <summary>
+        /// Gets or sets the options for editable column.
+        /// </summary>
+        public JqGridColumnEditOptions EditOptions { get; set; }
 
-		/// <summary>
-		/// Gets or sets the rules for editable column.
-		/// </summary>
-		public JqGridColumnRules EditRules { get; set; }
+        /// <summary>
+        /// Gets or sets the rules for editable column.
+        /// </summary>
+        public JqGridColumnRules EditRules { get; set; }
 
-		/// <summary>
-		/// Gets or sets the type for editable column.
-		/// </summary>
-		public JqGridColumnEditTypes EditType { get; set; } = JqGridColumnEditTypes.Default;
+        /// <summary>
+        /// Gets or sets the type for editable column.
+        /// </summary>
+        public JqGridColumnEditTypes EditType { get; set; } = JqGridColumnEditTypes.Default;
 
-		/// <summary>
-		/// Gets or sets the value which defines if internal recalculation of the width of the column is disabled (default false).
-		/// </summary>
-		public bool? Fixed { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if internal recalculation of the width of the column is disabled (default false).
+        /// </summary>
+        public bool? Fixed { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if column shouldn't scroll out of view when user is moving horizontally across the grid.
-		/// </summary>
-		public bool? Frozen { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if column shouldn't scroll out of view when user is moving horizontally across the grid.
+        /// </summary>
+        public bool? Frozen { get; set; }
 
-		/// <summary>
-		/// Gets or sets the predefined formatter type ('' delimited string) or custom JavaScript formatting function name.
-		/// </summary>
-		public SettedString Formatter { get; set; }
+        /// <summary>
+        /// Gets or sets the predefined formatter type ('' delimited string) or custom JavaScript formatting function name.
+        /// </summary>
+        public SettedString Formatter { get; set; }
 
-		/// <summary>
-		/// Gets or sets the options for predefined formatter (every predefined formatter uses only a subset of all options), which are overwriting the defaults from the language file.
-		/// </summary>
-		public JqGridColumnFormatterOptions FormatterOptions { get; set; }
+        /// <summary>
+        /// Gets or sets the options for predefined formatter (every predefined formatter uses only a subset of all options), which are overwriting the defaults from the language file.
+        /// </summary>
+        public JqGridColumnFormatterOptions FormatterOptions { get; set; }
 
-		/// <summary>
-		/// Get or sets additional, used in form editing, options for editable column.
-		/// </summary>
-		public JqGridColumnFormOptions FormOptions { get; set; }
+        /// <summary>
+        /// Get or sets additional, used in form editing, options for editable column.
+        /// </summary>
+        public JqGridColumnFormOptions FormOptions { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if this column is hidden at initialization (default false).
-		/// </summary>
-		public bool? Hidden { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if this column is hidden at initialization (default false).
+        /// </summary>
+        public bool? Hidden { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if this column will appear in the modal dialog where users can choose which columns to show or hide.
-		/// </summary>
-		public bool? HideInDialog { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if this column will appear in the modal dialog where users can choose which columns to show or hide.
+        /// </summary>
+        public bool? HideInDialog { get; set; }
 
-		/// <summary>
-		/// Gets or sets the sorting order for first column sorting.
-		/// </summary>
-		public JqGridSortingOrders InitialSortingOrder { get; set; } = JqGridSortingOrders.Default;
+        /// <summary>
+        /// Gets or sets the sorting order for first column sorting.
+        /// </summary>
+        public JqGridSortingOrders InitialSortingOrder { get; set; } = JqGridSortingOrders.Default;
 
-		/// <summary>
-		/// Gets or sets the JSON mapping for the column in the incoming JSON string.
-		/// </summary>
-		public string JsonMapping { get; set; }
+        /// <summary>
+        /// Gets or sets the JSON mapping for the column in the incoming JSON string.
+        /// </summary>
+        public string JsonMapping { get; set; }
 
-		/// <summary>
-		/// Defines if this column value should be used as unique row id (in case there is no id from the server). 
-		/// </summary>
-		public bool? Key { get; set; }
+        /// <summary>
+        /// Defines if this column value should be used as unique row id (in case there is no id from the server). 
+        /// </summary>
+        public bool? Key { get; set; }
 
-		internal JqGridColumnLabelOptions LabelOptions { get; set; }
+        internal JqGridColumnLabelOptions LabelOptions { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if column can be resized (default true).
-		/// </summary>
-		public bool? Resizable { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if column can be resized (default true).
+        /// </summary>
+        public bool? Resizable { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value defining if this column can be searched.
-		/// </summary>
-		public bool? Searchable { get; set; }
+        /// <summary>
+        /// Gets or sets the value defining if this column can be searched.
+        /// </summary>
+        public bool? Searchable { get; set; }
 
-		/// <summary>
-		/// Gets or sets the options for searchable column.
-		/// </summary>
-		public JqGridColumnSearchOptions SearchOptions { get; set; }
+        /// <summary>
+        /// Gets or sets the options for searchable column.
+        /// </summary>
+        public JqGridColumnSearchOptions SearchOptions { get; set; }
 
-		/// <summary>
-		/// Gets or sets the additional conditions for validating user input in search field.
-		/// </summary>
-		public JqGridColumnRules SearchRules { get; set; }
+        /// <summary>
+        /// Gets or sets the additional conditions for validating user input in search field.
+        /// </summary>
+        public JqGridColumnRules SearchRules { get; set; }
 
-		/// <summary>
-		/// Gets or sets the type of the search field for the column.
-		/// </summary>
-		public JqGridColumnSearchTypes SearchType { get; set; } = JqGridColumnSearchTypes.Default;
+        /// <summary>
+        /// Gets or sets the type of the search field for the column.
+        /// </summary>
+        public JqGridColumnSearchTypes SearchType { get; set; } = JqGridColumnSearchTypes.Default;
 
-		/// <summary>
-		/// Gets or sets the grouping summary type.
-		/// </summary>
-		public JqGridColumnSummaryTypes? SummaryType { get; set; }
+        /// <summary>
+        /// Gets or sets the grouping summary type.
+        /// </summary>
+        public JqGridColumnSummaryTypes? SummaryType { get; set; }
 
-		/// <summary>
-		/// Gets or sets the grouping summary template.
-		/// </summary>
-		public SettedString SummaryTemplate { get; set; }
+        /// <summary>
+        /// Gets or sets the grouping summary template.
+        /// </summary>
+        public SettedString SummaryTemplate { get; set; }
 
-		/// <summary>
-		/// Gets or sets the grouping summary function for custom type.
-		/// </summary>
-		public string SummaryFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the grouping summary function for custom type.
+        /// </summary>
+        public string SummaryFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value defining if this column can be sorted.
-		/// </summary>
-		public bool? Sortable { get; set; }
+        /// <summary>
+        /// Gets or sets the value defining if this column can be sorted.
+        /// </summary>
+        public bool? Sortable { get; set; }
 
-		/// <summary>
-		/// Gets or sets the type of the column for appropriate sorting when datatype is local.
-		/// </summary>
-		public JqGridColumnSortTypes SortType { get; set; } = JqGridColumnSortTypes.Default;
+        /// <summary>
+        /// Gets or sets the type of the column for appropriate sorting when datatype is local.
+        /// </summary>
+        public JqGridColumnSortTypes SortType { get; set; } = JqGridColumnSortTypes.Default;
 
-		/// <summary>
-		/// Gets or sets the custom sorting function when the SortType is set to JqGridColumnSortTypes.Function.
-		/// </summary>
-		public SettedString SortFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the custom sorting function when the SortType is set to JqGridColumnSortTypes.Function.
+        /// </summary>
+        public SettedString SortFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets the index name for sorting and searching (default String.Empty)
-		/// </summary>
-		public SettedString Index { get; set; }
+        /// <summary>
+        /// Gets or sets the index name for sorting and searching (default String.Empty)
+        /// </summary>
+        public SettedString Index { get; set; }
 
-		/// <summary>
-		/// Gets the unique name for the column.
-		/// </summary>
-		public string Name { get; }
+        /// <summary>
+        /// Gets the unique name for the column.
+        /// </summary>
+        public string Name { get; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if the title should be displayed in the column when user hovers a cell with the mouse.
-		/// </summary>
-		public bool? Title { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if the title should be displayed in the column when user hovers a cell with the mouse.
+        /// </summary>
+        public bool? Title { get; set; }
 
-		/// <summary>
-		/// Gets or sets the custom function to "unformat" a value of the cell when used in editing or client-side sorting
-		/// </summary>
-		public SettedString UnFormatter { get; set; }
+        /// <summary>
+        /// Gets or sets the custom function to "unformat" a value of the cell when used in editing or client-side sorting
+        /// </summary>
+        public SettedString UnFormatter { get; set; }
 
-		/// <summary>
-		/// Gets or sets the initial width in pixels of the column (default 150).
-		/// </summary>
-		public int? Width { get; set; }
+        /// <summary>
+        /// Gets or sets the initial width in pixels of the column (default 150).
+        /// </summary>
+        public int? Width { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if the column should appear in view form.
-		/// </summary>
-		public bool? Viewable { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if the column should appear in view form.
+        /// </summary>
+        public bool? Viewable { get; set; }
 
-		/// <summary>
-		/// Gets or sets the XML mapping for the column in the incomming XML file.
-		/// </summary>
-		public string XmlMapping { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the XML mapping for the column in the incomming XML file.
+        /// </summary>
+        public string XmlMapping { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnModel class.
-		/// </summary>
-		/// <param name="name">The unique name for the column.</param>
-		public JqGridColumnModel(string name)
-		{
-			Name = name;
-		}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnModel class.
+        /// </summary>
+        /// <param name="name">The unique name for the column.</param>
+        public JqGridColumnModel(string name)
+        {
+            Name = name;
+        }
 
-		internal JqGridColumnModel(ModelMetadata propertyMetadata)
-			: this(propertyMetadata.PropertyName)
-		{
-			var customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
+        internal JqGridColumnModel(ModelMetadata propertyMetadata)
+            : this(propertyMetadata.PropertyName)
+        {
+            IEnumerable<object> customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
 
-			var timeStampAttribute = customAttributes.OfType<TimestampAttribute>().FirstOrDefault();
-			if (timeStampAttribute != null)
-			{
-				Editable = true;
-				Hidden = true;
-			}
-			else
-			{
-				var rangeAttribute = customAttributes.OfType<RangeAttribute>().FirstOrDefault();
+            TimestampAttribute timeStampAttribute = customAttributes.OfType<TimestampAttribute>().FirstOrDefault();
+            if (timeStampAttribute != null)
+            {
+                Editable = true;
+                Hidden = true;
+            }
+            else
+            {
+                RangeAttribute rangeAttribute = customAttributes.OfType<RangeAttribute>().FirstOrDefault();
 
-				Alignment = propertyMetadata.GetColumnAlignment();
-				CellAttributes = propertyMetadata.GetColumnCellAttributes();
-				Classes = propertyMetadata.GetColumnClasses();
-				DateFormat = propertyMetadata.GetColumnDateFormat();
-				Fixed = propertyMetadata.GetColumnFixed();
-				Frozen = propertyMetadata.GetColumnFrozen();
-				Key = propertyMetadata.GetColumnKey();
-				Resizable = propertyMetadata.GetColumnResizable();
-				Title = propertyMetadata.GetColumnTitle();
-				Width = propertyMetadata.GetColumnWidth();
-				Viewable = propertyMetadata.GetColumnViewable();
+                Alignment = propertyMetadata.GetColumnAlignment();
+                CellAttributes = propertyMetadata.GetColumnCellAttributes();
+                Classes = propertyMetadata.GetColumnClasses();
+                DateFormat = propertyMetadata.GetColumnDateFormat();
+                Fixed = propertyMetadata.GetColumnFixed();
+                Frozen = propertyMetadata.GetColumnFrozen();
+                Key = propertyMetadata.GetColumnKey();
+                Resizable = propertyMetadata.GetColumnResizable();
+                Title = propertyMetadata.GetColumnTitle();
+                Width = propertyMetadata.GetColumnWidth();
+                Viewable = propertyMetadata.GetColumnViewable();
 
-				Editable = propertyMetadata.GetColumnEditable();
-				EditOptions = propertyMetadata.GetColumnEditOptions();
-				if (EditOptions != null)
-				{
-					var stringLengthAttribute = customAttributes.OfType<StringLengthAttribute>().FirstOrDefault();
-					if (stringLengthAttribute != null)
-					{
-						if (EditOptions.HtmlAttributes == null)
-							EditOptions.HtmlAttributes = new Dictionary<string, object>();
+                Editable = propertyMetadata.GetColumnEditable();
+                EditOptions = propertyMetadata.GetColumnEditOptions();
+                if (EditOptions != null)
+                {
+                    StringLengthAttribute stringLengthAttribute = customAttributes.OfType<StringLengthAttribute>().FirstOrDefault();
+                    if (stringLengthAttribute != null)
+                    {
+                        if (EditOptions.HtmlAttributes == null)
+                            EditOptions.HtmlAttributes = new Dictionary<string, object>();
 
-						if (EditOptions.HtmlAttributes.ContainsKey("maxlength"))
-							EditOptions.HtmlAttributes["maxlength"] = stringLengthAttribute.MaximumLength;
-						else
-							EditOptions.HtmlAttributes.Add("maxlength", stringLengthAttribute.MaximumLength);
-					}
-				}
-				EditRules = propertyMetadata.GetColumnEditRules();
-				if (EditRules != null)
-				{
-					var requiredAttribute = customAttributes.OfType<RequiredAttribute>().FirstOrDefault();
-					if (requiredAttribute != null)
-						EditRules.Required = true;
+                        if (EditOptions.HtmlAttributes.ContainsKey("maxlength"))
+                            EditOptions.HtmlAttributes["maxlength"] = stringLengthAttribute.MaximumLength;
+                        else
+                            EditOptions.HtmlAttributes.Add("maxlength", stringLengthAttribute.MaximumLength);
+                    }
+                }
+                EditRules = propertyMetadata.GetColumnEditRules();
+                if (EditRules != null)
+                {
+                    RequiredAttribute requiredAttribute = customAttributes.OfType<RequiredAttribute>().FirstOrDefault();
+                    if (requiredAttribute != null)
+                        EditRules.Required = true;
 
-					if (rangeAttribute != null)
-					{
-						EditRules.MaxValue = Convert.ToDouble(rangeAttribute.Maximum);
-						EditRules.MinValue = Convert.ToDouble(rangeAttribute.Minimum);
-					}
-				}
-				EditType = propertyMetadata.GetColumnEditType();
+                    if (rangeAttribute != null)
+                    {
+                        EditRules.MaxValue = Convert.ToDouble(rangeAttribute.Maximum);
+                        EditRules.MinValue = Convert.ToDouble(rangeAttribute.Minimum);
+                    }
+                }
+                EditType = propertyMetadata.GetColumnEditType();
 
-				Formatter = propertyMetadata.GetColumnFormatter();
-				FormatterOptions = propertyMetadata.GetColumnFormatterOptions();
-				UnFormatter = propertyMetadata.GetColumnUnFormatter();
+                Formatter = propertyMetadata.GetColumnFormatter();
+                FormatterOptions = propertyMetadata.GetColumnFormatterOptions();
+                UnFormatter = propertyMetadata.GetColumnUnFormatter();
 
-				FormOptions = propertyMetadata.GetColumnFormOptions();
+                FormOptions = propertyMetadata.GetColumnFormOptions();
 
-				LabelOptions = propertyMetadata.GetColumnLabelOptions();
+                LabelOptions = propertyMetadata.GetColumnLabelOptions();
 
-				Searchable = propertyMetadata.GetColumnSearchable();
-				SearchOptions = propertyMetadata.GetColumnSearchOptions();
-				SearchRules = propertyMetadata.GetColumnSearchRules();
-				if (SearchRules != null && rangeAttribute != null)
-				{
-					SearchRules.MaxValue = Convert.ToDouble(rangeAttribute.Maximum);
-					SearchRules.MinValue = Convert.ToDouble(rangeAttribute.Minimum);
-				}
-				SearchType = propertyMetadata.GetColumnSearchType();
+                Searchable = propertyMetadata.GetColumnSearchable();
+                SearchOptions = propertyMetadata.GetColumnSearchOptions();
+                SearchRules = propertyMetadata.GetColumnSearchRules();
+                if (SearchRules != null && rangeAttribute != null)
+                {
+                    SearchRules.MaxValue = Convert.ToDouble(rangeAttribute.Maximum);
+                    SearchRules.MinValue = Convert.ToDouble(rangeAttribute.Minimum);
+                }
+                SearchType = propertyMetadata.GetColumnSearchType();
 
-				InitialSortingOrder = propertyMetadata.GetColumnInitialSortingOrder();
-				Sortable = propertyMetadata.GetColumnSortable();
-				SortType = propertyMetadata.GetColumnSortType();
-				SortFunction = propertyMetadata.GetColumnSortFunction();
-				Index = propertyMetadata.GetColumnIndex();
+                InitialSortingOrder = propertyMetadata.GetColumnInitialSortingOrder();
+                Sortable = propertyMetadata.GetColumnSortable();
+                SortType = propertyMetadata.GetColumnSortType();
+                SortFunction = propertyMetadata.GetColumnSortFunction();
+                Index = propertyMetadata.GetColumnIndex();
 
-				SummaryType = propertyMetadata.GetColumnSummaryType();
-				SummaryTemplate = propertyMetadata.GetColumnSummaryTemplate();
-				SummaryFunction = propertyMetadata.GetColumnSummaryFunction();
+                SummaryType = propertyMetadata.GetColumnSummaryType();
+                SummaryTemplate = propertyMetadata.GetColumnSummaryTemplate();
+                SummaryFunction = propertyMetadata.GetColumnSummaryFunction();
 
-				if (!string.IsNullOrWhiteSpace(propertyMetadata.TemplateHint) && propertyMetadata.TemplateHint.Equals("HiddenInput"))
-					Hidden = true;
-				else
-					Hidden = false;
-				HideInDialog = propertyMetadata.GetColumnHideInDialog();
-			}
+                if (!string.IsNullOrWhiteSpace(propertyMetadata.TemplateHint) && propertyMetadata.TemplateHint.Equals("HiddenInput"))
+                    Hidden = true;
+                else
+                    Hidden = false;
+                HideInDialog = propertyMetadata.GetColumnHideInDialog();
+            }
 
-			JsonMapping = propertyMetadata.GetColumnJsonMapping();
-			XmlMapping = propertyMetadata.GetColumnXmlMapping();
-		}
-		#endregion
-	}
+            JsonMapping = propertyMetadata.GetColumnJsonMapping();
+            XmlMapping = propertyMetadata.GetColumnXmlMapping();
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnRules.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnRules.cs
@@ -1,92 +1,92 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents rules for jqGrid editable or searchable column
-	/// </summary>
-	public class JqGridColumnRules
-	{
-		#region Fields
-		private string _customFunction;
-		#endregion
+    /// <summary>
+    /// Class which represents rules for jqGrid editable or searchable column
+    /// </summary>
+    public class JqGridColumnRules
+    {
+        #region Fields
+        private string _customFunction;
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets if the value should be validated with custom function.
-		/// </summary>
-		public bool? Custom { get; set; }
+        #region Properties
+        /// <summary>
+        /// Gets or sets if the value should be validated with custom function.
+        /// </summary>
+        public bool? Custom { get; set; }
 
-		internal bool IsCustomFunctionSetted { get; set; }
-		/// <summary>
-		/// Gets or sets the name of custom validation function
-		/// </summary>
-		public string CustomFunction
-		{
-			get => _customFunction;
-			set
-			{
-				_customFunction = value;
-				IsCustomFunctionSetted = true;
-			}
-		}
+        internal bool IsCustomFunctionSetted { get; set; }
+        /// <summary>
+        /// Gets or sets the name of custom validation function
+        /// </summary>
+        public string CustomFunction
+        {
+            get => _customFunction;
+            set
+            {
+                _customFunction = value;
+                IsCustomFunctionSetted = true;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets if the value should be valid date based on DateFormat property (if not set than ISO date is used).
-		/// </summary>
-		public bool? Date { get; set; }
+        /// <summary>
+        /// Gets or sets if the value should be valid date based on DateFormat property (if not set than ISO date is used).
+        /// </summary>
+        public bool? Date { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if hidden column can be edited in form editing.
-		/// </summary>
-		public bool? EditHidden { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if hidden column can be edited in form editing.
+        /// </summary>
+        public bool? EditHidden { get; set; }
 
-		/// <summary>
-		/// Gets or sets if the value should be valid email
-		/// </summary>
-		public bool? Email { get; set; }
+        /// <summary>
+        /// Gets or sets if the value should be valid email
+        /// </summary>
+        public bool? Email { get; set; }
 
-		/// <summary>
-		/// Gets or sets if the value should be valid integer.
-		/// </summary>
-		public bool Integer { get; set; }
+        /// <summary>
+        /// Gets or sets if the value should be valid integer.
+        /// </summary>
+        public bool Integer { get; set; }
 
-		/// <summary>
-		/// Gets or set the maximum value.
-		/// </summary>
-		public double? MaxValue { get; set; }
+        /// <summary>
+        /// Gets or set the maximum value.
+        /// </summary>
+        public double? MaxValue { get; set; }
 
-		/// <summary>
-		/// Gets or sets the minimum value.
-		/// </summary>
-		public double? MinValue { get; set; }
+        /// <summary>
+        /// Gets or sets the minimum value.
+        /// </summary>
+        public double? MinValue { get; set; }
 
-		/// <summary>
-		/// Gets or sets if the value should be valid number
-		/// </summary>
-		public bool Number { get; set; }
+        /// <summary>
+        /// Gets or sets if the value should be valid number
+        /// </summary>
+        public bool Number { get; set; }
 
-		/// <summary>
-		/// Gets or sets if the value is required.
-		/// </summary>
-		public bool? Required { get; set; }
+        /// <summary>
+        /// Gets or sets if the value is required.
+        /// </summary>
+        public bool? Required { get; set; }
 
-		/// <summary>
-		/// Gets or sets if the value should be valid time (hh:mm format and optional am/pm at the end).
-		/// </summary>
-		public bool? Time { get; set; }
+        /// <summary>
+        /// Gets or sets if the value should be valid time (hh:mm format and optional am/pm at the end).
+        /// </summary>
+        public bool? Time { get; set; }
 
-		/// <summary>
-		/// Gets or sets if the value should be valid url.
-		/// </summary>
-		public bool? Url { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets if the value should be valid url.
+        /// </summary>
+        public bool? Url { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnRules class.
-		/// </summary>
-		public JqGridColumnRules()
-		{
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnRules class.
+        /// </summary>
+        public JqGridColumnRules()
+        {
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnRules.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnRules.cs
@@ -1,96 +1,92 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents rules for jqGrid editable or searchable column
-    /// </summary>
-    public class JqGridColumnRules
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets if the value should be validated with custom function.
-        /// </summary>
-        public bool Custom { get; set; }
+	/// <summary>
+	/// Class which represents rules for jqGrid editable or searchable column
+	/// </summary>
+	public class JqGridColumnRules
+	{
+		#region Fields
+		private string _customFunction;
+		#endregion
 
-        /// <summary>
-        /// Gets or sets the name of custom validation function
-        /// </summary>
-        public string CustomFunction { get; set; }
+		#region Properties
+		/// <summary>
+		/// Gets or sets if the value should be validated with custom function.
+		/// </summary>
+		public bool? Custom { get; set; }
 
-        /// <summary>
-        /// Gets or sets if the value should be valid date based on DateFormat property (if not set than ISO date is used).
-        /// </summary>
-        public bool Date { get; set; }
+		internal bool IsCustomFunctionSetted { get; set; }
+		/// <summary>
+		/// Gets or sets the name of custom validation function
+		/// </summary>
+		public string CustomFunction
+		{
+			get => _customFunction;
+			set
+			{
+				_customFunction = value;
+				IsCustomFunctionSetted = true;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the value which defines if hidden column can be edited in form editing.
-        /// </summary>
-        public bool EditHidden { get; set; }
+		/// <summary>
+		/// Gets or sets if the value should be valid date based on DateFormat property (if not set than ISO date is used).
+		/// </summary>
+		public bool? Date { get; set; }
 
-        /// <summary>
-        /// Gets or sets if the value should be valid email
-        /// </summary>
-        public bool Email { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if hidden column can be edited in form editing.
+		/// </summary>
+		public bool? EditHidden { get; set; }
 
-        /// <summary>
-        /// Gets or sets if the value should be valid integer.
-        /// </summary>
-        public bool Integer { get; set; }
+		/// <summary>
+		/// Gets or sets if the value should be valid email
+		/// </summary>
+		public bool? Email { get; set; }
 
-        /// <summary>
-        /// Gets or set the maximum value.
-        /// </summary>
-        public double? MaxValue { get; set; }
+		/// <summary>
+		/// Gets or sets if the value should be valid integer.
+		/// </summary>
+		public bool Integer { get; set; }
 
-        /// <summary>
-        /// Gets or sets the minimum value.
-        /// </summary>
-        public double? MinValue { get; set; }
+		/// <summary>
+		/// Gets or set the maximum value.
+		/// </summary>
+		public double? MaxValue { get; set; }
 
-        /// <summary>
-        /// Gets or sets if the value should be valid number
-        /// </summary>
-        public bool Number { get; set; }
+		/// <summary>
+		/// Gets or sets the minimum value.
+		/// </summary>
+		public double? MinValue { get; set; }
 
-        /// <summary>
-        /// Gets or sets if the value is required.
-        /// </summary>
-        public bool Required { get; set; }
+		/// <summary>
+		/// Gets or sets if the value should be valid number
+		/// </summary>
+		public bool Number { get; set; }
 
-        /// <summary>
-        /// Gets or sets if the value should be valid time (hh:mm format and optional am/pm at the end).
-        /// </summary>
-        public bool Time { get; set; }
+		/// <summary>
+		/// Gets or sets if the value is required.
+		/// </summary>
+		public bool? Required { get; set; }
 
-        /// <summary>
-        /// Gets or sets if the value should be valid url.
-        /// </summary>
-        public bool Url { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets if the value should be valid time (hh:mm format and optional am/pm at the end).
+		/// </summary>
+		public bool? Time { get; set; }
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnRules class.
-        /// </summary>
-        public JqGridColumnRules()
-        {
-            Custom = false;
-            CustomFunction = null;
-            Date = false;
-            EditHidden = false;
-            Email = false;
-            Integer = false;
-            MaxValue = null;
-            MinValue = null;
-            Number = false;
-            Required = false;
-            Time = false;
-            Url = false;
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Gets or sets if the value should be valid url.
+		/// </summary>
+		public bool? Url { get; set; }
+		#endregion
+
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnRules class.
+		/// </summary>
+		public JqGridColumnRules()
+		{
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSearchOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSearchOptions.cs
@@ -1,44 +1,36 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <inheritdoc />
-	/// <summary>
-	/// Class which represents options for jqGrid searchable column
-	/// </summary>
-	public class JqGridColumnSearchOptions : JqGridColumnElementOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the value which defines if Clear ("X") button is available at the end of search field in jqGrid filter toolbar.
-		/// </summary>
-		public bool? ClearSearch { get; set; }
+    /// <inheritdoc />
+    /// <summary>
+    /// Class which represents options for jqGrid searchable column
+    /// </summary>
+    public class JqGridColumnSearchOptions : JqGridColumnElementOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the value which defines if Clear ("X") button is available at the end of search field in jqGrid filter toolbar.
+        /// </summary>
+        public bool? ClearSearch { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if hidden column can be searched.
-		/// </summary>
-		public bool? SearchHidden { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if hidden column can be searched.
+        /// </summary>
+        public bool? SearchHidden { get; set; }
 
-		/// <summary>
-		/// Gets or sets the available search operators for the column.
-		/// </summary>
-		public JqGridSearchOperators SearchOperators { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the available search operators for the column.
+        /// </summary>
+        public JqGridSearchOperators SearchOperators { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridColumnSearchOptions class.
-		/// </summary>
-		public JqGridColumnSearchOptions()
-		{
-			/*BuildSelect = null;
-			ClearSearch = true;
-			DataEvents = null;
-			DataInit = null;
-			DataUrl = null;
-			DefaultValue = null;
-			HtmlAttributes = null;
-			SearchHidden = false;*/
-			SearchOperators = JqGridSearchOperators.Default;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridColumnSearchOptions class.
+        /// </summary>
+        public JqGridColumnSearchOptions()
+        {
+            SearchOperators = JqGridSearchOperators.Default;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSearchOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSearchOptions.cs
@@ -1,43 +1,44 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid searchable column
-    /// </summary>
-    public class JqGridColumnSearchOptions: JqGridColumnElementOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the value which defines if Clear ("X") button is available at the end of search field in jqGrid filter toolbar.
-        /// </summary>
-        public bool ClearSearch { get; set; }
+	/// <inheritdoc />
+	/// <summary>
+	/// Class which represents options for jqGrid searchable column
+	/// </summary>
+	public class JqGridColumnSearchOptions : JqGridColumnElementOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the value which defines if Clear ("X") button is available at the end of search field in jqGrid filter toolbar.
+		/// </summary>
+		public bool? ClearSearch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if hidden column can be searched.
-        /// </summary>
-        public bool SearchHidden { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if hidden column can be searched.
+		/// </summary>
+		public bool? SearchHidden { get; set; }
 
-        /// <summary>
-        /// Gets or sets the available search operators for the column.
-        /// </summary>
-        public JqGridSearchOperators SearchOperators { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the available search operators for the column.
+		/// </summary>
+		public JqGridSearchOperators SearchOperators { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridColumnSearchOptions class.
-        /// </summary>
-        public JqGridColumnSearchOptions()
-        {
-            BuildSelect = null;
-            ClearSearch = true;
-            DataEvents = null;
-            DataInit = null;
-            DataUrl = null;
-            DefaultValue = null;
-            HtmlAttributes = null;
-            SearchHidden = false;
-            SearchOperators = (JqGridSearchOperators)32768;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridColumnSearchOptions class.
+		/// </summary>
+		public JqGridColumnSearchOptions()
+		{
+			/*BuildSelect = null;
+			ClearSearch = true;
+			DataEvents = null;
+			DataInit = null;
+			DataUrl = null;
+			DefaultValue = null;
+			HtmlAttributes = null;
+			SearchHidden = false;*/
+			SearchOperators = JqGridSearchOperators.Default;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSearchTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSearchTypes.cs
@@ -1,33 +1,33 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available types of search fields for jqGrid
-	/// </summary>
-	public enum JqGridColumnSearchTypes
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Input element of type text.
-		/// </summary>
-		Text,
-		/// <summary>
-		/// Select element
-		/// </summary>
-		Select,
-		/// <summary>
-		/// jQuery UI Autocomplete widget
-		/// </summary>
-		JQueryUIAutocomplete,
-		/// <summary>
-		/// jQuery UI Datepicker widget
-		/// </summary>
-		JQueryUIDatepicker,
-		/// <summary>
-		/// jQuery UI Spinner widget
-		/// </summary>
-		JQueryUISpinner
-	}
+    /// <summary>
+    /// Defines available types of search fields for jqGrid
+    /// </summary>
+    public enum JqGridColumnSearchTypes
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Input element of type text.
+        /// </summary>
+        Text,
+        /// <summary>
+        /// Select element
+        /// </summary>
+        Select,
+        /// <summary>
+        /// jQuery UI Autocomplete widget
+        /// </summary>
+        JQueryUIAutocomplete,
+        /// <summary>
+        /// jQuery UI Datepicker widget
+        /// </summary>
+        JQueryUIDatepicker,
+        /// <summary>
+        /// jQuery UI Spinner widget
+        /// </summary>
+        JQueryUISpinner
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSearchTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSearchTypes.cs
@@ -1,34 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available types of search fields for jqGrid
-    /// </summary>
-    public enum JqGridColumnSearchTypes
-    {
-        /// <summary>
-        /// Input element of type text.
-        /// </summary>
-        Text,
-        /// <summary>
-        /// Select element
-        /// </summary>
-        Select,
-        /// <summary>
-        /// jQuery UI Autocomplete widget
-        /// </summary>
-        JQueryUIAutocomplete,
-        /// <summary>
-        /// jQuery UI Datepicker widget
-        /// </summary>
-        JQueryUIDatepicker,
-        /// <summary>
-        /// jQuery UI Spinner widget
-        /// </summary>
-        JQueryUISpinner
-    }
+	/// <summary>
+	/// Defines available types of search fields for jqGrid
+	/// </summary>
+	public enum JqGridColumnSearchTypes
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Input element of type text.
+		/// </summary>
+		Text,
+		/// <summary>
+		/// Select element
+		/// </summary>
+		Select,
+		/// <summary>
+		/// jQuery UI Autocomplete widget
+		/// </summary>
+		JQueryUIAutocomplete,
+		/// <summary>
+		/// jQuery UI Datepicker widget
+		/// </summary>
+		JQueryUIDatepicker,
+		/// <summary>
+		/// jQuery UI Spinner widget
+		/// </summary>
+		JQueryUISpinner
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSortTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSortTypes.cs
@@ -1,34 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines the type of the column for appropriate sorting when datatype is local.
-    /// </summary>
-    public enum JqGridColumnSortTypes
-    {
-        /// <summary>
-        /// Sorting as integers.
-        /// </summary>
-        Integer,
-        /// <summary>
-        /// Sorting as decimal numbers.
-        /// </summary>
-        Float,
-        /// <summary>
-        /// Sorting as date.
-        /// </summary>
-        Date,
-        /// <summary>
-        /// Sorting as text.
-        /// </summary>
-        Text,
-        /// <summary>
-        /// Sorting using custom function (this option is not supported in configuration import/export).
-        /// </summary>
-        Function
-     }
+	/// <summary>
+	/// Defines the type of the column for appropriate sorting when datatype is local.
+	/// </summary>
+	public enum JqGridColumnSortTypes
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Sorting as integers.
+		/// </summary>
+		Integer,
+		/// <summary>
+		/// Sorting as decimal numbers.
+		/// </summary>
+		Float,
+		/// <summary>
+		/// Sorting as date.
+		/// </summary>
+		Date,
+		/// <summary>
+		/// Sorting as text.
+		/// </summary>
+		Text,
+		/// <summary>
+		/// Sorting using custom function (this option is not supported in configuration import/export).
+		/// </summary>
+		Function
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSortTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSortTypes.cs
@@ -1,33 +1,33 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines the type of the column for appropriate sorting when datatype is local.
-	/// </summary>
-	public enum JqGridColumnSortTypes
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Sorting as integers.
-		/// </summary>
-		Integer,
-		/// <summary>
-		/// Sorting as decimal numbers.
-		/// </summary>
-		Float,
-		/// <summary>
-		/// Sorting as date.
-		/// </summary>
-		Date,
-		/// <summary>
-		/// Sorting as text.
-		/// </summary>
-		Text,
-		/// <summary>
-		/// Sorting using custom function (this option is not supported in configuration import/export).
-		/// </summary>
-		Function
-	}
+    /// <summary>
+    /// Defines the type of the column for appropriate sorting when datatype is local.
+    /// </summary>
+    public enum JqGridColumnSortTypes
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Sorting as integers.
+        /// </summary>
+        Integer,
+        /// <summary>
+        /// Sorting as decimal numbers.
+        /// </summary>
+        Float,
+        /// <summary>
+        /// Sorting as date.
+        /// </summary>
+        Date,
+        /// <summary>
+        /// Sorting as text.
+        /// </summary>
+        Text,
+        /// <summary>
+        /// Sorting using custom function (this option is not supported in configuration import/export).
+        /// </summary>
+        Function
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSummaryTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSummaryTypes.cs
@@ -1,38 +1,37 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available types of grouping summary for jqGrid column.
-    /// </summary>
-    public enum JqGridColumnSummaryTypes
-    {
-        /// <summary>
-        /// The sum function.
-        /// </summary>
-        Sum,
-        /// <summary>
-        /// The count function.
-        /// </summary>
-        Count,
-        /// <summary>
-        /// The average function.
-        /// </summary>
-        Avg,
-        /// <summary>
-        /// The minimum function.
-        /// </summary>
-        Min,
-        /// <summary>
-        /// The maximum function.
-        /// </summary>
-        Max,
-        /// <summary>
-        /// The custom function.
-        /// </summary>
-        Custom
-    }
+	/// <summary>
+	/// Defines available types of grouping summary for jqGrid column.
+	/// </summary>
+	public enum JqGridColumnSummaryTypes
+	{
+		/// <summary>
+		/// Disable summary if by default it enabled
+		/// </summary>
+		Disable,
+		/// <summary>
+		/// The sum function.
+		/// </summary>
+		Sum,
+		/// <summary>
+		/// The count function.
+		/// </summary>
+		Count,
+		/// <summary>
+		/// The average function.
+		/// </summary>
+		Avg,
+		/// <summary>
+		/// The minimum function.
+		/// </summary>
+		Min,
+		/// <summary>
+		/// The maximum function.
+		/// </summary>
+		Max,
+		/// <summary>
+		/// The custom function.
+		/// </summary>
+		Custom
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSummaryTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridColumnSummaryTypes.cs
@@ -1,37 +1,37 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available types of grouping summary for jqGrid column.
-	/// </summary>
-	public enum JqGridColumnSummaryTypes
-	{
-		/// <summary>
-		/// Disable summary if by default it enabled
-		/// </summary>
-		Disable,
-		/// <summary>
-		/// The sum function.
-		/// </summary>
-		Sum,
-		/// <summary>
-		/// The count function.
-		/// </summary>
-		Count,
-		/// <summary>
-		/// The average function.
-		/// </summary>
-		Avg,
-		/// <summary>
-		/// The minimum function.
-		/// </summary>
-		Min,
-		/// <summary>
-		/// The maximum function.
-		/// </summary>
-		Max,
-		/// <summary>
-		/// The custom function.
-		/// </summary>
-		Custom
-	}
+    /// <summary>
+    /// Defines available types of grouping summary for jqGrid column.
+    /// </summary>
+    public enum JqGridColumnSummaryTypes
+    {
+        /// <summary>
+        /// Disable summary if by default it enabled
+        /// </summary>
+        Disable,
+        /// <summary>
+        /// The sum function.
+        /// </summary>
+        Sum,
+        /// <summary>
+        /// The count function.
+        /// </summary>
+        Count,
+        /// <summary>
+        /// The average function.
+        /// </summary>
+        Avg,
+        /// <summary>
+        /// The minimum function.
+        /// </summary>
+        Min,
+        /// <summary>
+        /// The maximum function.
+        /// </summary>
+        Max,
+        /// <summary>
+        /// The custom function.
+        /// </summary>
+        Custom
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridConfiguration.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridConfiguration.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jqGrid configuration container
-    /// </summary>
-    [ModelBinder(typeof(ModelBinders.JqGridJsonModelBinder))]
-    public class JqGridConfiguration
-    {
-        #region Properties
-        /// <summary>
-        /// Options
-        /// </summary>
-        public JqGridOptions Settings { get; set; }
-        #endregion
-    }
+	/// <summary>
+	/// jqGrid configuration container
+	/// </summary>
+	[ModelBinder(typeof(ModelBinders.JqGridJsonModelBinder))]
+	public class JqGridConfiguration
+	{
+		#region Properties
+		/// <summary>
+		/// Options
+		/// </summary>
+		public JqGridOptions Settings { get; set; }
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridConfiguration.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridConfiguration.cs
@@ -2,17 +2,17 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// jqGrid configuration container
-	/// </summary>
-	[ModelBinder(typeof(ModelBinders.JqGridJsonModelBinder))]
-	public class JqGridConfiguration
-	{
-		#region Properties
-		/// <summary>
-		/// Options
-		/// </summary>
-		public JqGridOptions Settings { get; set; }
-		#endregion
-	}
+    /// <summary>
+    /// jqGrid configuration container
+    /// </summary>
+    [ModelBinder(typeof(ModelBinders.JqGridJsonModelBinder))]
+    public class JqGridConfiguration
+    {
+        #region Properties
+        /// <summary>
+        /// Options
+        /// </summary>
+        public JqGridOptions Settings { get; set; }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridDataTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridDataTypes.cs
@@ -1,33 +1,33 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// jqGrid data types
-	/// </summary>
-	public enum JqGridDataTypes
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// XML data
-		/// </summary>
-		Xml,
-		/// <summary>
-		/// XML data as string
-		/// </summary>
-		XmlString,
-		/// <summary>
-		/// JSON data
-		/// </summary>
-		Json,
-		/// <summary>
-		/// JSONP data
-		/// </summary>
-		Jsonp,
-		/// <summary>
-		/// JSON data as string
-		/// </summary>
-		JsonString
-	}
+    /// <summary>
+    /// jqGrid data types
+    /// </summary>
+    public enum JqGridDataTypes
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// XML data
+        /// </summary>
+        Xml,
+        /// <summary>
+        /// XML data as string
+        /// </summary>
+        XmlString,
+        /// <summary>
+        /// JSON data
+        /// </summary>
+        Json,
+        /// <summary>
+        /// JSONP data
+        /// </summary>
+        Jsonp,
+        /// <summary>
+        /// JSON data as string
+        /// </summary>
+        JsonString
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridDataTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridDataTypes.cs
@@ -1,31 +1,33 @@
-﻿using System;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jqGrid data types
-    /// </summary>
-    public enum JqGridDataTypes
-    {
-        /// <summary>
-        /// XML data
-        /// </summary>
-        Xml,
-        /// <summary>
-        /// XML data as string
-        /// </summary>
-        XmlString,
-        /// <summary>
-        /// JSON data
-        /// </summary>
-        Json,
-        /// <summary>
-        /// JSONP data
-        /// </summary>
-        Jsonp,
-        /// <summary>
-        /// JSON data as string
-        /// </summary>
-        JsonString
-    }
+	/// <summary>
+	/// jqGrid data types
+	/// </summary>
+	public enum JqGridDataTypes
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// XML data
+		/// </summary>
+		Xml,
+		/// <summary>
+		/// XML data as string
+		/// </summary>
+		XmlString,
+		/// <summary>
+		/// JSON data
+		/// </summary>
+		Json,
+		/// <summary>
+		/// JSONP data
+		/// </summary>
+		Jsonp,
+		/// <summary>
+		/// JSON data as string
+		/// </summary>
+		JsonString
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridDynamicScrollingModes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridDynamicScrollingModes.cs
@@ -1,26 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available modes for jqGrid dynamic scrolling
-    /// </summary>
-    public enum JqGridDynamicScrollingModes
-    {
-        /// <summary>
-        /// Dynamic scrolling disabled.
-        /// </summary>
-        Disabled,
-        /// <summary>
-        /// Dynamic scrolling enabled, the grid will hold all items requested.
-        /// </summary>
-        HoldAllRows,
-        /// <summary>
-        /// Dynamic scrolling enabled, the grid will hold only visible rows.
-        /// </summary>
-        HoldVisibleRows
-    }
+	/// <summary>
+	/// Defines available modes for jqGrid dynamic scrolling
+	/// </summary>
+	public enum JqGridDynamicScrollingModes
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Dynamic scrolling disabled.
+		/// </summary>
+		Disabled,
+		/// <summary>
+		/// Dynamic scrolling enabled, the grid will hold all items requested.
+		/// </summary>
+		HoldAllRows,
+		/// <summary>
+		/// Dynamic scrolling enabled, the grid will hold only visible rows.
+		/// </summary>
+		HoldVisibleRows
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridDynamicScrollingModes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridDynamicScrollingModes.cs
@@ -1,25 +1,25 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available modes for jqGrid dynamic scrolling
-	/// </summary>
-	public enum JqGridDynamicScrollingModes
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Dynamic scrolling disabled.
-		/// </summary>
-		Disabled,
-		/// <summary>
-		/// Dynamic scrolling enabled, the grid will hold all items requested.
-		/// </summary>
-		HoldAllRows,
-		/// <summary>
-		/// Dynamic scrolling enabled, the grid will hold only visible rows.
-		/// </summary>
-		HoldVisibleRows
-	}
+    /// <summary>
+    /// Defines available modes for jqGrid dynamic scrolling
+    /// </summary>
+    public enum JqGridDynamicScrollingModes
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Dynamic scrolling disabled.
+        /// </summary>
+        Disabled,
+        /// <summary>
+        /// Dynamic scrolling enabled, the grid will hold all items requested.
+        /// </summary>
+        HoldAllRows,
+        /// <summary>
+        /// Dynamic scrolling enabled, the grid will hold only visible rows.
+        /// </summary>
+        HoldVisibleRows
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridExtendColumnModel.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridExtendColumnModel.cs
@@ -2,119 +2,119 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Options for extend column model
-	/// </summary>
-	public class JqGridExtendColumnModel
-	{
-		#region Fields
+    /// <summary>
+    /// Options for extend column model
+    /// </summary>
+    public class JqGridExtendColumnModel
+    {
+        #region Fields
 
-		private object _editOptionsPostData;
-		private IDictionary<string, object> _editOptionsHtmlAttributes;
-		private IDictionary<string, string> _editOptionsValueDictionary;
-		private IDictionary<string, object> _labelOptionsCssStyles;
-		private IDictionary<string, object> _labelOptionsHtmlAttributes;
-		private IDictionary<string, string> _searchOptionsValueDictionary;
-		private IDictionary<string, object> _searchOptionsHtmlAttributes;
+        private object _editOptionsPostData;
+        private IDictionary<string, object> _editOptionsHtmlAttributes;
+        private IDictionary<string, string> _editOptionsValueDictionary;
+        private IDictionary<string, object> _labelOptionsCssStyles;
+        private IDictionary<string, object> _labelOptionsHtmlAttributes;
+        private IDictionary<string, string> _searchOptionsValueDictionary;
+        private IDictionary<string, object> _searchOptionsHtmlAttributes;
 
-		#endregion
+        #endregion
 
-		internal bool IsEditOptionsPostDataSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
-		/// </summary>
-		public object EditOptionsPostData
-		{
-			get => _editOptionsPostData;
-			set
-			{
-				_editOptionsPostData = value;
-				IsEditOptionsPostDataSetted = true;
-			}
-		}
+        internal bool IsEditOptionsPostDataSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
+        /// </summary>
+        public object EditOptionsPostData
+        {
+            get => _editOptionsPostData;
+            set
+            {
+                _editOptionsPostData = value;
+                IsEditOptionsPostDataSetted = true;
+            }
+        }
 
-		internal bool IsEditOptionsHtmlAttributesSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets a dictionary where keys should be valid attributes for the element in edit mode.
-		/// </summary>
-		public IDictionary<string, object> EditOptionsHtmlAttributes
-		{
-			get => _editOptionsHtmlAttributes;
-			set
-			{
-				_editOptionsHtmlAttributes = value;
-				IsEditOptionsHtmlAttributesSetted = true;
-			}
-		}
+        internal bool IsEditOptionsHtmlAttributesSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets a dictionary where keys should be valid attributes for the element in edit mode.
+        /// </summary>
+        public IDictionary<string, object> EditOptionsHtmlAttributes
+        {
+            get => _editOptionsHtmlAttributes;
+            set
+            {
+                _editOptionsHtmlAttributes = value;
+                IsEditOptionsHtmlAttributesSetted = true;
+            }
+        }
 
-		internal bool IsEditOptionsValueDictionarySetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element in edit mode.
-		/// </summary>
-		public IDictionary<string, string> EditOptionsValueDictionary
-		{
-			get => _editOptionsValueDictionary;
-			set
-			{
-				_editOptionsValueDictionary = value;
-				IsEditOptionsValueDictionarySetted = true;
-			}
-		}
+        internal bool IsEditOptionsValueDictionarySetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element in edit mode.
+        /// </summary>
+        public IDictionary<string, string> EditOptionsValueDictionary
+        {
+            get => _editOptionsValueDictionary;
+            set
+            {
+                _editOptionsValueDictionary = value;
+                IsEditOptionsValueDictionarySetted = true;
+            }
+        }
 
-		internal bool IsLabelOptionsCssStylesSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets a dictionary where keys should be CSS styles for the label (will be applied only if Class is null or empty string).
-		/// </summary>
-		public IDictionary<string, object> LabelOptionsCssStyles
-		{
-			get => _labelOptionsCssStyles;
-			set
-			{
-				_labelOptionsCssStyles = value;
-				IsLabelOptionsCssStylesSetted = true;
-			}
-		}
+        internal bool IsLabelOptionsCssStylesSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets a dictionary where keys should be CSS styles for the label (will be applied only if Class is null or empty string).
+        /// </summary>
+        public IDictionary<string, object> LabelOptionsCssStyles
+        {
+            get => _labelOptionsCssStyles;
+            set
+            {
+                _labelOptionsCssStyles = value;
+                IsLabelOptionsCssStylesSetted = true;
+            }
+        }
 
-		internal bool IsLabelOptionsHtmlAttributesSetted { get; private set; }
-		/// <summary>
-		///Gets or sets a dictionary where keys should be valid attributes for the label.
-		/// </summary>
-		public IDictionary<string, object> LabelOptionsHtmlAttributes
-		{
-			get => _labelOptionsHtmlAttributes;
-			set
-			{
-				_labelOptionsHtmlAttributes = value;
-				IsLabelOptionsHtmlAttributesSetted = true;
-			}
-		}
+        internal bool IsLabelOptionsHtmlAttributesSetted { get; private set; }
+        /// <summary>
+        ///Gets or sets a dictionary where keys should be valid attributes for the label.
+        /// </summary>
+        public IDictionary<string, object> LabelOptionsHtmlAttributes
+        {
+            get => _labelOptionsHtmlAttributes;
+            set
+            {
+                _labelOptionsHtmlAttributes = value;
+                IsLabelOptionsHtmlAttributesSetted = true;
+            }
+        }
 
-		internal bool IsSearchOptionsValueDictionarySetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element in search mode.
-		/// </summary>
-		public IDictionary<string, string> SearchOptionsValueDictionary
-		{
-			get => _searchOptionsValueDictionary;
-			set
-			{
-				_searchOptionsValueDictionary = value;
-				IsSearchOptionsValueDictionarySetted = true;
-			}
-		}
+        internal bool IsSearchOptionsValueDictionarySetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element in search mode.
+        /// </summary>
+        public IDictionary<string, string> SearchOptionsValueDictionary
+        {
+            get => _searchOptionsValueDictionary;
+            set
+            {
+                _searchOptionsValueDictionary = value;
+                IsSearchOptionsValueDictionarySetted = true;
+            }
+        }
 
-		internal bool IsSearchOptionsHtmlAttributesSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets a dictionary where keys should be valid attributes for the element in search mode.
-		/// </summary>
-		public IDictionary<string, object> SearchOptionsHtmlAttributes
-		{
-			get => _searchOptionsHtmlAttributes;
-			set
-			{
-				_searchOptionsHtmlAttributes = value;
-				IsSearchOptionsHtmlAttributesSetted = true;
-			}
-		}
-	}
+        internal bool IsSearchOptionsHtmlAttributesSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets a dictionary where keys should be valid attributes for the element in search mode.
+        /// </summary>
+        public IDictionary<string, object> SearchOptionsHtmlAttributes
+        {
+            get => _searchOptionsHtmlAttributes;
+            set
+            {
+                _searchOptionsHtmlAttributes = value;
+                IsSearchOptionsHtmlAttributesSetted = true;
+            }
+        }
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridExtendColumnModel.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridExtendColumnModel.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections.Generic;
+
+namespace Lib.Web.Mvc.JQuery.JqGrid
+{
+	/// <summary>
+	/// Options for extend column model
+	/// </summary>
+	public class JqGridExtendColumnModel
+	{
+		#region Fields
+
+		private object _editOptionsPostData;
+		private IDictionary<string, object> _editOptionsHtmlAttributes;
+		private IDictionary<string, string> _editOptionsValueDictionary;
+		private IDictionary<string, object> _labelOptionsCssStyles;
+		private IDictionary<string, object> _labelOptionsHtmlAttributes;
+		private IDictionary<string, string> _searchOptionsValueDictionary;
+		private IDictionary<string, object> _searchOptionsHtmlAttributes;
+
+		#endregion
+
+		internal bool IsEditOptionsPostDataSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the additional data which will be added to the AJAX request to get the data for the select element (if EditType is JqGridColumnEditTypes.Select).
+		/// </summary>
+		public object EditOptionsPostData
+		{
+			get => _editOptionsPostData;
+			set
+			{
+				_editOptionsPostData = value;
+				IsEditOptionsPostDataSetted = true;
+			}
+		}
+
+		internal bool IsEditOptionsHtmlAttributesSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets a dictionary where keys should be valid attributes for the element in edit mode.
+		/// </summary>
+		public IDictionary<string, object> EditOptionsHtmlAttributes
+		{
+			get => _editOptionsHtmlAttributes;
+			set
+			{
+				_editOptionsHtmlAttributes = value;
+				IsEditOptionsHtmlAttributesSetted = true;
+			}
+		}
+
+		internal bool IsEditOptionsValueDictionarySetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element in edit mode.
+		/// </summary>
+		public IDictionary<string, string> EditOptionsValueDictionary
+		{
+			get => _editOptionsValueDictionary;
+			set
+			{
+				_editOptionsValueDictionary = value;
+				IsEditOptionsValueDictionarySetted = true;
+			}
+		}
+
+		internal bool IsLabelOptionsCssStylesSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets a dictionary where keys should be CSS styles for the label (will be applied only if Class is null or empty string).
+		/// </summary>
+		public IDictionary<string, object> LabelOptionsCssStyles
+		{
+			get => _labelOptionsCssStyles;
+			set
+			{
+				_labelOptionsCssStyles = value;
+				IsLabelOptionsCssStylesSetted = true;
+			}
+		}
+
+		internal bool IsLabelOptionsHtmlAttributesSetted { get; private set; }
+		/// <summary>
+		///Gets or sets a dictionary where keys should be valid attributes for the label.
+		/// </summary>
+		public IDictionary<string, object> LabelOptionsHtmlAttributes
+		{
+			get => _labelOptionsHtmlAttributes;
+			set
+			{
+				_labelOptionsHtmlAttributes = value;
+				IsLabelOptionsHtmlAttributesSetted = true;
+			}
+		}
+
+		internal bool IsSearchOptionsValueDictionarySetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the dictionary which will be serialized into set of value:label pairs for select element in search mode.
+		/// </summary>
+		public IDictionary<string, string> SearchOptionsValueDictionary
+		{
+			get => _searchOptionsValueDictionary;
+			set
+			{
+				_searchOptionsValueDictionary = value;
+				IsSearchOptionsValueDictionarySetted = true;
+			}
+		}
+
+		internal bool IsSearchOptionsHtmlAttributesSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets a dictionary where keys should be valid attributes for the element in search mode.
+		/// </summary>
+		public IDictionary<string, object> SearchOptionsHtmlAttributes
+		{
+			get => _searchOptionsHtmlAttributes;
+			set
+			{
+				_searchOptionsHtmlAttributes = value;
+				IsSearchOptionsHtmlAttributesSetted = true;
+			}
+		}
+	}
+}

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridOptions.cs
@@ -1,65 +1,60 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid filter grid.
-    /// </summary>
-    public class JqGridFilterGridOptions : JqGridFilterOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the type of the filter grid.
-        /// </summary>
-        public JqGridFilterGridTypes? Type { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid filter grid.
+	/// </summary>
+	public class JqGridFilterGridOptions : JqGridFilterOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the type of the filter grid.
+		/// </summary>
+		public JqGridFilterGridTypes? Type { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of CSS class which will be applied to the buttons.
-        /// </summary>
-        public string ButtonsClass { get; set; }
+		/// <summary>
+		/// Gets or sets the name of CSS class which will be applied to the buttons.
+		/// </summary>
+		public string ButtonsClass { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if clear button is enabled.
-        /// </summary>
-        public bool? ClearEnabled { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if clear button is enabled.
+		/// </summary>
+		public bool? ClearEnabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for clear button.
-        /// </summary>
-        public string ClearText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for clear button.
+		/// </summary>
+		public string ClearText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of CSS class which will be applied to the form.
-        /// </summary>
-        public string FormClass { get; set; }
+		/// <summary>
+		/// Gets or sets the name of CSS class which will be applied to the form.
+		/// </summary>
+		public string FormClass { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if after a search every column to which search is applied is marked as searchable.
-        /// </summary>
-        public bool? MarkSearched { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if after a search every column to which search is applied is marked as searchable.
+		/// </summary>
+		public bool? MarkSearched { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if search button is enabled.
-        /// </summary>
-        public bool? SearchEnabled { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if search button is enabled.
+		/// </summary>
+		public bool? SearchEnabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for search button.
-        /// </summary>
-        public string SearchText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for search button.
+		/// </summary>
+		public string SearchText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of CSS class which will be applied to the table.
-        /// </summary>
-        public string TableClass { get; set; }
+		/// <summary>
+		/// Gets or sets the name of CSS class which will be applied to the table.
+		/// </summary>
+		public string TableClass { get; set; }
 
-        /// <summary>
-        /// Gets or sets a separate url for searching values.
-        /// </summary>
-        public string Url { get; set; }
-        #endregion
-    }
+		/// <summary>
+		/// Gets or sets a separate url for searching values.
+		/// </summary>
+		public string Url { get; set; }
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridOptions.cs
@@ -1,60 +1,60 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid filter grid.
-	/// </summary>
-	public class JqGridFilterGridOptions : JqGridFilterOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the type of the filter grid.
-		/// </summary>
-		public JqGridFilterGridTypes? Type { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid filter grid.
+    /// </summary>
+    public class JqGridFilterGridOptions : JqGridFilterOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the type of the filter grid.
+        /// </summary>
+        public JqGridFilterGridTypes? Type { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name of CSS class which will be applied to the buttons.
-		/// </summary>
-		public string ButtonsClass { get; set; }
+        /// <summary>
+        /// Gets or sets the name of CSS class which will be applied to the buttons.
+        /// </summary>
+        public string ButtonsClass { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if clear button is enabled.
-		/// </summary>
-		public bool? ClearEnabled { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if clear button is enabled.
+        /// </summary>
+        public bool? ClearEnabled { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for clear button.
-		/// </summary>
-		public string ClearText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for clear button.
+        /// </summary>
+        public string ClearText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name of CSS class which will be applied to the form.
-		/// </summary>
-		public string FormClass { get; set; }
+        /// <summary>
+        /// Gets or sets the name of CSS class which will be applied to the form.
+        /// </summary>
+        public string FormClass { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if after a search every column to which search is applied is marked as searchable.
-		/// </summary>
-		public bool? MarkSearched { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if after a search every column to which search is applied is marked as searchable.
+        /// </summary>
+        public bool? MarkSearched { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if search button is enabled.
-		/// </summary>
-		public bool? SearchEnabled { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if search button is enabled.
+        /// </summary>
+        public bool? SearchEnabled { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for search button.
-		/// </summary>
-		public string SearchText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for search button.
+        /// </summary>
+        public string SearchText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name of CSS class which will be applied to the table.
-		/// </summary>
-		public string TableClass { get; set; }
+        /// <summary>
+        /// Gets or sets the name of CSS class which will be applied to the table.
+        /// </summary>
+        public string TableClass { get; set; }
 
-		/// <summary>
-		/// Gets or sets a separate url for searching values.
-		/// </summary>
-		public string Url { get; set; }
-		#endregion
-	}
+        /// <summary>
+        /// Gets or sets a separate url for searching values.
+        /// </summary>
+        public string Url { get; set; }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridRowModel.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridRowModel.cs
@@ -1,60 +1,57 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents row for jqGrid filter grid.
-    /// </summary>
-    public class JqGridFilterGridRowModel
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the corresponding column name from columns models.
-        /// </summary>
-        public string ColumnName { get; private set; }
+	/// <summary>
+	/// Class which represents row for jqGrid filter grid.
+	/// </summary>
+	public class JqGridFilterGridRowModel
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the corresponding column name from columns models.
+		/// </summary>
+		public string ColumnName { get; }
 
-        /// <summary>
-        /// Gets or sets the default value for the search input element.
-        /// </summary>
-        public string DefaultValue { get; set; }
+		/// <summary>
+		/// Gets or sets the default value for the search input element.
+		/// </summary>
+		public string DefaultValue { get; set; }
 
-        /// <summary>
-        /// Gets the label of the field.
-        /// </summary>
-        public string Label { get; private set; }
+		/// <summary>
+		/// Gets the label of the field.
+		/// </summary>
+		public string Label { get; }
 
-        /// <summary>
-        /// Gets or sets the type of the search field (default JqGridColumnSearchTypes.Text).
-        /// </summary>
-        public JqGridColumnSearchTypes SearchType { get; set; }
+		/// <summary>
+		/// Gets or sets the type of the search field (default JqGridColumnSearchTypes.Text).
+		/// </summary>
+		public JqGridColumnSearchTypes SearchType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the URL to get the AJAX data for the select element (if SearchType is JqGridColumnSearchTypes.Select)
-        /// </summary>
-        public string SelectUrl { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the URL to get the AJAX data for the select element (if SearchType is JqGridColumnSearchTypes.Select)
+		/// </summary>
+		public string SelectUrl { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridRecord class.
-        /// </summary>
-        /// <param name="columnName">The corresponding column name from columns models.</param>
-        /// <param name="label">The label of the field.</param>
-        public JqGridFilterGridRowModel(string columnName, string label)
-        {
-            if (String.IsNullOrWhiteSpace(columnName))
-                throw new ArgumentNullException("columnName");
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridRecord class.
+		/// </summary>
+		/// <param name="columnName">The corresponding column name from columns models.</param>
+		/// <param name="label">The label of the field.</param>
+		public JqGridFilterGridRowModel(string columnName, string label)
+		{
+			if (string.IsNullOrWhiteSpace(columnName))
+				throw new ArgumentNullException(nameof(columnName));
 
-            if (String.IsNullOrWhiteSpace(label))
-                throw new ArgumentNullException("label");
+			if (string.IsNullOrWhiteSpace(label))
+				throw new ArgumentNullException(nameof(label));
 
-            ColumnName = columnName;
-            Label = label;
-            SearchType = JqGridColumnSearchTypes.Text;
-        }
-        #endregion
-    }
+			ColumnName = columnName;
+			Label = label;
+			SearchType = JqGridColumnSearchTypes.Text;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridRowModel.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridRowModel.cs
@@ -2,56 +2,56 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents row for jqGrid filter grid.
-	/// </summary>
-	public class JqGridFilterGridRowModel
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the corresponding column name from columns models.
-		/// </summary>
-		public string ColumnName { get; }
+    /// <summary>
+    /// Class which represents row for jqGrid filter grid.
+    /// </summary>
+    public class JqGridFilterGridRowModel
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the corresponding column name from columns models.
+        /// </summary>
+        public string ColumnName { get; }
 
-		/// <summary>
-		/// Gets or sets the default value for the search input element.
-		/// </summary>
-		public string DefaultValue { get; set; }
+        /// <summary>
+        /// Gets or sets the default value for the search input element.
+        /// </summary>
+        public string DefaultValue { get; set; }
 
-		/// <summary>
-		/// Gets the label of the field.
-		/// </summary>
-		public string Label { get; }
+        /// <summary>
+        /// Gets the label of the field.
+        /// </summary>
+        public string Label { get; }
 
-		/// <summary>
-		/// Gets or sets the type of the search field (default JqGridColumnSearchTypes.Text).
-		/// </summary>
-		public JqGridColumnSearchTypes SearchType { get; set; }
+        /// <summary>
+        /// Gets or sets the type of the search field (default JqGridColumnSearchTypes.Text).
+        /// </summary>
+        public JqGridColumnSearchTypes SearchType { get; set; }
 
-		/// <summary>
-		/// Gets or sets the URL to get the AJAX data for the select element (if SearchType is JqGridColumnSearchTypes.Select)
-		/// </summary>
-		public string SelectUrl { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the URL to get the AJAX data for the select element (if SearchType is JqGridColumnSearchTypes.Select)
+        /// </summary>
+        public string SelectUrl { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridRecord class.
-		/// </summary>
-		/// <param name="columnName">The corresponding column name from columns models.</param>
-		/// <param name="label">The label of the field.</param>
-		public JqGridFilterGridRowModel(string columnName, string label)
-		{
-			if (string.IsNullOrWhiteSpace(columnName))
-				throw new ArgumentNullException(nameof(columnName));
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridRecord class.
+        /// </summary>
+        /// <param name="columnName">The corresponding column name from columns models.</param>
+        /// <param name="label">The label of the field.</param>
+        public JqGridFilterGridRowModel(string columnName, string label)
+        {
+            if (string.IsNullOrWhiteSpace(columnName))
+                throw new ArgumentNullException(nameof(columnName));
 
-			if (string.IsNullOrWhiteSpace(label))
-				throw new ArgumentNullException(nameof(label));
+            if (string.IsNullOrWhiteSpace(label))
+                throw new ArgumentNullException(nameof(label));
 
-			ColumnName = columnName;
-			Label = label;
-			SearchType = JqGridColumnSearchTypes.Text;
-		}
-		#endregion
-	}
+            ColumnName = columnName;
+            Label = label;
+            SearchType = JqGridColumnSearchTypes.Text;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridTypes.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available types of jqGrid filter grid.
-    /// </summary>
-    public enum JqGridFilterGridTypes
-    {
-        /// <summary>
-        /// Filter grid with horizontal orientation.
-        /// </summary>
-        Horizontal,
-        /// <summary>
-        /// Filter grid with vertical orientation.
-        /// </summary>
-        Vertical
-    }
+	/// <summary>
+	/// Defines available types of jqGrid filter grid.
+	/// </summary>
+	public enum JqGridFilterGridTypes
+	{
+		/// <summary>
+		/// Filter grid with horizontal orientation.
+		/// </summary>
+		Horizontal,
+		/// <summary>
+		/// Filter grid with vertical orientation.
+		/// </summary>
+		Vertical
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterGridTypes.cs
@@ -1,17 +1,17 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available types of jqGrid filter grid.
-	/// </summary>
-	public enum JqGridFilterGridTypes
-	{
-		/// <summary>
-		/// Filter grid with horizontal orientation.
-		/// </summary>
-		Horizontal,
-		/// <summary>
-		/// Filter grid with vertical orientation.
-		/// </summary>
-		Vertical
-	}
+    /// <summary>
+    /// Defines available types of jqGrid filter grid.
+    /// </summary>
+    public enum JqGridFilterGridTypes
+    {
+        /// <summary>
+        /// Filter grid with horizontal orientation.
+        /// </summary>
+        Horizontal,
+        /// <summary>
+        /// Filter grid with vertical orientation.
+        /// </summary>
+        Vertical
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterOptions.cs
@@ -1,40 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Abstract class which represents options for jqGrid filter toolba and grid.
-    /// </summary>
-    public abstract class JqGridFilterOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the name of the function for event which is raised after clearing entered values.
-        /// </summary>
-        public string AfterClear { get; set; }
+	/// <summary>
+	/// Abstract class which represents options for jqGrid filter toolba and grid.
+	/// </summary>
+	public abstract class JqGridFilterOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the name of the function for event which is raised after clearing entered values.
+		/// </summary>
+		public string AfterClear { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of the function for event which is raised after searching.
-        /// </summary>
-        public string AfterSearch { get; set; }
+		/// <summary>
+		/// Gets or sets the name of the function for event which is raised after searching.
+		/// </summary>
+		public string AfterSearch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if searching is performed automatically.
-        /// </summary>
-        public bool? AutoSearch { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if searching is performed automatically.
+		/// </summary>
+		public bool? AutoSearch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of the function for event which is raised before clearing entered values.
-        /// </summary>
-        public string BeforeClear { get; set; }
+		/// <summary>
+		/// Gets or sets the name of the function for event which is raised before clearing entered values.
+		/// </summary>
+		public string BeforeClear { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of the function for event which is raised before searching.
-        /// </summary>
-        public string BeforeSearch { get; set; }
-        #endregion
-    }
+		/// <summary>
+		/// Gets or sets the name of the function for event which is raised before searching.
+		/// </summary>
+		public string BeforeSearch { get; set; }
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterOptions.cs
@@ -1,35 +1,35 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Abstract class which represents options for jqGrid filter toolba and grid.
-	/// </summary>
-	public abstract class JqGridFilterOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the name of the function for event which is raised after clearing entered values.
-		/// </summary>
-		public string AfterClear { get; set; }
+    /// <summary>
+    /// Abstract class which represents options for jqGrid filter toolba and grid.
+    /// </summary>
+    public abstract class JqGridFilterOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of the function for event which is raised after clearing entered values.
+        /// </summary>
+        public string AfterClear { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name of the function for event which is raised after searching.
-		/// </summary>
-		public string AfterSearch { get; set; }
+        /// <summary>
+        /// Gets or sets the name of the function for event which is raised after searching.
+        /// </summary>
+        public string AfterSearch { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if searching is performed automatically.
-		/// </summary>
-		public bool? AutoSearch { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if searching is performed automatically.
+        /// </summary>
+        public bool? AutoSearch { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name of the function for event which is raised before clearing entered values.
-		/// </summary>
-		public string BeforeClear { get; set; }
+        /// <summary>
+        /// Gets or sets the name of the function for event which is raised before clearing entered values.
+        /// </summary>
+        public string BeforeClear { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name of the function for event which is raised before searching.
-		/// </summary>
-		public string BeforeSearch { get; set; }
-		#endregion
-	}
+        /// <summary>
+        /// Gets or sets the name of the function for event which is raised before searching.
+        /// </summary>
+        public string BeforeSearch { get; set; }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterToolbarOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterToolbarOptions.cs
@@ -4,76 +4,76 @@ using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid filter toolbar.
-	/// </summary>
-	public class JqGridFilterToolbarOptions : JqGridFilterOptions
-	{
-		#region Fields
-		private JqGridSearchOperators _defaultSearchOperator;
-		#endregion
+    /// <summary>
+    /// Class which represents options for jqGrid filter toolbar.
+    /// </summary>
+    public class JqGridFilterToolbarOptions : JqGridFilterOptions
+    {
+        #region Fields
+        private JqGridSearchOperators _defaultSearchOperator;
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets the default search operator for all fields (it will be overriden by JqGridColumnSearchOptions.SearchOperators).
-		/// </summary>
-		public JqGridSearchOperators DefaultSearchOperator
-		{
-			get => _defaultSearchOperator;
+        #region Properties
+        /// <summary>
+        /// Gets or sets the default search operator for all fields (it will be overriden by JqGridColumnSearchOptions.SearchOperators).
+        /// </summary>
+        public JqGridSearchOperators DefaultSearchOperator
+        {
+            get => _defaultSearchOperator;
 
-			set
-			{
-				if (value == JqGridSearchOperators.EqualOrNotEqual || value == JqGridSearchOperators.NoTextOperators || value == JqGridSearchOperators.NullOperators || value == JqGridSearchOperators.TextOperators)
-					throw new ArgumentException("DefaultSearchOperator must be a simple operator", "DefaultSearchOperator");
-				_defaultSearchOperator = value;
-			}
-		}
+            set
+            {
+                if (value == JqGridSearchOperators.EqualOrNotEqual || value == JqGridSearchOperators.NoTextOperators || value == JqGridSearchOperators.NullOperators || value == JqGridSearchOperators.TextOperators)
+                    throw new ArgumentException("DefaultSearchOperator must be a simple operator", "DefaultSearchOperator");
+                _defaultSearchOperator = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the grouping operator for filters.
-		/// </summary>
-		public JqGridSearchGroupingOperators GroupingOperator { get; set; }
+        /// <summary>
+        /// Gets or sets the grouping operator for filters.
+        /// </summary>
+        public JqGridSearchGroupingOperators GroupingOperator { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if the user needs to press Enter key in text input to trigger search or if searching should triggered after typing any character.
-		/// </summary>
-		public bool SearchOnEnter { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if the user needs to press Enter key in text input to trigger search or if searching should triggered after typing any character.
+        /// </summary>
+        public bool SearchOnEnter { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if user is allowed to select operation when searching.
-		/// </summary>
-		public bool SearchOperators { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if user is allowed to select operation when searching.
+        /// </summary>
+        public bool SearchOperators { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for the operation button.
-		/// </summary>
-		public string OperandToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for the operation button.
+        /// </summary>
+        public string OperandToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or sets the short texts for search operators which are dispalyed to the user when a operation button is clicked.
-		/// </summary>
-		public Dictionary<JqGridSearchOperators, string> Operands { get; set; }
+        /// <summary>
+        /// Gets or sets the short texts for search operators which are dispalyed to the user when a operation button is clicked.
+        /// </summary>
+        public Dictionary<JqGridSearchOperators, string> Operands { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if filters should be posted as JSON string (the same as in advanced searching) or as key:value pairs.
-		/// </summary>
-		public bool StringResult { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the value which defines if filters should be posted as JSON string (the same as in advanced searching) or as key:value pairs.
+        /// </summary>
+        public bool StringResult { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridJsonResult class.
-		/// </summary>
-		public JqGridFilterToolbarOptions()
-		{
-			DefaultSearchOperator = JqGridSearchOperators.Bw;
-			GroupingOperator = JqGridSearchGroupingOperators.Or;
-			SearchOnEnter = true;
-			SearchOperators = false;
-			OperandToolTip = JqGridFilterToolbarDefaults.OperandToolTip;
-			Operands = null;
-			StringResult = false;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridJsonResult class.
+        /// </summary>
+        public JqGridFilterToolbarOptions()
+        {
+            DefaultSearchOperator = JqGridSearchOperators.Bw;
+            GroupingOperator = JqGridSearchGroupingOperators.Or;
+            SearchOnEnter = true;
+            SearchOperators = false;
+            OperandToolTip = JqGridFilterToolbarDefaults.OperandToolTip;
+            Operands = null;
+            StringResult = false;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterToolbarOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFilterToolbarOptions.cs
@@ -1,81 +1,79 @@
 ﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid filter toolbar.
-    /// </summary>
-    public class JqGridFilterToolbarOptions : JqGridFilterOptions
-    {
-        #region Fields
-        private JqGridSearchOperators _defaultSearchOperator;
-        #endregion
+	/// <summary>
+	/// Class which represents options for jqGrid filter toolbar.
+	/// </summary>
+	public class JqGridFilterToolbarOptions : JqGridFilterOptions
+	{
+		#region Fields
+		private JqGridSearchOperators _defaultSearchOperator;
+		#endregion
 
-        #region Properties
-        /// <summary>
-        /// Gets or sets the default search operator for all fields (it will be overriden by JqGridColumnSearchOptions.SearchOperators).
-        /// </summary>
-        public JqGridSearchOperators DefaultSearchOperator
-        {
-            get { return _defaultSearchOperator; }
+		#region Properties
+		/// <summary>
+		/// Gets or sets the default search operator for all fields (it will be overriden by JqGridColumnSearchOptions.SearchOperators).
+		/// </summary>
+		public JqGridSearchOperators DefaultSearchOperator
+		{
+			get => _defaultSearchOperator;
 
-            set
-            {
-                if (value == JqGridSearchOperators.EqualOrNotEqual || value == JqGridSearchOperators.NoTextOperators || value == JqGridSearchOperators.NullOperators || value == JqGridSearchOperators.TextOperators)
-                    throw new ArgumentException("DefaultSearchOperator must be a simple operator", "DefaultSearchOperator");
-                _defaultSearchOperator = value;
-            }
-        }
+			set
+			{
+				if (value == JqGridSearchOperators.EqualOrNotEqual || value == JqGridSearchOperators.NoTextOperators || value == JqGridSearchOperators.NullOperators || value == JqGridSearchOperators.TextOperators)
+					throw new ArgumentException("DefaultSearchOperator must be a simple operator", "DefaultSearchOperator");
+				_defaultSearchOperator = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the grouping operator for filters.
-        /// </summary>
-        public JqGridSearchGroupingOperators GroupingOperator { get; set; }
+		/// <summary>
+		/// Gets or sets the grouping operator for filters.
+		/// </summary>
+		public JqGridSearchGroupingOperators GroupingOperator { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if the user needs to press Enter key in text input to trigger search or if searching should triggered after typing any character.
-        /// </summary>
-        public bool SearchOnEnter { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if the user needs to press Enter key in text input to trigger search or if searching should triggered after typing any character.
+		/// </summary>
+		public bool SearchOnEnter { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if user is allowed to select operation when searching.
-        /// </summary>
-        public bool SearchOperators { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if user is allowed to select operation when searching.
+		/// </summary>
+		public bool SearchOperators { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for the operation button.
-        /// </summary>
-        public string OperandToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for the operation button.
+		/// </summary>
+		public string OperandToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or sets the short texts for search operators which are dispalyed to the user when a operation button is clicked.
-        /// </summary>
-        public Dictionary<JqGridSearchOperators, string> Operands { get; set; }
+		/// <summary>
+		/// Gets or sets the short texts for search operators which are dispalyed to the user when a operation button is clicked.
+		/// </summary>
+		public Dictionary<JqGridSearchOperators, string> Operands { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if filters should be posted as JSON string (the same as in advanced searching) or as key:value pairs.
-        /// </summary>
-        public bool StringResult { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the value which defines if filters should be posted as JSON string (the same as in advanced searching) or as key:value pairs.
+		/// </summary>
+		public bool StringResult { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridJsonResult class.
-        /// </summary>
-        public JqGridFilterToolbarOptions()
-        {
-            DefaultSearchOperator = JqGridSearchOperators.Bw;
-            GroupingOperator = JqGridSearchGroupingOperators.Or;
-            SearchOnEnter = true;
-            SearchOperators = false;
-            OperandToolTip = JqGridFilterToolbarDefaults.OperandToolTip;
-            Operands = null;
-            StringResult = false;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridJsonResult class.
+		/// </summary>
+		public JqGridFilterToolbarOptions()
+		{
+			DefaultSearchOperator = JqGridSearchOperators.Bw;
+			GroupingOperator = JqGridSearchGroupingOperators.Or;
+			SearchOnEnter = true;
+			SearchOperators = false;
+			OperandToolTip = JqGridFilterToolbarDefaults.OperandToolTip;
+			Operands = null;
+			StringResult = false;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFormButtonIcon.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFormButtonIcon.cs
@@ -1,69 +1,64 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for form editing button icon.
-    /// </summary>
-    public class JqGridFormButtonIcon
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the value indicating if icon is enabled.
-        /// </summary>
-        public bool Enabled { get; set; }
+	/// <summary>
+	/// Class which represents options for form editing button icon.
+	/// </summary>
+	public class JqGridFormButtonIcon
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the value indicating if icon is enabled.
+		/// </summary>
+		public bool Enabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon position (relative to the text).
-        /// </summary>
-        public JqGridFormButtonIconPositions Position { get; set; }
+		/// <summary>
+		/// Gets or sets the icon position (relative to the text).
+		/// </summary>
+		public JqGridFormButtonIconPositions Position { get; set; }
 
-        /// <summary>
-        /// Gets or sets the jQuery UI icon class (ui-icon-*).
-        /// </summary>
-        public string Class { get; set; }
+		/// <summary>
+		/// Gets or sets the jQuery UI icon class (ui-icon-*).
+		/// </summary>
+		public string Class { get; set; }
 
-        /// <summary>
-        /// Gets the predefined close icon.
-        /// </summary>
-        public static JqGridFormButtonIcon CloseIcon { get { return new JqGridFormButtonIcon() { Enabled = true, Position = JqGridFormButtonIconPositions.Left, Class = "ui-icon-close" }; } }
+		/// <summary>
+		/// Gets the predefined close icon.
+		/// </summary>
+		public static JqGridFormButtonIcon CloseIcon { get { return new JqGridFormButtonIcon() { Enabled = true, Position = JqGridFormButtonIconPositions.Left, Class = "ui-icon-close" }; } }
 
-        /// <summary>
-        /// Gets the predefined cancel icon.
-        /// </summary>
-        public static JqGridFormButtonIcon CancelIcon { get { return new JqGridFormButtonIcon() { Enabled = true, Position = JqGridFormButtonIconPositions.Left, Class = "ui-icon-cancel" }; } }
+		/// <summary>
+		/// Gets the predefined cancel icon.
+		/// </summary>
+		public static JqGridFormButtonIcon CancelIcon { get { return new JqGridFormButtonIcon() { Enabled = true, Position = JqGridFormButtonIconPositions.Left, Class = "ui-icon-cancel" }; } }
 
-        /// <summary>
-        /// Gets the predefined delete icon.
-        /// </summary>
-        public static JqGridFormButtonIcon DeleteIcon { get { return new JqGridFormButtonIcon() { Enabled = true, Position = JqGridFormButtonIconPositions.Left, Class = "ui-icon-delete" }; } }
+		/// <summary>
+		/// Gets the predefined delete icon.
+		/// </summary>
+		public static JqGridFormButtonIcon DeleteIcon { get { return new JqGridFormButtonIcon() { Enabled = true, Position = JqGridFormButtonIconPositions.Left, Class = "ui-icon-delete" }; } }
 
-        /// <summary>
-        /// Gets the predefined save icon.
-        /// </summary>
-        public static JqGridFormButtonIcon SaveIcon { get { return new JqGridFormButtonIcon() { Enabled = true, Position = JqGridFormButtonIconPositions.Left, Class = "ui-icon-disk" }; } }
-        #endregion
+		/// <summary>
+		/// Gets the predefined save icon.
+		/// </summary>
+		public static JqGridFormButtonIcon SaveIcon { get { return new JqGridFormButtonIcon() { Enabled = true, Position = JqGridFormButtonIconPositions.Left, Class = "ui-icon-disk" }; } }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridFormButtonIcon class.
-        /// </summary>
-        public JqGridFormButtonIcon()
-        { }
-        #endregion
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridFormButtonIcon class.
+		/// </summary>
+		public JqGridFormButtonIcon()
+		{ }
+		#endregion
 
-        #region Methods
-        public override bool Equals(object obj)
-        {
-            if (obj == null || GetType() != obj.GetType())
-                return false;
+		#region Methods
+		public override bool Equals(object obj)
+		{
+			if (obj == null || GetType() != obj.GetType())
+				return false;
 
-            JqGridFormButtonIcon objCasted = (JqGridFormButtonIcon)obj;
-            return (Enabled == objCasted.Enabled) && (Position == objCasted.Position) && (Class == objCasted.Class);
-        }
-        #endregion
-    }
+			JqGridFormButtonIcon objCasted = (JqGridFormButtonIcon)obj;
+			return (Enabled == objCasted.Enabled) && (Position == objCasted.Position) && (Class == objCasted.Class);
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFormButtonIconPositions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFormButtonIconPositions.cs
@@ -1,22 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    ///  Defines available position for form editing button icon.
-    /// </summary>
-    public enum JqGridFormButtonIconPositions
-    {
-        /// <summary>
-        /// Put the icon to left of the text.
-        /// </summary>
-        Left,
-        /// <summary>
-        /// Put the icon to right of the text.
-        /// </summary>
-        Right
-    }
+	/// <summary>
+	///  Defines available position for form editing button icon.
+	/// </summary>
+	public enum JqGridFormButtonIconPositions
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Put the icon to left of the text.
+		/// </summary>
+		Left,
+		/// <summary>
+		/// Put the icon to right of the text.
+		/// </summary>
+		Right
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFormButtonIconPositions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFormButtonIconPositions.cs
@@ -1,21 +1,21 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	///  Defines available position for form editing button icon.
-	/// </summary>
-	public enum JqGridFormButtonIconPositions
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Put the icon to left of the text.
-		/// </summary>
-		Left,
-		/// <summary>
-		/// Put the icon to right of the text.
-		/// </summary>
-		Right
-	}
+    /// <summary>
+    ///  Defines available position for form editing button icon.
+    /// </summary>
+    public enum JqGridFormButtonIconPositions
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Put the icon to left of the text.
+        /// </summary>
+        Left,
+        /// <summary>
+        /// Put the icon to right of the text.
+        /// </summary>
+        Right
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridFormKeyboardNavigation.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridFormKeyboardNavigation.cs
@@ -1,49 +1,44 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for form editing navigation keys.
-    /// </summary>
-    public class JqGridFormKeyboardNavigation
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the value indicating if keyboard navigation is enabled.
-        /// </summary>
-        public bool Enabled { get; set; }
+	/// <summary>
+	/// Class which represents options for form editing navigation keys.
+	/// </summary>
+	public class JqGridFormKeyboardNavigation
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the value indicating if keyboard navigation is enabled.
+		/// </summary>
+		public bool Enabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets the key for "record up".
-        /// </summary>
-        public char RecordUp { get; set; }
+		/// <summary>
+		/// Gets or sets the key for "record up".
+		/// </summary>
+		public char RecordUp { get; set; }
 
-        /// <summary>
-        /// Gets or sets the key for "record down".
-        /// </summary>
-        public char RecordDown { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the key for "record down".
+		/// </summary>
+		public char RecordDown { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridFormKeyboardNavigation class.
-        /// </summary>
-        public JqGridFormKeyboardNavigation()
-        {
-            Enabled = false;
-            RecordUp = (char)38;
-            RecordDown = (char)40;
-        }
-        #endregion
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridFormKeyboardNavigation class.
+		/// </summary>
+		public JqGridFormKeyboardNavigation()
+		{
+			Enabled = false;
+			RecordUp = (char)38;
+			RecordDown = (char)40;
+		}
+		#endregion
 
-        #region Methods
-        internal bool IsDefault()
-        {
-            return (!Enabled && (RecordUp == (char)38) && (RecordDown == (char)40));
-        }
-        #endregion
-    }
+		#region Methods
+		internal bool IsDefault()
+		{
+			return (!Enabled && (RecordUp == (char)38) && (RecordDown == (char)40));
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridGroupHeader.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridGroupHeader.cs
@@ -1,51 +1,48 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid grouping header.
-    /// </summary>
-    public class JqGridGroupHeader
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the name from colModel from which the grouping header begin, including the same field.
-        /// </summary>
-        public string StartColumn { get; private set; }
+	/// <summary>
+	/// Class which represents options for jqGrid grouping header.
+	/// </summary>
+	public class JqGridGroupHeader
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the name from colModel from which the grouping header begin, including the same field.
+		/// </summary>
+		public string StartColumn { get; private set; }
 
-        /// <summary>
-        /// Gets the number of columns which are included for this group.
-        /// </summary>
-        public int NumberOfColumns { get; private set; }
+		/// <summary>
+		/// Gets the number of columns which are included for this group.
+		/// </summary>
+		public int NumberOfColumns { get; private set; }
 
-        /// <summary>
-        /// Gets the text for this group (can contain HTML tags).
-        /// </summary>
-        public string Title { get; private set; }
-        #endregion
+		/// <summary>
+		/// Gets the text for this group (can contain HTML tags).
+		/// </summary>
+		public string Title { get; private set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridGroupHeader class.
-        /// <param name="startColumn">The name from colModel from which the grouping header begin, including the same field.</param>
-        /// <param name="numberOfColumns">The number of columns which are included for this group.</param>
-        /// <param name="title">The text for this group (can contain HTML tags).</param>
-        /// </summary>
-        public JqGridGroupHeader(string startColumn, int numberOfColumns, string title = "")
-        {
-            if (String.IsNullOrWhiteSpace(startColumn))
-                throw new ArgumentNullException("startColumn");
-            StartColumn = startColumn;
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridGroupHeader class.
+		/// <param name="startColumn">The name from colModel from which the grouping header begin, including the same field.</param>
+		/// <param name="numberOfColumns">The number of columns which are included for this group.</param>
+		/// <param name="title">The text for this group (can contain HTML tags).</param>
+		/// </summary>
+		public JqGridGroupHeader(string startColumn, int numberOfColumns, string title = "")
+		{
+			if (String.IsNullOrWhiteSpace(startColumn))
+				throw new ArgumentNullException("startColumn");
+			StartColumn = startColumn;
 
-            if (numberOfColumns <= 0)
-                throw new ArgumentOutOfRangeException("numberOfColumns");
-            NumberOfColumns = numberOfColumns;
+			if (numberOfColumns <= 0)
+				throw new ArgumentOutOfRangeException("numberOfColumns");
+			NumberOfColumns = numberOfColumns;
 
-            Title = title;
-        }
-        #endregion
-    }
+			Title = title;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridGroupHeader.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridGroupHeader.cs
@@ -2,47 +2,47 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid grouping header.
-	/// </summary>
-	public class JqGridGroupHeader
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the name from colModel from which the grouping header begin, including the same field.
-		/// </summary>
-		public string StartColumn { get; private set; }
+    /// <summary>
+    /// Class which represents options for jqGrid grouping header.
+    /// </summary>
+    public class JqGridGroupHeader
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the name from colModel from which the grouping header begin, including the same field.
+        /// </summary>
+        public string StartColumn { get; private set; }
 
-		/// <summary>
-		/// Gets the number of columns which are included for this group.
-		/// </summary>
-		public int NumberOfColumns { get; private set; }
+        /// <summary>
+        /// Gets the number of columns which are included for this group.
+        /// </summary>
+        public int NumberOfColumns { get; private set; }
 
-		/// <summary>
-		/// Gets the text for this group (can contain HTML tags).
-		/// </summary>
-		public string Title { get; private set; }
-		#endregion
+        /// <summary>
+        /// Gets the text for this group (can contain HTML tags).
+        /// </summary>
+        public string Title { get; private set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridGroupHeader class.
-		/// <param name="startColumn">The name from colModel from which the grouping header begin, including the same field.</param>
-		/// <param name="numberOfColumns">The number of columns which are included for this group.</param>
-		/// <param name="title">The text for this group (can contain HTML tags).</param>
-		/// </summary>
-		public JqGridGroupHeader(string startColumn, int numberOfColumns, string title = "")
-		{
-			if (String.IsNullOrWhiteSpace(startColumn))
-				throw new ArgumentNullException("startColumn");
-			StartColumn = startColumn;
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridGroupHeader class.
+        /// <param name="startColumn">The name from colModel from which the grouping header begin, including the same field.</param>
+        /// <param name="numberOfColumns">The number of columns which are included for this group.</param>
+        /// <param name="title">The text for this group (can contain HTML tags).</param>
+        /// </summary>
+        public JqGridGroupHeader(string startColumn, int numberOfColumns, string title = "")
+        {
+            if (String.IsNullOrWhiteSpace(startColumn))
+                throw new ArgumentNullException(nameof(startColumn));
+            StartColumn = startColumn;
 
-			if (numberOfColumns <= 0)
-				throw new ArgumentOutOfRangeException("numberOfColumns");
-			NumberOfColumns = numberOfColumns;
+            if (numberOfColumns <= 0)
+                throw new ArgumentOutOfRangeException(nameof(numberOfColumns));
+            NumberOfColumns = numberOfColumns;
 
-			Title = title;
-		}
-		#endregion
-	}
+            Title = title;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridGroupingView.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridGroupingView.cs
@@ -1,97 +1,93 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid grouping view.
-    /// </summary>
-    public class JqGridGroupingView
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the array of names from ColumnsModels on which jqGrid will group. Each value represents separate level (jqGrid supports only one level at this time).
-        /// </summary>
-        public string[] Fields { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid grouping view.
+	/// </summary>
+	public class JqGridGroupingView
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the array of names from ColumnsModels on which jqGrid will group. Each value represents separate level (jqGrid supports only one level at this time).
+		/// </summary>
+		public string[] Fields { get; set; }
 
-        /// <summary>
-        /// Gets or sets the array of initial sort orders for every level.
-        /// </summary>
-        public JqGridSortingOrders[] Orders { get; set; }
+		/// <summary>
+		/// Gets or sets the array of initial sort orders for every level.
+		/// </summary>
+		public JqGridSortingOrders[] Orders { get; set; }
 
-        /// <summary>
-        /// Gets or sets the array of grouping headers texts for every level.
-        /// </summary>
-        public string[] Texts { get; set; }
+		/// <summary>
+		/// Gets or sets the array of grouping headers texts for every level.
+		/// </summary>
+		public string[] Texts { get; set; }
 
-        /// <summary>
-        /// Gets or sets the array of values for every level indicating if the column on which we group is visible.
-        /// </summary>
-        public bool[] ColumnShow { get; set; }
+		/// <summary>
+		/// Gets or sets the array of values for every level indicating if the column on which we group is visible.
+		/// </summary>
+		public bool[] ColumnShow { get; set; }
 
-        /// <summary>
-        /// Gets or sets the values for every level indicating if the summary (footer) row for that level is enabled.
-        /// </summary>
-        public bool[] Summary { get; set; }
+		/// <summary>
+		/// Gets or sets the values for every level indicating if the summary (footer) row for that level is enabled.
+		/// </summary>
+		public bool[] Summary { get; set; }
 
-        /// <summary>
-        /// Gets or sets the array of callbacks which allow "not exact" grouping.
-        /// </summary>
-        public string[] IsInTheSameGroupCallbacks { get; set; }
+		/// <summary>
+		/// Gets or sets the array of callbacks which allow "not exact" grouping.
+		/// </summary>
+		public string[] IsInTheSameGroupCallbacks { get; set; }
 
-        /// <summary>
-        /// Gets or sets the array of callbacks for formatting group display values.
-        /// </summary>
-        public string[] FormatDisplayFieldCallbacks { get; set; }
+		/// <summary>
+		/// Gets or sets the array of callbacks for formatting group display values.
+		/// </summary>
+		public string[] FormatDisplayFieldCallbacks { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if summary row is visible when the group is collapsed.
-        /// </summary>
-        public bool SummaryOnHide { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if summary row is visible when the group is collapsed.
+		/// </summary>
+		public bool SummaryOnHide { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the group names should be added to request SortingName
-        /// </summary>
-        public bool DataSorted { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the group names should be added to request SortingName
+		/// </summary>
+		public bool DataSorted { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the groups should be initially collapsed.
-        /// </summary>
-        public bool Collapse { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the groups should be initially collapsed.
+		/// </summary>
+		public bool Collapse { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) that will be used if the group is collapsed.
-        /// </summary>
-        public string PlusIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) that will be used if the group is collapsed.
+		/// </summary>
+		public string PlusIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) that will be used if the group is expanded.
-        /// </summary>
-        public string MinusIcon { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) that will be used if the group is expanded.
+		/// </summary>
+		public string MinusIcon { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridGroupingView class.
-        /// </summary>
-        public JqGridGroupingView()
-        {
-            Fields = null;
-            Orders = null;
-            Texts = null;
-            ColumnShow = null;
-            Summary = null;
-            IsInTheSameGroupCallbacks = null;
-            FormatDisplayFieldCallbacks = null;
-            SummaryOnHide = false;
-            DataSorted = false;
-            Collapse = false;
-            PlusIcon = JqGridOptionsDefaults.GroupingPlusIcon;
-            MinusIcon = JqGridOptionsDefaults.GroupingMinusIcon;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridGroupingView class.
+		/// </summary>
+		public JqGridGroupingView()
+		{
+			Fields = null;
+			Orders = null;
+			Texts = null;
+			ColumnShow = null;
+			Summary = null;
+			IsInTheSameGroupCallbacks = null;
+			FormatDisplayFieldCallbacks = null;
+			SummaryOnHide = false;
+			DataSorted = false;
+			Collapse = false;
+			PlusIcon = JqGridOptionsDefaults.GroupingPlusIcon;
+			MinusIcon = JqGridOptionsDefaults.GroupingMinusIcon;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridGroupingView.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridGroupingView.cs
@@ -2,92 +2,92 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid grouping view.
-	/// </summary>
-	public class JqGridGroupingView
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the array of names from ColumnsModels on which jqGrid will group. Each value represents separate level (jqGrid supports only one level at this time).
-		/// </summary>
-		public string[] Fields { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid grouping view.
+    /// </summary>
+    public class JqGridGroupingView
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the array of names from ColumnsModels on which jqGrid will group. Each value represents separate level (jqGrid supports only one level at this time).
+        /// </summary>
+        public string[] Fields { get; set; }
 
-		/// <summary>
-		/// Gets or sets the array of initial sort orders for every level.
-		/// </summary>
-		public JqGridSortingOrders[] Orders { get; set; }
+        /// <summary>
+        /// Gets or sets the array of initial sort orders for every level.
+        /// </summary>
+        public JqGridSortingOrders[] Orders { get; set; }
 
-		/// <summary>
-		/// Gets or sets the array of grouping headers texts for every level.
-		/// </summary>
-		public string[] Texts { get; set; }
+        /// <summary>
+        /// Gets or sets the array of grouping headers texts for every level.
+        /// </summary>
+        public string[] Texts { get; set; }
 
-		/// <summary>
-		/// Gets or sets the array of values for every level indicating if the column on which we group is visible.
-		/// </summary>
-		public bool[] ColumnShow { get; set; }
+        /// <summary>
+        /// Gets or sets the array of values for every level indicating if the column on which we group is visible.
+        /// </summary>
+        public bool[] ColumnShow { get; set; }
 
-		/// <summary>
-		/// Gets or sets the values for every level indicating if the summary (footer) row for that level is enabled.
-		/// </summary>
-		public bool[] Summary { get; set; }
+        /// <summary>
+        /// Gets or sets the values for every level indicating if the summary (footer) row for that level is enabled.
+        /// </summary>
+        public bool[] Summary { get; set; }
 
-		/// <summary>
-		/// Gets or sets the array of callbacks which allow "not exact" grouping.
-		/// </summary>
-		public string[] IsInTheSameGroupCallbacks { get; set; }
+        /// <summary>
+        /// Gets or sets the array of callbacks which allow "not exact" grouping.
+        /// </summary>
+        public string[] IsInTheSameGroupCallbacks { get; set; }
 
-		/// <summary>
-		/// Gets or sets the array of callbacks for formatting group display values.
-		/// </summary>
-		public string[] FormatDisplayFieldCallbacks { get; set; }
+        /// <summary>
+        /// Gets or sets the array of callbacks for formatting group display values.
+        /// </summary>
+        public string[] FormatDisplayFieldCallbacks { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if summary row is visible when the group is collapsed.
-		/// </summary>
-		public bool SummaryOnHide { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if summary row is visible when the group is collapsed.
+        /// </summary>
+        public bool SummaryOnHide { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the group names should be added to request SortingName
-		/// </summary>
-		public bool DataSorted { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the group names should be added to request SortingName
+        /// </summary>
+        public bool DataSorted { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the groups should be initially collapsed.
-		/// </summary>
-		public bool Collapse { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the groups should be initially collapsed.
+        /// </summary>
+        public bool Collapse { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) that will be used if the group is collapsed.
-		/// </summary>
-		public string PlusIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) that will be used if the group is collapsed.
+        /// </summary>
+        public string PlusIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) that will be used if the group is expanded.
-		/// </summary>
-		public string MinusIcon { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) that will be used if the group is expanded.
+        /// </summary>
+        public string MinusIcon { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridGroupingView class.
-		/// </summary>
-		public JqGridGroupingView()
-		{
-			Fields = null;
-			Orders = null;
-			Texts = null;
-			ColumnShow = null;
-			Summary = null;
-			IsInTheSameGroupCallbacks = null;
-			FormatDisplayFieldCallbacks = null;
-			SummaryOnHide = false;
-			DataSorted = false;
-			Collapse = false;
-			PlusIcon = JqGridOptionsDefaults.GroupingPlusIcon;
-			MinusIcon = JqGridOptionsDefaults.GroupingMinusIcon;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridGroupingView class.
+        /// </summary>
+        public JqGridGroupingView()
+        {
+            Fields = null;
+            Orders = null;
+            Texts = null;
+            ColumnShow = null;
+            Summary = null;
+            IsInTheSameGroupCallbacks = null;
+            FormatDisplayFieldCallbacks = null;
+            SummaryOnHide = false;
+            DataSorted = false;
+            Collapse = false;
+            PlusIcon = JqGridOptionsDefaults.GroupingPlusIcon;
+            MinusIcon = JqGridOptionsDefaults.GroupingMinusIcon;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridHelper.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridHelper.cs
@@ -9,2617 +9,2617 @@ using System.Web.Script.Serialization;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Helper class for generating jqGrid HMTL and JavaScript
-	/// </summary>
-	/// <typeparam name="TModel">Type of model for this grid</typeparam>
-	public class JqGridHelper<TModel> : IJqGridHelper
-	{
-		#region Fields
-		private JqGridOptions _options;
-		private JqGridInlineNavigatorOptions _inlineNavigatorOptions;
-		private JqGridNavigatorOptions _navigatorOptions;
-		private JqGridNavigatorActionOptions _navigatorEditActionOptions;
-		private JqGridNavigatorActionOptions _navigatorAddActionOptions;
-		private JqGridNavigatorActionOptions _navigatorDeleteActionOptions;
-		private JqGridNavigatorActionOptions _navigatorSearchActionOptions;
-		private JqGridNavigatorActionOptions _navigatorViewActionOptions;
-		private List<JqGridNavigatorControlOptions> _navigatorControlsOptions = new List<JqGridNavigatorControlOptions>();
-		private bool _filterToolbar = false;
-		private JqGridFilterToolbarOptions _filterToolbarOptions;
-		private List<JqGridFilterGridRowModel> _filterGridModel;
-		private JqGridFilterGridOptions _filterGridOptions;
-		private IDictionary<string, object> _footerData = null;
-		private bool _footerDataUseFormatters = true;
-		private bool _groupHeadersUseColSpanStyle = false;
-		private IEnumerable<JqGridGroupHeader> _groupHeaders = null;
-		private bool _setFrozenColumns = false;
-		private bool _asSubgrid = false;
-		private object _subgridHelper = null;
-		#endregion
-
-		#region Properties
-		/// <summary>
-		/// Gets the grid identifier.
-		/// </summary>
-		public string Id => _options.Id;
-
-		private string GridSelector => _asSubgrid ? "'#' + subgridTableId" : $"'#{Id}'";
-
-		/// <summary>
-		/// Gets the grid pager identifier.
-		/// </summary>
-		public string PagerId => _options.Id + "Pager";
-
-		private string TopPagerSelector => _asSubgrid ? "'#' + subgridTableId + '_toppager'" : $"'#{Id}_toppager'";
-
-		private string PagerSelector => _asSubgrid ? "'#' + subgridPagerId" : $"'#{PagerId}'";
-
-		/// <summary>
-		/// Gets the filter grid (div) placeholder identifier.
-		/// </summary>
-		public string FilterGridId => _options.Id + "Search";
-
-		private string FilterGridSelector => _asSubgrid ? "'#' + subgridFilterGridId" : $"'#{FilterGridId}'";
-
-		#endregion
-
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridHelper class.
-		/// </summary>
-		/// <param name="id">Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div (id='{0}Search') and in JavaScript.</param>
-		/// <param name="afterInsertRow">The function for event which is raised after every inserted row.</param>
-		/// <param name="afterEditCell">The function for event which is raised after the edited cell is edited.</param>
-		/// <param name="afterRestoreCell">The function for event which is raised after calling the method restoreCell or the user press ESC leaving the changes.</param>
-		/// <param name="afterSaveCell">The function for event which is raised after the cell has been successfully saved.</param>
-		/// <param name="afterSubmitCell">The function for event which is raised after the cell and other data is posted to the server.</param>
-		/// <param name="altClass">The class that is used for alternate rows.</param>
-		/// <param name="altRows">The value indicating if the grid should be "zebra-striped".</param>
-		/// <param name="autoEncode">The value indicating if the grid should auto encode/decode the data.</param>
-		/// <param name="autoWidth">The value indicating if the grid width will be recalculated automatically to the width of the parent element.</param>
-		/// <param name="beforeRequest">The function for event which is raised before requesting any data.</param>
-		/// <param name="beforeSelectRow">The function for event which is raised when the user click on the row, but before selecting it.</param>
-		/// <param name="beforeEditCell">The function for event which is raised before editing the cell.</param>
-		/// <param name="beforeSaveCell">The function for event which is raised before validation of values if any.</param>
-		/// <param name="beforeSubmitCell">The function for event which is raised before submit the cell content to the server.</param>
-		/// <param name="beforeProcessing">This function for event which is raised before proccesing the data returned from the server.</param>
-		/// <param name="caption">The caption for the grid.</param>
-		/// <param name="cellLayout">The padding plus border width of the cell.</param>
-		/// <param name="cellEditingEnabled">The value indicating if cell editing is enabled.</param>
-		/// <param name="cellEditingSubmitMode">The cell editing submit mode.</param>
-		/// <param name="cellEditingUrl">The URL for cell editing submit.</param>
-		/// <param name="dataString">The string of data which will be used when DataType is set to JqGridDataTypes.XmlString or JqGridDataTypes.JsonString.</param>
-		/// <param name="dataType">The type of information to expect to represent data in the grid.</param>
-		/// <param name="deepEmpty">The value indicating if jqGrid should be using jQuery.empty for the the row and all its children elements.</param>
-		/// <param name="direction">The language direction in grid.</param>
-		/// <param name="dynamicScrollingMode">The value which defines if dynamic scrolling is enabled.</param>
-		/// <param name="dynamicScrollingTimeout">The timeout (in miliseconds) if DynamicScrollingMode is set to JqGridDynamicScrollingModes.HoldVisibleRows.</param>
-		/// <param name="editingUrl">The url for inline and form editing</param>
-		/// <param name="emptyRecords">The information to be displayed when the returned (or the current) number of records is zero.</param>
-		/// <param name="expandColumnClick">The value which defines whether the tree is expanded and/or collapsed when user clicks on the text of the expanded column, not only on the image.</param>
-		/// <param name="expandColumn">The name of column which should be used to expand the tree grid.</param>
-		/// <param name="errorCell">The function for event which is raised when there is a server error while saving cell.</param>
-		/// <param name="formatCell">The function for event which allows formatting the cell content before editing.</param>
-		/// <param name="footerEnabled">The value indicating if the footer table (with one row) will be placed below the grid records and above the pager.</param>
-		/// <param name="gridView">The value indicating if all the data should be inserted into DOM with one jQuery call.</param>
-		/// <param name="groupingEnabled">The value indicating if the grouping is enabled.</param>
-		/// <param name="groupingView">The grouping view options.</param>
-		/// <param name="height">The height of the grid in pixels (default 'auto').</param>
-		/// <param name="headerTitles">The value which defines whether the title attribute is added to the column headers.</param>
-		/// <param name="hidden">The value which defines whether the grid is initialy hidden (no data loaded, only caption layer is shown). Takes effect only if the caption is not empty string and hiddenEnabled is true.</param>
-		/// <param name="hoverRows">The value which defines whether the mouse hovering over the grid data rows is enabled</param>
-		/// <param name="ignoreCase">The value which defines whether the local searching is case-sensitive.</param>
-		/// <param name="hiddenEnabled">The value which defines whether the show/hide grid button is enabled. Takes effect only if the caption is not empty string.</param>
-		/// <param name="jsonReader">The JSON reader for the grid.</param>
-		/// <param name="loadBeforeSend">The function for pre-callback to modify the XMLHttpRequest object before it is sent.</param>
-		/// <param name="loadError">The function for event which is raised after the request fails.</param>
-		/// <param name="loadComplete">The function for event which is raised immediately after every server request.</param>
-		/// <param name="loadOnce">The value which defines whether the grid should load the data only once and all further manipulationsshould be done on the client side.</param>
-		/// <param name="methodType">The type of request to make.</param>
-		/// <param name="multiKey">The key which should be pressed when the user makes multiselection.</param>
-		/// <param name="multiBoxOnly">The value which defines whether the multiselection is done only when the checkbox is clicked.</param>
-		/// <param name="multiSelect">The value which defines whether the multiselection is enabled.</param>
-		/// <param name="multiSelectWidth">The width of the multiselect colum.</param>
-		/// <param name="multiSort">The value which defines whether the sorting by multiple columns is enabled.</param>
-		/// <param name="gridComplete">The function for event which is raised after all the data is loaded into the grid and all other processes are complete.</param>
-		/// <param name="onCellSelect">The function for event which is raised when user clicks on particular cell in the grid.</param>
-		/// <param name="onDoubleClickRow">The function for event which is raised immediately after row was double clicked.</param>
-		/// <param name="onHeaderClick">The function for event which is raised after clicking to hide or show grid.</param>
-		/// <param name="onInitGrid">The function for event which is raised only once before populating the data.</param>
-		/// <param name="onPaging">The function for event which is raised before populating the data after page index/size change.</param>
-		/// <param name="onRightClickRow">The function for event which is raised immediately after row was right clicked.</param>
-		/// <param name="onSelectAll">The function for event which is raised when MultipleSelect option is true and user clicks on the header checkbox.</param>
-		/// <param name="onSelectCell">The function for event which is raised after the cell is selected for editing.</param>
-		/// <param name="onSelectRow">The function for event which is raised immediately after row was clicked.</param>
-		/// <param name="onSortCol">The function for event which is raised immediately after sortable column was clicked and before sorting the data.</param>
-		/// <param name="pager">If grid should use a pager bar to navigate through the records.</param>
-		/// <param name="parametersNames">The customized names for jqGrid request parameters.</param>
-		/// <param name="postData">The additional data which will be added to the request.</param>
-		/// <param name="postDataScript">The JavaScript which will dynamically generate the additional data which will be added to the request (this property takes precedence over postData).</param>
-		/// <param name="resizeStart">The function for event which is raised when user starts resizing a column.</param>
-		/// <param name="resizeStop">The function for event which is raised after the column is resized.</param>
-		/// <param name="rowAttributes">The function which can add attributes to the row during the creation of the data (dynamically).</param>
-		/// <param name="rowsList">The array to construct a select box element in the pager in which user can change the number of the visible rows.</param>
-		/// <param name="rowsNumber">How many records should be displayed in the grid.</param>
-		/// <param name="rowsNumbers">The value which defines whether a new column, which purpose is to count the number of available rows, should be added at left of the grid.</param>
-		/// <param name="rowsNumbersWidth">The width of the row number column.</param>
-		/// <param name="shrinkToFit">The value which defines whether the columns width should be recalculated to fit the width of the grid.</param>
-		/// <param name="scrollOffset">The width of vertical scrollbar.</param>
-		/// <param name="serializeCellData">The function for event which can serialize the data passed to the ajax request when the cell is being saved.</param>
-		/// <param name="serializeGridData">The function for event which can serialize the data passed to the ajax request.</param>
-		/// <param name="serializeSubGridData">The function for event which can serialize the data passed to the subgrid ajax request.</param>
-		/// <param name="sortable">The value which defines whether the columns can be reordered by dragging and dropping them with the mouse.</param>
-		/// <param name="sortingName">The initial sorting column index, when  using data returned from server.</param>
-		/// <param name="sortingOrder">The initial sorting order, when  using data returned from server.</param>
-		/// <param name="styleUI">The CSS framework.</param>
-		/// <param name="subgridEnabled">The value which defines if subgrid is enabled.</param>
-		/// <param name="subgridModel">The subgrid model.</param>
-		/// <param name="subgridHelper">The subgrid helper for "Subgrid as Grid" scenario. If this option has value, the SugridModel, SubgridUrl and SubGridRowExpanded options are ignored. It will also add additional parameter 'id' to the request.</param>
-		/// <param name="subgridUrl">The url for subgrid data requests.</param>
-		/// <param name="subgridColumnWidth">The width of subgrid expand/colapse column.</param>
-		/// <param name="subGridBeforeExpand">The function for event which is raised just before expanding the subgrid.</param>
-		/// <param name="subGridRowColapsed">The function for event which is raised when the user clicks on the plus icon of the grid.</param>
-		/// <param name="subGridRowExpanded">The function for event which is raised when the user clicks on the minus icon of the grid.</param>
-		/// <param name="topPager">The value indicating if jqGrid should place a pager element at top of the grid below the caption (if available).</param>
-		/// <param name="treeGridEnabled">The value which defines if TreeGrid is enabled.</param>
-		/// <param name="treeGridModel">The model for TreeGrid.</param>
-		/// <param name="url">The url for data requests.</param>
-		/// <param name="userDataOnFooter">The value indicating if the values from user data should be placed on footer.</param>
-		/// <param name="viewRecords">If grid should display the beginning and ending record number out of the total number of records in the query.</param>
-		/// <param name="width">The width of the grid in pixels.</param>
-		/// <param name="compatibilityMode">The compatibility mode.</param>
-		[Obsolete("Now this constructor creates more redurant JavaScript code. Use new constructor with JqGridOption parameter")]
-		public JqGridHelper(string id, string afterInsertRow = null, string afterEditCell = null, string afterRestoreCell = null, string afterSaveCell = null, string afterSubmitCell = null, string altClass = JqGridOptionsDefaults.AltClass, bool altRows = false, bool autoEncode = false, bool autoWidth = false, string beforeRequest = null, string beforeSelectRow = null, string beforeEditCell = null, string beforeSaveCell = null, string beforeSubmitCell = null, string beforeProcessing = null, string caption = null, int cellLayout = JqGridOptionsDefaults.CellLayout, bool cellEditingEnabled = false, JqGridCellEditingSubmitModes cellEditingSubmitMode = JqGridCellEditingSubmitModes.remote, string cellEditingUrl = null, string dataString = null, JqGridDataTypes dataType = JqGridDataTypes.Xml, bool deepEmpty = false, JqGridLanguageDirections direction = JqGridLanguageDirections.Ltr, JqGridDynamicScrollingModes dynamicScrollingMode = JqGridDynamicScrollingModes.Disabled, int dynamicScrollingTimeout = 200, string editingUrl = null, string emptyRecords = JqGridOptionsDefaults.EmptyRecords, bool expandColumnClick = true, string expandColumn = null, int? height = null, string errorCell = null, string formatCell = null, bool footerEnabled = false, bool gridView = false, bool groupingEnabled = false, JqGridGroupingView groupingView = null, bool headerTitles = false, bool hidden = false, bool hiddenEnabled = true, bool hoverRows = true, bool ignoreCase = false, JqGridJsonReader jsonReader = null, string loadBeforeSend = null, string loadError = null, string loadComplete = null, bool loadOnce = false, JqGridMethodTypes methodType = JqGridMethodTypes.Default, JqGridMultiKeys multiKey = JqGridMultiKeys.Default, bool multiBoxOnly = false, bool multiSelect = false, int multiSelectWidth = 20, bool multiSort = false, string gridComplete = null, string onCellSelect = null, string onDoubleClickRow = null, string onHeaderClick = null, string onInitGrid = null, string onPaging = null, string onRightClickRow = null, string onSelectAll = null, string onSelectCell = null, string onSelectRow = null, string onSortCol = null, bool pager = false, JqGridParametersNames parametersNames = null, object postData = null, string postDataScript = null, string resizeStart = null, string resizeStop = null, string rowAttributes = null, List<int> rowsList = null, int rowsNumber = 20, bool rowsNumbers = false, int rowsNumbersWidth = 25, bool shrinkToFit = true, int scrollOffset = 18, string serializeCellData = null, string serializeGridData = null, string serializeSubGridData = null, bool sortable = false, string sortingName = "", JqGridSortingOrders sortingOrder = JqGridSortingOrders.Asc, JqGridStyleUIOptions styleUI = JqGridStyleUIOptions.jQueryUI, bool subgridEnabled = false, JqGridSubgridModel subgridModel = null, object subgridHelper = null, string subgridUrl = null, int subgridColumnWidth = 20, string subGridBeforeExpand = null, string subGridRowColapsed = null, string subGridRowExpanded = null, bool topPager = false, bool treeGridEnabled = false, JqGridTreeGridModels treeGridModel = JqGridTreeGridModels.Nested, string url = null, bool userDataOnFooter = false, bool viewRecords = false, int? width = null, JqGridCompatibilityModes compatibilityMode = JqGridCompatibilityModes.JqGrid)
-			: this(new JqGridOptions<TModel>(id) { CompatibilityMode = compatibilityMode, AfterInsertRow = afterInsertRow, AfterEditCell = afterEditCell, AfterRestoreCell = afterRestoreCell, AfterSaveCell = afterSaveCell, AfterSubmitCell = afterSubmitCell, AltClass = altClass, AltRows = altRows, AutoEncode = autoEncode, AutoWidth = autoWidth, BeforeRequest = beforeRequest, BeforeSelectRow = beforeSelectRow, BeforeEditCell = beforeEditCell, BeforeSaveCell = beforeSaveCell, BeforeSubmitCell = beforeSubmitCell, BeforeProcessing = beforeProcessing, Caption = caption, CellLayout = cellLayout, CellEditingEnabled = cellEditingEnabled, CellEditingSubmitMode = cellEditingSubmitMode, CellEditingUrl = cellEditingUrl, DataString = dataString, DataType = dataType, DeepEmpty = deepEmpty, Direction = direction, DynamicScrollingMode = dynamicScrollingMode, DynamicScrollingTimeout = dynamicScrollingTimeout, EditingUrl = editingUrl, EmptyRecords = emptyRecords, ExpandColumnClick = expandColumnClick, ExpandColumn = expandColumn, ErrorCell = errorCell, FormatCell = formatCell, FooterEnabled = footerEnabled, GridView = gridView, GroupingEnabled = groupingEnabled, GroupingView = groupingView, Height = height, HeaderTitles = headerTitles, Hidden = hidden, HiddenEnabled = hiddenEnabled, HoverRows = hoverRows, IgnoreCase = ignoreCase, JsonReader = jsonReader, LoadBeforeSend = loadBeforeSend, LoadError = loadError, LoadComplete = loadComplete, LoadOnce = loadOnce, MethodType = methodType, MultiBoxOnly = multiBoxOnly, MultiKey = multiKey, MultiSelect = multiSelect, MultiSelectWidth = multiSelectWidth, MultiSort = multiSort, GridComplete = gridComplete, OnCellSelect = onCellSelect, OnDoubleClickRow = onDoubleClickRow, OnHeaderClick = onHeaderClick, OnInitGrid = onInitGrid, OnPaging = onPaging, OnRightClickRow = onRightClickRow, OnSelectAll = onSelectAll, OnSelectRow = onSelectRow, OnSelectCell = onSelectCell, OnSortCol = onSortCol, Pager = pager, ParametersNames = parametersNames, PostData = postData, PostDataScript = postDataScript, RowAttributes = rowAttributes, RowsList = rowsList, RowsNumber = rowsNumber, RowsNumbers = rowsNumbers, RowsNumbersWidth = rowsNumbersWidth, ShrinkToFit = shrinkToFit, ScrollOffset = scrollOffset, SerializeCellData = serializeCellData, SerializeGridData = serializeGridData, SerializeSubGridData = serializeSubGridData, Sortable = sortable, SortingName = sortingName, SortingOrder = sortingOrder, StyleUI = styleUI, SubgridEnabled = subgridEnabled, SubgridModel = subgridModel, SubgridUrl = subgridUrl, SubgridColumnWidth = subgridColumnWidth, SubGridBeforeExpand = subGridBeforeExpand, SubGridRowColapsed = subGridRowColapsed, SubGridRowExpanded = subGridRowExpanded, TopPager = topPager, TreeGridEnabled = treeGridEnabled, TreeGridModel = treeGridModel, Url = url, UserDataOnFooter = userDataOnFooter, ViewRecords = viewRecords, Width = width }, subgridHelper)
-		{
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the JqGridHelper class.
-		/// </summary>
-		/// <param name="options">Options for the grid</param>
-		/// <param name="subgridHelper">The subgrid helper for "Subgrid as Grid" scenario. If this option has value, the SugridModel, SubgridUrl and SubGridRowExpanded options are ignored. It will also add additional parameter 'id' to the request.</param>
-		public JqGridHelper(JqGridOptions options, object subgridHelper = null)
-		{
-			_options = options;
-			_options.SetModel(typeof(TModel));
-
-			if (subgridHelper != null)
-			{
-				var subgridHelperType = subgridHelper.GetType();
-				if (!subgridHelperType.IsGenericType || subgridHelperType.GetGenericTypeDefinition() != typeof(JqGridHelper<>))
-					throw new ArgumentException("The object must be of type JqGridHelper<T>.", nameof(subgridHelper));
-				_subgridHelper = subgridHelper;
-			}
-		}
-		#endregion
-
-		#region Methods
-		/// <summary>
-		/// Returns the HTML that is used to render the table placeholder for the grid. 
-		/// </summary>
-		/// <returns>The HTML that represents the table placeholder for jqGrid</returns>
-		public MvcHtmlString GetTableHtml()
-		{
-			return MvcHtmlString.Create($"<table id='{Id}'></table>");
-		}
-
-		/// <summary>
-		/// Returns the HTML that is used to render the pager (div) placeholder for the grid. 
-		/// </summary>
-		/// <returns>The HTML that represents the pager (div) placeholder for jqGrid</returns>
-		public MvcHtmlString GetPagerHtml()
-		{
-			return MvcHtmlString.Create($"<div id='{PagerId}'></div>");
-		}
-
-		/// <summary>
-		/// Returns the HTML that is used to render the filter grid (div) placeholder for the grid. 
-		/// </summary>
-		/// <returns>The HTML that represents the filter grid (div) placeholder for jqGrid</returns>
-		public MvcHtmlString GetFilterGridHtml()
-		{
-			return MvcHtmlString.Create($"<div id='{FilterGridId}'></div>");
-		}
-
-		/// <summary>
-		/// Returns the HTML that is used to render the table placeholder for the grid with pager placeholder below it and filter grid (if enabled) placeholder above it.
-		/// </summary>
-		/// <returns>The HTML that represents the table placeholder for jqGrid with pager placeholder below i</returns>
-		public MvcHtmlString GetHtml()
-		{
-			if (_filterGridModel != null && _options.Pager)
-				return MvcHtmlString.Create(GetFilterGridHtml().ToHtmlString() + GetTableHtml().ToHtmlString() + GetPagerHtml().ToHtmlString());
-			if (_filterGridModel != null)
-				return MvcHtmlString.Create(GetFilterGridHtml().ToHtmlString() + GetTableHtml().ToHtmlString());
-			if (_options.Pager)
-				return MvcHtmlString.Create(GetTableHtml().ToHtmlString() + GetPagerHtml().ToHtmlString());
-			return GetTableHtml();
-		}
-
-		/// <summary>
-		/// Return the JavaScript that is used to initialize jqGrid with given options.
-		/// </summary>
-		/// <returns>The JavaScript that initializes jqGrid with give options</returns>
-		/// <exception cref="System.InvalidOperationException">
-		/// <list type="bullet">
-		/// <item><description>TreeGrid and data grouping are both enabled.</description></item>
-		/// <item><description>Rows numbers and data grouping are both enabled.</description></item>
-		/// <item><description>Dynamic scrolling and data grouping are both enabled.</description></item>
-		/// <item><description>TreeGrid and GridView are both enabled.</description></item>
-		/// <item><description>SubGrid and GridView are both enabled.</description></item>
-		/// <item><description>AfterInsertRow event and GridView are both enabled.</description></item>
-		/// </list> 
-		/// </exception>
-		public MvcHtmlString GetJavaScript()
-		{
-			ValidateLimitations();
-
-			var javaScriptBuilder = new StringBuilder();
-
-			javaScriptBuilder.AppendFormat("$({0}).jqGrid({{", GridSelector).AppendLine();
-			AppendColumnsNames(javaScriptBuilder);
-			AppendColumnsModels(javaScriptBuilder);
-			AppendOptions(javaScriptBuilder);
-			javaScriptBuilder.Append("})");
-
-			foreach (var columnModel in _options.ColumnsModels)
-			{
-				if (columnModel.LabelOptions != null)
-					AppendColumnLabelOptions(columnModel.Name, columnModel.LabelOptions, javaScriptBuilder);
-			}
-
-			if (_options.FooterEnabled.GetValueOrDefault() && _footerData != null && _footerData.Any())
-				AppendFooterData(javaScriptBuilder);
-
-			if (_navigatorOptions != null)
-				AppendNavigator(javaScriptBuilder);
-
-			if (_inlineNavigatorOptions != null)
-				AppendInlineNavigator(javaScriptBuilder);
-
-			if (_filterToolbar)
-				AppendFilterToolbar(javaScriptBuilder);
-
-			if (_groupHeaders != null && _groupHeaders.Any())
-				AppendGroupHeaders(javaScriptBuilder);
-
-			if (_setFrozenColumns)
-				javaScriptBuilder.Append(".jqGrid('setFrozenColumns')");
-
-			javaScriptBuilder.AppendLine(";");
-
-			if (_filterGridModel != null)
-				AppendFilterGrid(javaScriptBuilder);
-
-			return MvcHtmlString.Create(javaScriptBuilder.ToString());
-		}
-
-		internal string GetSubGridRowExpanded()
-		{
-			_asSubgrid = true;
-
-			StringBuilder subGridRowExpandedBuilder = new StringBuilder();
-			subGridRowExpandedBuilder.AppendLine("function(subgridId, rowId) {");
-
-			if (_filterGridModel != null)
-			{
-				subGridRowExpandedBuilder.AppendLine("var subgridFilterGridId = subgridId + '_s';");
-				subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<div id=\"' + subgridFilterGridId + '\"></div>');");
-			}
-
-			subGridRowExpandedBuilder.AppendLine("var subgridTableId = subgridId + '_t';");
-			subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<table id=\"' + subgridTableId + '\"></table>');");
-
-			if (_options.Pager)
-			{
-				subGridRowExpandedBuilder.AppendLine("var subgridPagerId = subgridId + '_p';");
-				subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<div id=\"' + subgridPagerId + '\"></div>');");
-			}
-
-			subGridRowExpandedBuilder.AppendLine(GetJavaScript().ToString());
-
-			subGridRowExpandedBuilder.Append("}");
-			return subGridRowExpandedBuilder.ToString();
-		}
-
-		private void ValidateLimitations()
-		{
-			if (_options.TreeGridEnabled.GetValueOrDefault() && _options.GroupingEnabled.GetValueOrDefault())
-				throw new InvalidOperationException("TreeGrid and data grouping can not be enabled at the same time.");
-
-			if (_options.RowsNumbers.GetValueOrDefault() && _options.GroupingEnabled.GetValueOrDefault())
-				throw new InvalidOperationException("Rows numbers and data grouping can not be enabled at the same time.");
-
-			if (_options.DynamicScrollingMode != JqGridDynamicScrollingModes.Disabled && _options.GroupingEnabled.GetValueOrDefault())
-				throw new InvalidOperationException("Dynamic scrolling and data grouping can not be enabled at the same time.");
-
-			if (_options.TreeGridEnabled.GetValueOrDefault() && _options.GridView.GetValueOrDefault())
-				throw new InvalidOperationException("TreeGrid and GridView can not be enabled at the same time.");
-
-			if (_options.SubgridEnabled.GetValueOrDefault() && _options.GridView.GetValueOrDefault())
-				throw new InvalidOperationException("SubGrid and GridView can not be enabled at the same time.");
-
-			if (!string.IsNullOrWhiteSpace(_options.AfterInsertRow) && _options.GridView.GetValueOrDefault())
-				throw new InvalidOperationException("AfterInsertRow event and GridView can not be enabled at the same time.");
-		}
-
-		private void AppendColumnsNames(StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.Append("colNames: [");
-
-			foreach (var columnName in _options.ColumnsNames)
-				javaScriptBuilder.AppendFormat("'{0}',", columnName);
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 1] == ',')
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-
-			javaScriptBuilder.AppendLine("],");
-		}
-
-		private void AppendColumnsModels(StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.AppendLine("colModel: [");
-
-			var lastColumnModelIndex = _options.ColumnsModels.Count - 1;
-			for (var columnModelIndex = 0; columnModelIndex < _options.ColumnsModels.Count; columnModelIndex++)
-			{
-				var columnModel = _options.ColumnsModels[columnModelIndex];
-				javaScriptBuilder.Append("{ ");
-
-				if (columnModel.Alignment != JqGridAlignments.Default)
-					javaScriptBuilder.AppendFormat("align: '{0}', ", columnModel.Alignment.ToString().ToLower());
-
-				if (columnModel.Index?.IsSetted ?? false)
-					javaScriptBuilder.AppendFormat("index: '{0}', ", columnModel.Index.Value);
-
-				if (columnModel.CellAttributes?.IsSetted ?? false)
-					javaScriptBuilder.AppendFormat("cellattr: {0}, ", columnModel.CellAttributes.Value);
-
-				if (columnModel.Classes?.IsSetted ?? false)
-					javaScriptBuilder.AppendFormat("classes: '{0}', ", columnModel.Classes.Value);
-
-				if (columnModel.DateFormat?.IsSetted ?? false)
-					javaScriptBuilder.AppendFormat("datefmt: '{0}', ", columnModel.DateFormat.Value);
-
-				if (columnModel.Editable.HasValue)
-				{
-					javaScriptBuilder.AppendFormat("editable: {0}, ", columnModel.Editable.Value.ToString().ToLower());
-					if (columnModel.Editable.Value)
-					{
-						if (columnModel.EditType != JqGridColumnEditTypes.Default)
-							javaScriptBuilder.AppendFormat("edittype: '{0}', ", columnModel.EditType.ToString().ToLower());
-						AppendEditOptions(columnModel.EditOptions, javaScriptBuilder);
-						AppendColumnRules("editrules", columnModel.EditRules, javaScriptBuilder);
-						AppendFormOptions(columnModel.FormOptions, javaScriptBuilder);
-					}
-				}
-
-				if (columnModel.Fixed.HasValue)
-					javaScriptBuilder.AppendFormat("fixed: {0}, ", columnModel.Fixed.ToString().ToLower());
-
-				if (columnModel.Frozen.HasValue)
-					javaScriptBuilder.AppendFormat("frozen: {0}, ", columnModel.Frozen.ToString().ToLower());
-
-				if (columnModel.Formatter?.IsSetted ?? false)
-				{
-					javaScriptBuilder.AppendFormat("formatter: {0}, ", columnModel.Formatter.Value);
-					AppendFormatterOptions(columnModel.Formatter.Value, columnModel.FormatterOptions, javaScriptBuilder);
-					if (columnModel.UnFormatter?.IsSetted ?? false)
-						javaScriptBuilder.AppendFormat("unformat: {0}, ", columnModel.UnFormatter.Value);
-				}
-
-				if (columnModel.InitialSortingOrder != JqGridSortingOrders.Default)
-					javaScriptBuilder.AppendFormat("firstsortorder: '{0}', ", columnModel.InitialSortingOrder.ToString().ToLower());
-
-				if (columnModel.Hidden.HasValue)
-					javaScriptBuilder.AppendFormat("hidden: {0}, ", columnModel.Hidden.Value.ToString().ToLower());
-
-				if (columnModel.HideInDialog.HasValue)
-					javaScriptBuilder.AppendFormat("hidedlg: {0}, ", columnModel.HideInDialog.Value.ToString().ToLower());
-
-				if (!string.IsNullOrWhiteSpace(columnModel.JsonMapping))
-					javaScriptBuilder.AppendFormat("jsonmap: '{0}', ", columnModel.JsonMapping);
-
-				if (columnModel.Key.HasValue)
-					javaScriptBuilder.AppendFormat("key: {0}, ", columnModel.Key.Value.ToString().ToLower());
-
-				if (columnModel.Resizable.HasValue)
-					javaScriptBuilder.AppendFormat("resizable: {0}, ", columnModel.Resizable.Value.ToString().ToLower());
-
-				if (columnModel.Searchable.HasValue)
-				{
-					javaScriptBuilder.AppendFormat("search: {0}, ", columnModel.Searchable.Value.ToString().ToLower());
-					if (columnModel.Searchable.Value)
-					{
-						if (columnModel.SearchType != JqGridColumnSearchTypes.Default)
-							javaScriptBuilder.AppendFormat("stype: '{0}', ", columnModel.SearchType.ToString().ToLower());
-						AppendSearchOptions(columnModel.SearchOptions, javaScriptBuilder);
-						AppendColumnRules("searchrules", columnModel.SearchRules, javaScriptBuilder);
-					}
-				}
-
-				if (_options.GroupingEnabled.GetValueOrDefault())
-				{
-					if (columnModel.SummaryType.HasValue)
-					{
-						if (columnModel.SummaryType.Value != JqGridColumnSummaryTypes.Custom)
-							javaScriptBuilder.AppendFormat("summaryType: '{0}', ", columnModel.SummaryType.Value.ToString().ToLower());
-						else
-							javaScriptBuilder.AppendFormat("summaryType: {0}, ", columnModel.SummaryFunction);
-					}
-
-					if (columnModel.SummaryTemplate?.IsSetted ?? false)
-						javaScriptBuilder.AppendFormat("summaryTpl: '{0}', ", columnModel.SummaryTemplate.Value);
-				}
-
-				if (columnModel.Sortable.HasValue)
-				{
-					javaScriptBuilder.AppendFormat("sortable: {0}, ", columnModel.Sortable.Value.ToString().ToLower());
-					if (columnModel.Sortable.Value && columnModel.SortType != JqGridColumnSortTypes.Default)
-					{
-						if (columnModel.SortType == JqGridColumnSortTypes.Function && (columnModel.SortFunction?.IsSetted ?? false))
-							javaScriptBuilder.AppendFormat("sorttype: {0}, ", columnModel.SortFunction);
-						else if (columnModel.SortType != JqGridColumnSortTypes.Function)
-							javaScriptBuilder.AppendFormat("sorttype: '{0}', ", columnModel.SortType.ToString().ToLower());
-
-					}
-				}
-
-				if (columnModel.Title.HasValue)
-					javaScriptBuilder.AppendFormat("title: {0}, ", columnModel.Title.Value.ToString().ToLower());
-
-				if (columnModel.Width.HasValue)
-					javaScriptBuilder.AppendFormat("width: {0}, ", columnModel.Width.Value);
-
-				if (columnModel.Viewable.HasValue)
-					javaScriptBuilder.AppendFormat("viewable: {0}, ", columnModel.Viewable.ToString().ToLower());
-
-				if (!string.IsNullOrWhiteSpace(columnModel.XmlMapping))
-					javaScriptBuilder.AppendFormat("xmlmap: '{0}', ", columnModel.XmlMapping);
-
-				javaScriptBuilder.AppendFormat("name: '{0}' }}", columnModel.Name);
-
-				if (lastColumnModelIndex == columnModelIndex)
-					javaScriptBuilder.AppendLine();
-				else
-					javaScriptBuilder.AppendLine(",");
-			}
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 1);
-
-			javaScriptBuilder.AppendLine("],");
-		}
-
-		private void AppendEditOptions(JqGridColumnEditOptions editOptions, StringBuilder javaScriptBuilder)
-		{
-			if (editOptions != null)
-			{
-				var serializer = new JavaScriptSerializer();
-				javaScriptBuilder.Append("editoptions: { ");
-
-				if (editOptions.IsCustomElementFunctionSetted)
-					javaScriptBuilder.AppendFormat("custom_element: {0}, ", editOptions.CustomElementFunction);
-
-				if (editOptions.IsCustomValueFunctionSetted)
-					javaScriptBuilder.AppendFormat("custom_value: {0}, ", editOptions.CustomValueFunction);
-
-				if (editOptions.InternalDataEvents != null)
-				{
-					if (editOptions.DataEvents == null)
-						editOptions.DataEvents = new List<JqGridColumnDataEvent>();
-
-					foreach (var dataEvent in editOptions.InternalDataEvents)
-						editOptions.DataEvents.Add(new JqGridColumnDataEvent(dataEvent.Type, string.Format(dataEvent.Function, _options.Id)));
-				}
-				AppendElementOptions(editOptions, serializer, javaScriptBuilder);
-
-				if (editOptions.NullIfEmpty.HasValue)
-					javaScriptBuilder.AppendFormat("NullIfEmpty: {0}, ", editOptions.NullIfEmpty.Value.ToString().ToLower());
-
-				if (editOptions.HtmlAttributes != null && editOptions.HtmlAttributes.Any())
-				{
-					var htmlAttributesSerialized = serializer.Serialize(editOptions.HtmlAttributes);
-					javaScriptBuilder.AppendFormat("{0}, ", htmlAttributesSerialized.Substring(1, htmlAttributesSerialized.Length - 2));
-				}
-
-				if (editOptions.IsPostDataScriptsSetted)
-					javaScriptBuilder.AppendFormat("postData: {0}, ", editOptions.PostDataScript);
-				else if (editOptions.PostData != null)
-				{
-					serializer = new JavaScriptSerializer();
-					javaScriptBuilder.AppendFormat("postData: {0}, ", serializer.Serialize(editOptions.PostData));
-				}
-
-				if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-				{
-					javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-					javaScriptBuilder.Append(" }, ");
-				}
-				else
-					javaScriptBuilder.Remove(javaScriptBuilder.Length - 15, 15);
-			}
-		}
-
-		private void AppendElementOptions(JqGridColumnElementOptions elementOptions, JavaScriptSerializer serializer, StringBuilder javaScriptBuilder)
-		{
-			if (elementOptions.IsBuildSelectSetted)
-				javaScriptBuilder.AppendFormat("buildSelect: {0}, ", elementOptions.BuildSelect);
-
-			if (elementOptions.DataEvents != null && elementOptions.DataEvents.Any())
-			{
-				javaScriptBuilder.Append("dataEvents: [ ");
-				foreach (var dataEvent in elementOptions.DataEvents)
-				{
-					if (dataEvent.Data == null)
-						javaScriptBuilder.AppendFormat("{{ type: '{0}', fn: {1} }}, ", dataEvent.Type, dataEvent.Function);
-					else
-						javaScriptBuilder.AppendFormat("{{ type: '{0}', data: {1}, fn: {2} }}, ", dataEvent.Type, serializer.Serialize(dataEvent.Data), dataEvent.Function);
-				}
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" ], ");
-			}
-
-			if (elementOptions.JQueryUIWidgetDataInitRenderer != null)
-				javaScriptBuilder.AppendFormat("dataInit: {0}, ", elementOptions.JQueryUIWidgetDataInitRenderer(_options.CompatibilityMode, GridSelector));
-			else if (elementOptions.IsDataInitSetted)
-				javaScriptBuilder.AppendFormat("dataInit: {0}, ", elementOptions.DataInit);
-
-			if (elementOptions.IsDataUrlSetted)
-				javaScriptBuilder.AppendFormat("dataUrl: '{0}', ", elementOptions.DataUrl);
-
-			if (elementOptions.IsDefaultValueSetted)
-				javaScriptBuilder.AppendFormat("defaultValue: '{0}', ", elementOptions.DefaultValue);
-
-			if (elementOptions.IsValueSetted)
-				javaScriptBuilder.AppendFormat("value: '{0}', ", elementOptions.Value);
-			else if (elementOptions.ValueDictionary != null)
-				javaScriptBuilder.AppendFormat("value: {0}, ", serializer.Serialize(elementOptions.ValueDictionary));
-		}
-
-		private static void AppendColumnRules(string rulesName, JqGridColumnRules rules, StringBuilder javaScriptBuilder)
-		{
-			if (rules == null) return;
-			javaScriptBuilder.AppendFormat("{0}: {{ ", rulesName);
-
-			if (rules.Custom.HasValue)
-			{
-				javaScriptBuilder.AppendFormat("custom: {0}, ", rules.Custom.Value.ToString().ToLower());
-
-				if (rules.IsCustomFunctionSetted)
-					javaScriptBuilder.AppendFormat("custom_func: {0}, ", rules.CustomFunction);
-			}
-
-			if (rules.Date.HasValue)
-				javaScriptBuilder.AppendFormat("date: {0}, ", rules.Date.Value.ToString().ToLower());
-
-			if (rules.EditHidden.HasValue)
-				javaScriptBuilder.AppendFormat("edithidden: {0}, ", rules.EditHidden.Value.ToString().ToLower());
-
-			if (rules.Email.HasValue)
-				javaScriptBuilder.AppendFormat("email: {0}, ", rules.Email.Value.ToString().ToLower());
-
-			if (rules.Integer)
-				javaScriptBuilder.Append("integer: true, ");
-
-			if (rules.MaxValue.HasValue)
-				javaScriptBuilder.AppendFormat("maxValue: {0}, ", rules.MaxValue.Value);
-
-			if (rules.MinValue.HasValue)
-				javaScriptBuilder.AppendFormat("minValue: {0}, ", rules.MinValue.Value);
-
-			if (rules.Number)
-				javaScriptBuilder.Append("number: true, ");
-
-			if (rules.Required.HasValue)
-				javaScriptBuilder.AppendFormat("required: {0}, ", rules.Required.Value.ToString().ToLower());
-
-			if (rules.Time.HasValue)
-				javaScriptBuilder.AppendFormat("time: {0}, ", rules.Time.Value.ToString().ToLower());
-
-			if (rules.Url.HasValue)
-				javaScriptBuilder.AppendFormat("url: {0}, ", rules.Url.Value.ToString().ToLower());
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" }, ");
-			}
-			else
-			{
-				var rulesNameLength = rulesName.Length + 4;
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - rulesNameLength, rulesNameLength);
-			}
-		}
-
-		private static void AppendFormOptions(JqGridColumnFormOptions formOptions, StringBuilder javaScriptBuilder)
-		{
-			if (formOptions == null) return;
-			javaScriptBuilder.Append("formoptions: { ");
-
-			if (formOptions.ColumnPosition.HasValue)
-				javaScriptBuilder.AppendFormat("colpos: {0},", formOptions.ColumnPosition.Value);
-
-			if (formOptions.IsElementPrefixSetted)
-				javaScriptBuilder.AppendFormat("elmprefix: '{0}',", formOptions.ElementPrefix);
-
-			if (formOptions.IsElementSuffixSetted)
-				javaScriptBuilder.AppendFormat("elmsuffix: '{0}',", formOptions.ElementSuffix);
-
-			if (formOptions.IsLabelSetted)
-				javaScriptBuilder.AppendFormat("label: '{0}',", formOptions.Label);
-
-			if (formOptions.RowPosition.HasValue)
-				javaScriptBuilder.AppendFormat("rowpos: {0},", formOptions.RowPosition.Value);
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 1] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-				javaScriptBuilder.Append(" }, ");
-			}
-			else
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 15, 15);
-		}
-
-		private static void AppendFormatterOptions(string formatter, JqGridColumnFormatterOptions formatterOptions, StringBuilder javaScriptBuilder)
-		{
-			if (formatterOptions == null || formatterOptions.IsDefault(formatter)) return;
-			javaScriptBuilder.Append("formatoptions: { ");
-
-			switch (formatter)
-			{
-				case JqGridColumnPredefinedFormatters.Integer:
-					javaScriptBuilder.AppendFormat("{0}{1}", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
-					break;
-				case JqGridColumnPredefinedFormatters.Number:
-					javaScriptBuilder.AppendFormat("{0}{1}{2}{3}", !formatterOptions.DecimalPlaces.HasValue ? string.Empty : $"decimalPlaces: {formatterOptions.DecimalPlaces.Value}, ", !formatterOptions.IsDecimalSeparatorSetted ? string.Empty : $"decimalSeparator: '{formatterOptions.DecimalSeparator}', ", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
-					break;
-				case JqGridColumnPredefinedFormatters.Currency:
-					javaScriptBuilder.AppendFormat("{0}{1}{2}{3}{4}{5}", !formatterOptions.DecimalPlaces.HasValue ? string.Empty : $"decimalPlaces: {formatterOptions.DecimalPlaces.Value}, ", !formatterOptions.IsDecimalSeparatorSetted ? string.Empty : $"decimalSeparator: '{formatterOptions.DecimalSeparator}', ", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsPrefixSetted ? string.Empty : $"prefix: '{formatterOptions.Prefix}', ", !formatterOptions.IsSuffixSetted ? string.Empty : $"suffix: '{formatterOptions.Suffix}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
-					break;
-				case JqGridColumnPredefinedFormatters.Date:
-					javaScriptBuilder.AppendFormat("{0}{1}", !formatterOptions.IsSourceFormatSetted ? string.Empty : $"srcformat: '{formatterOptions.SourceFormat}', ", !formatterOptions.IsOutputFormatSetted ? string.Empty : $"newformat: '{formatterOptions.OutputFormat}', ");
-					break;
-				case JqGridColumnPredefinedFormatters.Link:
-					javaScriptBuilder.AppendFormat("target: '{0}', ", formatterOptions.Target);
-					break;
-				case JqGridColumnPredefinedFormatters.ShowLink:
-					javaScriptBuilder.AppendFormat("{0}{1}{2}{3}{4}", !formatterOptions.IsBaseLinkUrlSetted ? string.Empty : $"baseLinkUrl: '{formatterOptions.BaseLinkUrl}', ", !formatterOptions.IsShowActionSetted ? string.Empty : $"showAction: '{formatterOptions.ShowAction}', ", !formatterOptions.IsAddParamSetted ? string.Empty : $"addParam: '{formatterOptions.AddParam}', ", !formatterOptions.IsTargetSetted ? string.Empty : $"target: '{formatterOptions.Target}', ", !formatterOptions.IsIdNameSetted ? string.Empty : $"idName: '{formatterOptions.IdName}', ");
-					break;
-				case JqGridColumnPredefinedFormatters.CheckBox:
-					javaScriptBuilder.Append("disabled: false, ");
-					break;
-				case JqGridColumnPredefinedFormatters.Actions:
-					javaScriptBuilder.AppendFormat("{0}{1}{2}", formatterOptions.EditButton ? string.Empty : "editbutton: false, ", formatterOptions.DeleteButton ? string.Empty : "delbutton: false, ", !formatterOptions.UseFormEditing ? string.Empty : "editformbutton: true, ");
-
-					if (formatterOptions.EditButton)
-					{
-						if (!formatterOptions.UseFormEditing && formatterOptions.InlineEditingOptions != null)
-						{
-							if (formatterOptions.InlineEditingOptions.Keys)
-								javaScriptBuilder.Append("keys: true, ");
-
-							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.OnEditFunction))
-								javaScriptBuilder.AppendFormat("onEdit: {0}, ", formatterOptions.InlineEditingOptions.OnEditFunction);
-
-							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.SuccessFunction))
-								javaScriptBuilder.AppendFormat("onSuccess: {0}, ", formatterOptions.InlineEditingOptions.SuccessFunction);
-
-							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.Url))
-								javaScriptBuilder.AppendFormat("url: '{0}', ", formatterOptions.InlineEditingOptions.Url);
-
-							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.ExtraParamScript))
-								javaScriptBuilder.AppendFormat("extraparam: {0}, ", formatterOptions.InlineEditingOptions.ExtraParamScript);
-							else if (formatterOptions.InlineEditingOptions.ExtraParam != null)
-							{
-								JavaScriptSerializer serializer = new JavaScriptSerializer();
-								javaScriptBuilder.AppendFormat("extraparam: {0}, ", serializer.Serialize(formatterOptions.InlineEditingOptions.ExtraParam));
-							}
-
-							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.AfterSaveFunction))
-								javaScriptBuilder.AppendFormat("afterSave: {0}, ", formatterOptions.InlineEditingOptions.AfterSaveFunction);
-
-							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.ErrorFunction))
-								javaScriptBuilder.AppendFormat("onError: {0}, ", formatterOptions.InlineEditingOptions.ErrorFunction);
-
-							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.AfterRestoreFunction))
-								javaScriptBuilder.AppendFormat("afterRestore: {0}, ", formatterOptions.InlineEditingOptions.AfterRestoreFunction);
-
-							if (!formatterOptions.InlineEditingOptions.RestoreAfterError)
-								javaScriptBuilder.Append("restoreAfterError: false, ");
-
-							if (formatterOptions.InlineEditingOptions.MethodType != JqGridMethodTypes.Post)
-								javaScriptBuilder.Append("mtype: 'GET', ");
-						}
-						else if (formatterOptions.UseFormEditing && formatterOptions.FormEditingOptions != null)
-							AppendNavigatorActionOptions("editOptions: ", formatterOptions.FormEditingOptions, javaScriptBuilder);
-					}
-
-					if (formatterOptions.DeleteButton && formatterOptions.DeleteOptions != null)
-						AppendNavigatorActionOptions("delOptions: ", formatterOptions.DeleteOptions, javaScriptBuilder);
-					break;
-			}
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" }, ");
-			}
-			else
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 17, 17);
-		}
-
-		private void AppendSearchOptions(JqGridColumnSearchOptions searchOptions, StringBuilder javaScriptBuilder)
-		{
-			if (searchOptions == null) return;
-			var serializer = new JavaScriptSerializer();
-			javaScriptBuilder.Append("searchoptions: { ");
-
-			AppendElementOptions(searchOptions, serializer, javaScriptBuilder);
-
-			if (searchOptions.HtmlAttributes != null && searchOptions.HtmlAttributes.Count > 0)
-				javaScriptBuilder.AppendFormat("attr: {0}, ", serializer.Serialize(searchOptions.HtmlAttributes));
-
-			if (searchOptions.ClearSearch.HasValue)
-				javaScriptBuilder.AppendFormat("clearSearch: {0}, ", searchOptions.ClearSearch.Value.ToString().ToLower());
-
-			if (searchOptions.SearchHidden.HasValue)
-				javaScriptBuilder.AppendFormat("searchhidden: {0}, ", searchOptions.SearchHidden.Value.ToString().ToLower());
-
-			AppendSearchOperators(searchOptions.SearchOperators, javaScriptBuilder);
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" }, ");
-			}
-			else
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 17, 17);
-		}
-
-		private static void AppendSearchOperators(JqGridSearchOperators? searchOperators, StringBuilder javaScriptBuilder)
-		{
-			if (searchOperators.HasValue && searchOperators.Value != JqGridSearchOperators.Default)
-			{
-				javaScriptBuilder.Append("sopt: [ ");
-				foreach (JqGridSearchOperators searchOperator in Enum.GetValues(typeof(JqGridSearchOperators)))
-				{
-					if (searchOperator == JqGridSearchOperators.Default) continue;
-					if (searchOperator != JqGridSearchOperators.EqualOrNotEqual && searchOperator != JqGridSearchOperators.NoTextOperators && searchOperator != JqGridSearchOperators.TextOperators && (searchOperators.Value & searchOperator) == searchOperator)
-						javaScriptBuilder.AppendFormat("'{0}',", Enum.GetName(typeof(JqGridSearchOperators), searchOperator).ToLower());
-				}
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-				javaScriptBuilder.Append("], ");
-			}
-		}
-
-		private void AppendOptions(StringBuilder javaScriptBuilder)
-		{
-			if (_options.IsAfterInsertRowSetted)
-				javaScriptBuilder.AppendFormat("afterInsertRow: {0},", _options.AfterInsertRow.ToNullString()).AppendLine();
-
-			if (_options.IsAfterEditCellSetted)
-				javaScriptBuilder.AppendFormat("afterEditCell: {0},", _options.AfterEditCell.ToNullString()).AppendLine();
-
-			if (_options.IsAfterRestoreCellSetted)
-				javaScriptBuilder.AppendFormat("afterRestoreCell: {0},", _options.AfterRestoreCell.ToNullString()).AppendLine();
-
-			if (_options.IsAfterSaveCellSetted)
-				javaScriptBuilder.AppendFormat("afterSaveCell: {0},", _options.AfterSaveCell.ToNullString()).AppendLine();
-
-			if (_options.IsAfterSumbitCellSetted)
-				javaScriptBuilder.AppendFormat("afterSubmitCell: {0},", _options.AfterSubmitCell.ToNullString()).AppendLine();
-
-			if (_options.IsAltClassSetted)
-				javaScriptBuilder.AppendFormat("altclass: '{0}',", _options.AltClass.ToNullString()).AppendLine();
-
-			if (_options.AltRows.HasValue)
-				javaScriptBuilder.AppendFormat("altRows: {0},", _options.AltRows.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.AutoEncode.HasValue)
-				javaScriptBuilder.AppendFormat("autoencode: {0},", _options.AutoEncode.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.AutoWidth.HasValue)
-				javaScriptBuilder.AppendFormat("autowidth: {0},", _options.AutoWidth.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.IsBeforeRequestSetted)
-				javaScriptBuilder.AppendFormat("beforeRequest: {0},", _options.BeforeRequest.ToNullString()).AppendLine();
-
-			if (_options.IsBeforeSelectRowSetted)
-				javaScriptBuilder.AppendFormat("beforeSelectRow: {0},", _options.BeforeSelectRow.ToNullString()).AppendLine();
-
-			if (_options.IsBeforeEditCellSetted)
-				javaScriptBuilder.AppendFormat("beforeEditCell: {0},", _options.BeforeEditCell.ToNullString()).AppendLine();
-
-			if (_options.IsBeforeSaveCellSetted)
-				javaScriptBuilder.AppendFormat("beforeSaveCell: {0},", _options.BeforeSaveCell.ToNullString()).AppendLine();
-
-			if (_options.IsBeforeSubmitCellSetted)
-				javaScriptBuilder.AppendFormat("beforeSubmitCell: {0},", _options.BeforeSubmitCell.ToNullString()).AppendLine();
-
-			if (_options.IsBeforeProcessingSetted)
-				javaScriptBuilder.AppendFormat("beforeProcessing: {0},", _options.BeforeProcessing.ToNullString()).AppendLine();
-
-			if (_options.CellLayout.HasValue)
-				javaScriptBuilder.AppendFormat("cellLayout: {0},", _options.CellLayout.Value).AppendLine();
-
-			if (_options.CellEditingEnabled.HasValue)
-			{
-				javaScriptBuilder.AppendFormat("cellEdit: {0},", _options.CellEditingEnabled.Value.ToString().ToLower()).AppendLine();
-				if (_options.CellEditingEnabled.Value)
-				{
-					if (_options.CellEditingSubmitMode != JqGridCellEditingSubmitModes.Default)
-						javaScriptBuilder.AppendFormat("cellsubmit: '{0}',", _options.CellEditingSubmitMode).AppendLine();
-
-					if (_options.IsCellEditingUrlSetted)
-						javaScriptBuilder.AppendFormat("cellurl: '{0}',", _options.CellEditingUrl.ToNullString()).AppendLine();
-				}
-			}
-
-			if (_options.IsCaptionSetted)
-				javaScriptBuilder.AppendFormat("caption: '{0}',", _options.Caption.ToNullString()).AppendLine();
-
-			if (_options.HiddenEnabled.HasValue)
-				javaScriptBuilder.AppendFormat("hidegrid: {0},", _options.HiddenEnabled.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.Hidden.HasValue)
-				javaScriptBuilder.AppendFormat("hiddengrid: {0},", _options.Hidden.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.IsUsedDataString)
-				javaScriptBuilder.AppendFormat("datastr: '{0}',", _options.DataString).AppendLine();
-			else if (_asSubgrid)
-			{
-				if (_options.Url.Contains("?"))
-					javaScriptBuilder.AppendFormat("url: '{0}&id=' + encodeURIComponent(rowId),", _options.Url).AppendLine();
-				else
-					javaScriptBuilder.AppendFormat("url: '{0}?id=' + encodeURIComponent(rowId),", _options.Url).AppendLine();
-			}
-			else
-				javaScriptBuilder.AppendFormat("url: '{0}',", _options.Url).AppendLine();
-
-			if (_options.DataType != JqGridDataTypes.Default)
-				javaScriptBuilder.AppendFormat("datatype: '{0}',", _options.DataType.ToString().ToLower()).AppendLine();
-
-			if (_options.DeepEmpty.HasValue)
-				javaScriptBuilder.AppendFormat("deepempty: {0},", _options.DeepEmpty.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.Direction != JqGridLanguageDirections.Default)
-				javaScriptBuilder.AppendFormat("direction: '{0}',", _options.Direction.ToString().ToLower()).AppendLine();
-
-			if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.Disabled)
-				javaScriptBuilder.Append("scroll: false,").AppendLine();
-			else if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldAllRows)
-				javaScriptBuilder.Append("scroll: true,").AppendLine();
-			else if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldVisibleRows)
-			{
-				javaScriptBuilder.Append("scroll: 10,").AppendLine();
-				if (_options.DynamicScrollingTimeout.HasValue)
-					javaScriptBuilder.AppendFormat("scrollTimeout: {0},", _options.DynamicScrollingTimeout.Value).AppendLine();
-			}
-
-			if (_options.IsEmptyRecordsSetted)
-				javaScriptBuilder.AppendFormat("emptyrecords: '{0}',", _options.EmptyRecords.ToNullString()).AppendLine();
-
-			if (_options.IsEditingUrlSetted)
-				javaScriptBuilder.AppendFormat("editurl: '{0}',", _options.EditingUrl.ToNullString()).AppendLine();
-
-			if (_options.IsErrorCellSetted)
-				javaScriptBuilder.AppendFormat("errorCell: {0},", _options.ErrorCell.ToNullString()).AppendLine();
-
-			if (_options.IsFormatCellSetted)
-				javaScriptBuilder.AppendFormat("formatCell: {0},", _options.FormatCell.ToNullString()).AppendLine();
-
-			if (_options.FooterEnabled.HasValue)
-				javaScriptBuilder.AppendFormat("footerrow: {0},", _options.FooterEnabled.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.UserDataOnFooter.HasValue)
-				javaScriptBuilder.AppendFormat("userDataOnFooter: {0},", _options.UserDataOnFooter.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.GridView.HasValue)
-				javaScriptBuilder.AppendFormat("gridview: {0},", _options.GridView.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.GroupingEnabled.HasValue)
-			{
-				javaScriptBuilder.AppendFormat("grouping: {0},", _options.GroupingEnabled.Value.ToString().ToLower()).AppendLine();
-				if (_options.GroupingEnabled.Value)
-					AppendGroupingView(javaScriptBuilder);
-			}
-
-			if (_options.HeaderTitles.HasValue)
-				javaScriptBuilder.AppendFormat("headertitles: {0},", _options.HeaderTitles.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.HoverRows.HasValue)
-				javaScriptBuilder.AppendFormat("hoverrows: {0},", _options.HoverRows.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.IgnoreCase.HasValue)
-				javaScriptBuilder.AppendFormat("ignoreCase: {0},", _options.IgnoreCase.Value.ToString().ToLower()).AppendLine();
-
-			AppendJsonReader(javaScriptBuilder);
-
-			if (_options.IsLoadBeforeSendSetted)
-				javaScriptBuilder.AppendFormat("loadBeforeSend: {0},", _options.LoadBeforeSend.ToNullString()).AppendLine();
-
-			if (_options.IsLoadCompleteSetted)
-				javaScriptBuilder.AppendFormat("loadComplete: {0},", _options.LoadComplete.ToNullString()).AppendLine();
-
-			if (_options.IsLoadErrorSetted)
-				javaScriptBuilder.AppendFormat("loadError: {0},", _options.LoadError.ToNullString()).AppendLine();
-
-			if (_options.LoadOnce.HasValue)
-				javaScriptBuilder.AppendFormat("loadonce: {0},", _options.LoadOnce.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.MethodType != JqGridMethodTypes.Default)
-				javaScriptBuilder.AppendFormat("mtype: '{0}',", _options.MethodType.ToString().ToUpper()).AppendLine();
-
-			if (_options.MultiKey != JqGridMultiKeys.Default)
-				if (_options.MultiKey == JqGridMultiKeys.Disable)
-					javaScriptBuilder.Append("multikey: null,").AppendLine();
-				else
-					javaScriptBuilder.AppendFormat("multikey: '{0}Key',", _options.MultiKey.ToString().ToLower()).AppendLine();
-
-			if (_options.MultiBoxOnly.HasValue)
-				javaScriptBuilder.AppendFormat("multiboxonly: {0},", _options.MultiBoxOnly.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.MultiSelect.HasValue)
-				javaScriptBuilder.AppendFormat("multiselect: {0},", _options.MultiSelect.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.MultiSelectWidth.HasValue)
-				javaScriptBuilder.AppendFormat("multiselectWidth: {0},", _options.MultiSelectWidth.Value).AppendLine();
-
-			if (_options.MultiSort.HasValue)
-				javaScriptBuilder.AppendFormat("multiSort: {0},", _options.MultiSort.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.IsGridCompleteSetted)
-				javaScriptBuilder.AppendFormat("gridComplete: {0},", _options.GridComplete.ToNullString()).AppendLine();
-
-			if (_options.IsOnCellSelectSetted)
-				javaScriptBuilder.AppendFormat("onCellSelect: {0},", _options.OnCellSelect.ToNullString()).AppendLine();
-
-			if (_options.IsOnDoubleClickRowSetted)
-				javaScriptBuilder.AppendFormat("ondblClickRow: {0},", _options.OnDoubleClickRow.ToNullString()).AppendLine();
-
-			if (_options.IsOnHeaderClickSetted)
-				javaScriptBuilder.AppendFormat("onHeaderClick: {0},", _options.OnHeaderClick.ToNullString()).AppendLine();
-
-			if (_options.IsOnInitGridSetted)
-				javaScriptBuilder.AppendFormat("onInitGrid: {0},", _options.OnInitGrid.ToNullString()).AppendLine();
-
-			if (_options.IsOnPagingSetted)
-				javaScriptBuilder.AppendFormat("onPaging: {0},", _options.OnPaging.ToNullString()).AppendLine();
-
-			if (_options.IsOnRightClickRowSetted)
-				javaScriptBuilder.AppendFormat("onRightClickRow: {0},", _options.OnRightClickRow.ToNullString()).AppendLine();
-
-			if (_options.IsOnSelectAllSetted)
-				javaScriptBuilder.AppendFormat("onSelectAll: {0},", _options.OnSelectAll.ToNullString()).AppendLine();
-
-			if (_options.IsOnSelectCellSetted)
-				javaScriptBuilder.AppendFormat("onSelectCell: {0},", _options.OnSelectCell.ToNullString()).AppendLine();
-
-			if (_options.IsOnSelectRowSetted)
-				javaScriptBuilder.AppendFormat("onSelectRow: {0},", _options.OnSelectRow.ToNullString()).AppendLine();
-
-			if (_options.IsOnSortColSetted)
-				javaScriptBuilder.AppendFormat("onSortCol: {0},", _options.OnSortCol.ToNullString()).AppendLine();
-
-			if (_options.Pager)
-				javaScriptBuilder.AppendFormat("pager: {0},", PagerSelector).AppendLine();
-
-			AppendParametersNames(javaScriptBuilder);
-
-			if (_options.IsPostDataScriptSetted)
-				javaScriptBuilder.AppendFormat("postData: {0},", string.IsNullOrWhiteSpace(_options.PostDataScript) ? "{}" : _options.PostDataScript).AppendLine();
-			else if (_options.IsPostDataSetted)
-			{
-				var serializer = new JavaScriptSerializer();
-				if (_options.PostData == null)
-					javaScriptBuilder.Append("postData: {},");
-				else
-					javaScriptBuilder.AppendFormat("postData: {0},", serializer.Serialize(_options.PostData));
-			}
-
-			if (_options.IsResizeStartSetted)
-				javaScriptBuilder.AppendFormat("resizeStart: {0},", _options.ResizeStart.ToNullString()).AppendLine();
-
-			if (_options.IsResizeStopSetted)
-				javaScriptBuilder.AppendFormat("resizeStop: {0},", _options.ResizeStop.ToNullString()).AppendLine();
-
-			if (_options.IsRowAttributesSetted)
-				javaScriptBuilder.AppendFormat("rowattr: {0},", _options.RowAttributes.ToNullString()).AppendLine();
-
-			if (_options.RowsList != null && _options.RowsList.Any())
-			{
-				javaScriptBuilder.Append("rowList: [");
-				javaScriptBuilder.Append(string.Join(",", _options.RowsList));
-				javaScriptBuilder.Append("],").AppendLine();
-			}
-
-			if (_options.RowsNumber.HasValue)
-				javaScriptBuilder.AppendFormat("rowNum: {0},", _options.RowsNumber.Value).AppendLine();
-
-			if (_options.RowsNumbers.HasValue)
-				javaScriptBuilder.AppendFormat("rownumbers: {0},", _options.RowsNumbers.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.RowsNumbersWidth.HasValue)
-				javaScriptBuilder.AppendFormat("rownumWidth: {0},", _options.RowsNumbersWidth.Value).AppendLine();
-
-			if (_options.ColumnsRemaping != null && _options.ColumnsRemaping.Any())
-			{
-				javaScriptBuilder.Append("remapColumns: [");
-				javaScriptBuilder.Append(string.Join(",", _options.ColumnsRemaping));
-				javaScriptBuilder.Append("],").AppendLine();
-			}
-
-			if (_options.ShrinkToFit.HasValue)
-				javaScriptBuilder.AppendFormat("shrinkToFit: {0},", _options.ShrinkToFit.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.ScrollOffset.HasValue)
-				javaScriptBuilder.AppendFormat("scrollOffset: {0},", _options.ScrollOffset.Value).AppendLine();
-
-			if (_options.IsSerializeCellDataSetted)
-				javaScriptBuilder.AppendFormat("serializeCellData: {0},", _options.SerializeCellData.ToNullString()).AppendLine();
-
-			if (_options.IsSerializeGridDataSetted)
-				javaScriptBuilder.AppendFormat("serializeGridData: {0},", _options.SerializeGridData.ToNullString()).AppendLine();
-
-			if (_options.IsSerializeSubGridDataSetted)
-				javaScriptBuilder.AppendFormat("serializeSubGridData: {0},", _options.SerializeSubGridData.ToNullString()).AppendLine();
-
-			if (_options.Sortable.HasValue)
-				javaScriptBuilder.AppendFormat("sortable: {0},", _options.Sortable.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.IsSortingNameSetted)
-				javaScriptBuilder.AppendFormat("sortname: '{0}',", _options.SortingName.ToNullString()).AppendLine();
-
-			if (_options.SortingOrder != JqGridSortingOrders.Default)
-				javaScriptBuilder.AppendFormat("sortorder: '{0}',", _options.SortingOrder.ToString().ToLower()).AppendLine();
-
-			if (_options.StyleUI != JqGridStyleUIOptions.Default)
-				javaScriptBuilder.AppendFormat("styleUI: '{0}',", _options.StyleUI.ToString()).AppendLine();
-
-			if (_options.IconSet != JqGridBootstrap4IconSet.Default)
-				javaScriptBuilder.AppendFormat("iconSet: '{0}',", _options.IconSet);
-
-			if (_options.SubgridEnabled.HasValue)
-			{
-				javaScriptBuilder.AppendFormat("subGrid: {0},", _options.SubgridEnabled.Value.ToString().ToLower()).AppendLine();
-
-				if (_options.SubgridColumnWidth.HasValue)
-					javaScriptBuilder.AppendFormat("subGridWidth: {0},", _options.SubgridColumnWidth.Value).AppendLine();
-
-				if (_options.IsSubGridBeforeExpandSetted)
-					javaScriptBuilder.AppendFormat("subGridBeforeExpand: {0},", _options.SubGridBeforeExpand.ToNullString()).AppendLine();
-
-				if (_subgridHelper != null)
-				{
-					var subgridHelperType = _subgridHelper.GetType();
-					javaScriptBuilder.AppendFormat("subGridRowExpanded: {0},", subgridHelperType.GetMethod("GetSubGridRowExpanded", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).Invoke(_subgridHelper, null)).AppendLine();
-				}
-				else
-				{
-					AppendSubgridModel(javaScriptBuilder);
-
-					if (_options.IsSubgridUrlSetted)
-						javaScriptBuilder.AppendFormat("subGridUrl: '{0}',", _options.SubgridUrl.ToNullString()).AppendLine();
-
-
-					if (_options.IsSubGridRowExpandedSetted)
-						javaScriptBuilder.AppendFormat("subGridRowExpanded: {0},", _options.SubGridRowExpanded.ToNullString()).AppendLine();
-				}
-
-				if (_options.IsSubGridRowColapsedSetted)
-					javaScriptBuilder.AppendFormat("subGridRowColapsed: {0},", _options.SubGridRowColapsed.ToNullString()).AppendLine();
-			}
-
-			if (_options.TopPager.HasValue)
-				javaScriptBuilder.AppendFormat("toppager: {0},", _options.TopPager.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.TreeGridEnabled.HasValue)
-			{
-				javaScriptBuilder.AppendFormat("treeGrid: {0},", _options.TreeGridEnabled.Value.ToString().ToLower()).AppendLine();
-				if (_options.TreeGridEnabled.Value)
-				{
-
-					if (_options.ExpandColumnClick.HasValue)
-						javaScriptBuilder.AppendFormat("ExpandColClick: {0},", _options.ExpandColumnClick.Value.ToString().ToLower()).AppendLine();
-
-					if (_options.IsExpandColumnSetted)
-						javaScriptBuilder.AppendFormat("ExpandColumn: '{0}',", _options.ExpandColumn.ToNullString()).AppendLine();
-
-					if (_options.TreeGridModel != JqGridTreeGridModels.Default)
-						javaScriptBuilder.AppendFormat("treeGridModel: '{0}',", _options.TreeGridModel.ToString().ToLower()).AppendLine();
-				}
-			}
-
-			if (_options.ViewRecords.HasValue)
-				javaScriptBuilder.AppendFormat("viewrecords: {0},", _options.ViewRecords.Value.ToString().ToLower()).AppendLine();
-
-			if (_options.Width.HasValue)
-				javaScriptBuilder.AppendFormat("width: {0},", _options.Width.Value).AppendLine();
-
-			if (_options.Height.HasValue)
-				javaScriptBuilder.AppendFormat("height: {0}", _options.Height.Value).AppendLine();
-			else
-				javaScriptBuilder.AppendLine("height: '100%'");
-		}
-
-		private void AppendJsonReader(StringBuilder javaScriptBuilder)
-		{
-			if (_options.JsonReader == null || _options.JsonReader.IsGlobal) return;
-			javaScriptBuilder.Append("jsonReader: { ");
-
-			if (_options.JsonReader.Records != JqGridResponse.JsonReader.Records)
-				javaScriptBuilder.AppendFormat("root: '{0}', ", _options.JsonReader.Records);
-
-			if (_options.JsonReader.PageIndex != JqGridResponse.JsonReader.PageIndex)
-				javaScriptBuilder.AppendFormat("page: '{0}', ", _options.JsonReader.PageIndex);
-
-			if (_options.JsonReader.TotalPagesCount != JqGridResponse.JsonReader.TotalPagesCount)
-				javaScriptBuilder.AppendFormat("total: '{0}', ", _options.JsonReader.TotalPagesCount);
-
-			if (_options.JsonReader.TotalRecordsCount != JqGridResponse.JsonReader.TotalRecordsCount)
-				javaScriptBuilder.AppendFormat("records: '{0}', ", _options.JsonReader.TotalRecordsCount);
-
-			if (_options.JsonReader.RepeatItems != JqGridResponse.JsonReader.RepeatItems)
-				javaScriptBuilder.AppendFormat("repeatitems: {0}, ", _options.JsonReader.RepeatItems.ToString().ToLower());
-
-			if (_options.JsonReader.RecordValues != JqGridOptionsDefaults.ResponseRecordValues)
-				javaScriptBuilder.AppendFormat("cell: '{0}', ", _options.JsonReader.RecordValues);
-
-			if (_options.JsonReader.RecordId != JqGridResponse.JsonReader.RecordId)
-				javaScriptBuilder.AppendFormat("id: '{0}', ", _options.JsonReader.RecordId);
-
-			if (_options.JsonReader.UserData != JqGridResponse.JsonReader.UserData)
-				javaScriptBuilder.AppendFormat("userdata: '{0}', ", _options.JsonReader.UserData);
-
-			if (!_options.JsonReader.SubgridReader.IsGlobal)
-			{
-				javaScriptBuilder.Append("subgrid: { ");
-
-				if (_options.JsonReader.SubgridReader.Records != JqGridResponse.JsonReader.SubgridReader.Records)
-					javaScriptBuilder.AppendFormat("root: '{0}', ", _options.JsonReader.SubgridReader.Records);
-
-				if (_options.JsonReader.SubgridReader.RepeatItems != JqGridResponse.JsonReader.SubgridReader.RepeatItems)
-					javaScriptBuilder.AppendFormat("repeatitems: {0}, ", _options.JsonReader.SubgridReader.RepeatItems.ToString().ToLower());
-
-				if (_options.JsonReader.SubgridReader.RecordValues != JqGridResponse.JsonReader.SubgridReader.RecordValues)
-					javaScriptBuilder.AppendFormat("cell: '{0}', ", _options.JsonReader.SubgridReader.RecordValues);
-
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" }, ");
-			}
-
-			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-			javaScriptBuilder.Append(" }, ").AppendLine();
-		}
-
-		private void AppendParametersNames(StringBuilder javaScriptBuilder)
-		{
-			if (_options.ParametersNames == null || _options.ParametersNames.IsGlobal) return;
-			javaScriptBuilder.Append("prmNames: { ");
-
-			if (_options.ParametersNames.PageIndex != JqGridRequest.ParameterNames.PageIndex)
-				javaScriptBuilder.AppendFormat("page: '{0}', ", _options.ParametersNames.PageIndex);
-
-			if (_options.ParametersNames.RecordsCount != JqGridRequest.ParameterNames.RecordsCount)
-				javaScriptBuilder.AppendFormat("rows: '{0}', ", _options.ParametersNames.RecordsCount);
-
-			if (_options.ParametersNames.SortingName != JqGridRequest.ParameterNames.SortingName)
-				javaScriptBuilder.AppendFormat("sort: '{0}', ", _options.ParametersNames.SortingName);
-
-			if (_options.ParametersNames.SortingOrder != JqGridRequest.ParameterNames.SortingOrder)
-				javaScriptBuilder.AppendFormat("order: '{0}', ", _options.ParametersNames.SortingOrder);
-
-			if (_options.ParametersNames.Searching != JqGridRequest.ParameterNames.Searching)
-				javaScriptBuilder.AppendFormat("search: '{0}', ", _options.ParametersNames.Searching);
-
-			if (_options.ParametersNames.Id != JqGridRequest.ParameterNames.Id)
-				javaScriptBuilder.AppendFormat("id: '{0}', ", _options.ParametersNames.Id);
-
-			if (_options.ParametersNames.Operator != JqGridRequest.ParameterNames.Operator)
-				javaScriptBuilder.AppendFormat("oper: '{0}', ", _options.ParametersNames.Operator);
-
-			if (_options.ParametersNames.EditOperator != JqGridRequest.ParameterNames.EditOperator)
-				javaScriptBuilder.AppendFormat("editoper: '{0}', ", _options.ParametersNames.EditOperator);
-
-			if (_options.ParametersNames.AddOperator != JqGridRequest.ParameterNames.AddOperator)
-				javaScriptBuilder.AppendFormat("addoper: '{0}', ", _options.ParametersNames.AddOperator);
-
-			if (_options.ParametersNames.DeleteOperator != JqGridRequest.ParameterNames.DeleteOperator)
-				javaScriptBuilder.AppendFormat("deloper: '{0}', ", _options.ParametersNames.DeleteOperator);
-
-			if (_options.ParametersNames.SubgridId != JqGridRequest.ParameterNames.SubgridId)
-				javaScriptBuilder.AppendFormat("subgridid: '{0}', ", _options.ParametersNames.SubgridId);
-
-			if (_options.ParametersNames.PagesCount != JqGridRequest.ParameterNames.PagesCount)
-				javaScriptBuilder.AppendFormat("npage: '{0}', ", _options.ParametersNames.PagesCount);
-
-			if (_options.ParametersNames.TotalRows != JqGridRequest.ParameterNames.TotalRows)
-				javaScriptBuilder.AppendFormat("totalrows: '{0}', ", _options.ParametersNames.TotalRows);
-
-			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-			javaScriptBuilder.Append(" }, ").AppendLine();
-		}
-
-		private void AppendGroupingView(StringBuilder javaScriptBuilder)
-		{
-			if (_options.GroupingView == null) return;
-			javaScriptBuilder.Append("groupingView: { ");
-
-			if (_options.GroupingView.Fields != null && _options.GroupingView.Fields.Length > 0)
-			{
-				javaScriptBuilder.Append("groupField: [");
-				foreach (var field in _options.GroupingView.Fields)
-					javaScriptBuilder.AppendFormat("'{0}', ", field);
-				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-			}
-
-			if (_options.GroupingView.Orders != null && _options.GroupingView.Orders.Length > 0 && _options.GroupingView.Orders.Contains(JqGridSortingOrders.Desc))
-			{
-				javaScriptBuilder.Append("groupOrder: [");
-				foreach (var order in _options.GroupingView.Orders)
-					javaScriptBuilder.AppendFormat("'{0}', ", order.ToString().ToLower());
-				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-			}
-
-			if (_options.GroupingView.Texts != null && _options.GroupingView.Texts.Length > 0)
-			{
-				javaScriptBuilder.Append("groupText: [");
-				foreach (var text in _options.GroupingView.Texts)
-					javaScriptBuilder.AppendFormat("'{0}', ", text);
-				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-			}
-
-			if (_options.GroupingView.Summary != null && _options.GroupingView.Summary.Length > 0 && _options.GroupingView.Summary.Contains(true))
-			{
-				javaScriptBuilder.Append("groupSummary: [");
-				foreach (var summary in _options.GroupingView.Summary)
-					javaScriptBuilder.AppendFormat("{0}, ", summary.ToString().ToLower());
-				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-			}
-
-			if (_options.GroupingView.ColumnShow != null && _options.GroupingView.ColumnShow.Length > 0 && _options.GroupingView.ColumnShow.Contains(false))
-			{
-				javaScriptBuilder.Append("groupColumnShow: [");
-				foreach (var columnShow in _options.GroupingView.ColumnShow)
-					javaScriptBuilder.AppendFormat("{0}, ", columnShow.ToString().ToLower());
-				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-			}
-
-			if (_options.GroupingView.IsInTheSameGroupCallbacks != null && _options.GroupingView.IsInTheSameGroupCallbacks.Length > 0)
-			{
-				javaScriptBuilder.Append("isInTheSameGroup: [");
-				foreach (var isInTheSameGroupCallback in _options.GroupingView.IsInTheSameGroupCallbacks)
-					javaScriptBuilder.AppendFormat("{0}, ", isInTheSameGroupCallback);
-				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-			}
-
-			if (_options.GroupingView.FormatDisplayFieldCallbacks != null && _options.GroupingView.FormatDisplayFieldCallbacks.Length > 0)
-			{
-				javaScriptBuilder.Append("formatDisplayField: [");
-				foreach (var formatDisplayFieldCallback in _options.GroupingView.FormatDisplayFieldCallbacks)
-					javaScriptBuilder.AppendFormat("{0}, ", formatDisplayFieldCallback);
-				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-			}
-
-			if (_options.GroupingView.SummaryOnHide)
-				javaScriptBuilder.Append("showSummaryOnHide: true, ");
-
-			if (_options.GroupingView.DataSorted)
-				javaScriptBuilder.Append("groupDataSorted: true, ");
-
-			if (_options.GroupingView.Collapse)
-				javaScriptBuilder.Append("groupCollapse: true, ");
-
-			if (_options.GroupingView.PlusIcon != JqGridOptionsDefaults.GroupingPlusIcon)
-				javaScriptBuilder.AppendFormat("plusicon: '{0}', ", _options.GroupingView.PlusIcon);
-
-			if (_options.GroupingView.MinusIcon != JqGridOptionsDefaults.GroupingMinusIcon)
-				javaScriptBuilder.AppendFormat("minusicon: '{0}', ", _options.GroupingView.MinusIcon);
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" }, ").AppendLine();
-			}
-			else
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 16, 16);
-		}
-
-		private void AppendSubgridModel(StringBuilder javaScriptBuilder)
-		{
-			if (_options.SubgridModel == null) return;
-			javaScriptBuilder.AppendLine("subGridModel: [{ ");
-
-			javaScriptBuilder.Append("name: [");
-			foreach (var columnName in _options.SubgridModel.ColumnsNames)
-				javaScriptBuilder.AppendFormat("'{0}',", columnName);
-			if (_options.SubgridModel.ColumnsNames.Any())
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-			javaScriptBuilder.AppendLine("],");
-
-			javaScriptBuilder.Append("align: [");
-			foreach (var alignments in _options.SubgridModel.ColumnsAlignments)
-			{
-				var align = alignments == JqGridAlignments.Default ? JqGridAlignments.Left : alignments;
-				javaScriptBuilder.AppendFormat("'{0}',", align.ToString().ToLower());
-			}
-
-			if (_options.SubgridModel.ColumnsAlignments.Any())
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-			javaScriptBuilder.AppendLine("],");
-
-			javaScriptBuilder.Append("width: [");
-			foreach (var width in _options.SubgridModel.ColumnsWidths)
-				javaScriptBuilder.AppendFormat("{0},", width);
-			if (_options.SubgridModel.ColumnsWidths.Any())
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-			javaScriptBuilder.AppendLine("]");
-
-			javaScriptBuilder.AppendLine(" }],");
-		}
-
-		private void AppendNavigator(StringBuilder javaScriptBuilder)
-		{
-			var navigatorPagerSelector = _navigatorOptions.Pager == JqGridNavigatorPagers.Top ? TopPagerSelector : PagerSelector;
-			javaScriptBuilder.AppendFormat(".jqGrid('navGrid', {0},", navigatorPagerSelector).AppendLine();
-			AppendNavigatorOptions(javaScriptBuilder);
-
-			if (_navigatorEditActionOptions != null || _navigatorAddActionOptions != null || _navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
-			{
-				javaScriptBuilder.AppendLine(",");
-				AppendNavigatorActionOptions(string.Empty, _navigatorEditActionOptions, javaScriptBuilder);
-				if (_navigatorAddActionOptions != null || _navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
-				{
-					javaScriptBuilder.AppendLine(",");
-					AppendNavigatorActionOptions(string.Empty, _navigatorAddActionOptions, javaScriptBuilder);
-					if (_navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
-					{
-						javaScriptBuilder.AppendLine(",");
-						AppendNavigatorActionOptions(string.Empty, _navigatorDeleteActionOptions, javaScriptBuilder);
-						if (_navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
-						{
-							javaScriptBuilder.AppendLine(",");
-							AppendNavigatorActionOptions(string.Empty, _navigatorSearchActionOptions, javaScriptBuilder);
-							if (_navigatorViewActionOptions != null)
-							{
-								javaScriptBuilder.AppendLine(",");
-								AppendNavigatorActionOptions(string.Empty, _navigatorViewActionOptions, javaScriptBuilder);
-							}
-						}
-					}
-				}
-			}
-
-			javaScriptBuilder.Append(")");
-
-			foreach (var controlOptions in _navigatorControlsOptions)
-			{
-				if (controlOptions is JqGridNavigatorButtonOptions buttonOptions)
-				{
-					AppendNavigatorButton(navigatorPagerSelector, buttonOptions, javaScriptBuilder);
-					if (_navigatorOptions.Pager == JqGridNavigatorPagers.Standard && controlOptions.CloneToTop)
-						AppendNavigatorButton(TopPagerSelector, buttonOptions, javaScriptBuilder);
-				}
-				else if (controlOptions is JqGridNavigatorSeparatorOptions separatorOptions)
-				{
-					AppendNavigatorSeparator(navigatorPagerSelector, separatorOptions, javaScriptBuilder);
-					if (_navigatorOptions.Pager == JqGridNavigatorPagers.Standard && controlOptions.CloneToTop)
-						AppendNavigatorSeparator(TopPagerSelector, separatorOptions, javaScriptBuilder);
-				}
-			}
-		}
-
-		private static void AppendBaseNavigatorOptions(JqGridNavigatorOptionsBase baseNavigatorOptions, StringBuilder javaScriptBuilder)
-		{
-			if (!baseNavigatorOptions.Add)
-				javaScriptBuilder.Append("add: false, ");
-
-			if (baseNavigatorOptions.AddIcon != JqGridNavigatorDefaults.AddIcon)
-				javaScriptBuilder.AppendFormat("addicon: '{0}', ", baseNavigatorOptions.AddIcon);
-
-			if (!string.IsNullOrEmpty(baseNavigatorOptions.AddText))
-				javaScriptBuilder.AppendFormat("addtext: '{0}', ", baseNavigatorOptions.AddText);
-
-			if (baseNavigatorOptions.AddToolTip != JqGridNavigatorDefaults.AddToolTip)
-				javaScriptBuilder.AppendFormat("addtitle: '{0}', ", baseNavigatorOptions.AddToolTip);
-
-			if (!baseNavigatorOptions.Edit)
-				javaScriptBuilder.Append("edit: false, ");
-
-			if (baseNavigatorOptions.EditIcon != JqGridNavigatorDefaults.EditIcon)
-				javaScriptBuilder.AppendFormat("editicon: '{0}', ", baseNavigatorOptions.EditIcon);
-
-			if (!string.IsNullOrEmpty(baseNavigatorOptions.EditText))
-				javaScriptBuilder.AppendFormat("edittext: '{0}', ", baseNavigatorOptions.EditText);
-
-			if (baseNavigatorOptions.EditToolTip != JqGridNavigatorDefaults.EditToolTip)
-				javaScriptBuilder.AppendFormat("edittitle: '{0}', ", baseNavigatorOptions.EditToolTip);
-
-			if (baseNavigatorOptions.Position != JqGridAlignments.Left)
-				javaScriptBuilder.AppendFormat("position: '{0}', ", baseNavigatorOptions.Position.ToString().ToLower());
-		}
-
-		private void AppendNavigatorOptions(StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.Append("{ ");
-
-			AppendBaseNavigatorOptions(_navigatorOptions, javaScriptBuilder);
-
-			if (_navigatorOptions.AlertCaption != JqGridNavigatorDefaults.AlertCaption)
-				javaScriptBuilder.AppendFormat("alertcap: '{0}', ", _navigatorOptions.AlertCaption);
-
-			if (_navigatorOptions.AlertText != JqGridNavigatorDefaults.AlertText)
-				javaScriptBuilder.AppendFormat("alerttext: '{0}', ", _navigatorOptions.AlertText);
-
-			if (_navigatorOptions.CloneToTop)
-				javaScriptBuilder.Append("cloneToTop: true, ");
-
-			if (!_navigatorOptions.CloseOnEscape)
-				javaScriptBuilder.Append("closeOnEscape: false, ");
-
-			if (!_navigatorOptions.Delete)
-				javaScriptBuilder.Append("del: false, ");
-
-			if (_navigatorOptions.DeleteIcon != JqGridNavigatorDefaults.DeleteIcon)
-				javaScriptBuilder.AppendFormat("delicon: '{0}', ", _navigatorOptions.DeleteIcon);
-
-			if (!string.IsNullOrEmpty(_navigatorOptions.DeleteText))
-				javaScriptBuilder.AppendFormat("deltext: '{0}', ", _navigatorOptions.DeleteText);
-
-			if (_navigatorOptions.DeleteToolTip != JqGridNavigatorDefaults.DeleteToolTip)
-				javaScriptBuilder.AppendFormat("deltitle: '{0}', ", _navigatorOptions.DeleteToolTip);
-
-			if (!_navigatorOptions.Refresh)
-				javaScriptBuilder.Append("refresh: false, ");
-
-			if (_navigatorOptions.RefreshIcon != JqGridNavigatorDefaults.RefreshIcon)
-				javaScriptBuilder.AppendFormat("refreshicon: '{0}', ", _navigatorOptions.RefreshIcon);
-
-			if (!string.IsNullOrEmpty(_navigatorOptions.RefreshText))
-				javaScriptBuilder.AppendFormat("refreshtext: '{0}', ", _navigatorOptions.RefreshText);
-
-			if (_navigatorOptions.RefreshToolTip != JqGridNavigatorDefaults.RefreshToolTip)
-				javaScriptBuilder.AppendFormat("refreshtitle: '{0}', ", _navigatorOptions.RefreshToolTip);
-
-			if (_navigatorOptions.RefreshMode != JqGridRefreshModes.FirstPage)
-				javaScriptBuilder.Append("refreshstate: 'current', ");
-
-			if (!string.IsNullOrWhiteSpace(_navigatorOptions.AfterRefresh))
-				javaScriptBuilder.AppendFormat("afterRefresh: {0}, ", _navigatorOptions.AfterRefresh);
-
-			if (!string.IsNullOrWhiteSpace(_navigatorOptions.BeforeRefresh))
-				javaScriptBuilder.AppendFormat("beforeRefresh: {0}, ", _navigatorOptions.BeforeRefresh);
-
-			if (!_navigatorOptions.Search)
-				javaScriptBuilder.Append("search: false, ");
-
-			if (_navigatorOptions.SearchIcon != JqGridNavigatorDefaults.SearchIcon)
-				javaScriptBuilder.AppendFormat("searchicon: '{0}', ", _navigatorOptions.SearchIcon);
-
-			if (!string.IsNullOrEmpty(_navigatorOptions.SearchText))
-				javaScriptBuilder.AppendFormat("searchtext: '{0}', ", _navigatorOptions.SearchText);
-
-			if (_navigatorOptions.SearchToolTip != JqGridNavigatorDefaults.SearchToolTip)
-				javaScriptBuilder.AppendFormat("searchtitle: '{0}', ", _navigatorOptions.SearchToolTip);
-
-			if (_navigatorOptions.View)
-				javaScriptBuilder.Append("view: true, ");
-
-			if (_navigatorOptions.ViewIcon != JqGridNavigatorDefaults.ViewIcon)
-				javaScriptBuilder.AppendFormat("viewicon: '{0}', ", _navigatorOptions.ViewIcon);
-
-			if (!string.IsNullOrEmpty(_navigatorOptions.ViewText))
-				javaScriptBuilder.AppendFormat("viewtext: '{0}', ", _navigatorOptions.ViewText);
-
-			if (_navigatorOptions.ViewToolTip != JqGridNavigatorDefaults.ViewToolTip)
-				javaScriptBuilder.AppendFormat("viewtitle: '{0}', ", _navigatorOptions.ViewToolTip);
-
-			if (!string.IsNullOrWhiteSpace(_navigatorOptions.AddFunction))
-				javaScriptBuilder.AppendFormat("addfunc: {0}, ", _navigatorOptions.AddFunction);
-
-			if (!string.IsNullOrWhiteSpace(_navigatorOptions.EditFunction))
-				javaScriptBuilder.AppendFormat("editfunc: {0}, ", _navigatorOptions.EditFunction);
-
-			if (!string.IsNullOrWhiteSpace(_navigatorOptions.DeleteFunction))
-				javaScriptBuilder.AppendFormat("delfunc: {0}, ", _navigatorOptions.DeleteFunction);
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" }");
-			}
-			else
-				javaScriptBuilder.Append("}");
-		}
-
-		private static void AppendNavigatorActionOptions(string optionsName, JqGridNavigatorActionOptions actionOptions, StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.AppendFormat("{0}{{ ", optionsName);
-
-			if (actionOptions != null)
-			{
-				if (actionOptions.Left != 0)
-					javaScriptBuilder.AppendFormat("left: {0}, ", actionOptions.Left);
-
-				if (actionOptions.Top != 0)
-					javaScriptBuilder.AppendFormat("top: {0}, ", actionOptions.Top);
-
-				if (actionOptions.DataWidth.HasValue)
-					javaScriptBuilder.AppendFormat("datawidth: {0}, ", actionOptions.DataWidth.Value);
-
-				if (actionOptions.Height.HasValue)
-					javaScriptBuilder.AppendFormat("height: {0}, ", actionOptions.Height.Value);
-
-				if (actionOptions.DataHeight.HasValue)
-					javaScriptBuilder.AppendFormat("dataheight: {0}, ", actionOptions.DataHeight.Value);
-
-				if (actionOptions.Modal)
-					javaScriptBuilder.Append("modal: true, ");
-
-				if (!actionOptions.Dragable)
-					javaScriptBuilder.Append("drag: false, ");
-
-				if (!actionOptions.Resizable)
-					javaScriptBuilder.Append("resize: false, ");
-
-				if (!actionOptions.UseJqModal)
-					javaScriptBuilder.Append("jqModal: false, ");
-
-				if (actionOptions.CloseOnEscape)
-					javaScriptBuilder.Append("closeOnEscape: true, ");
-
-				if (actionOptions.Overlay != 30)
-					javaScriptBuilder.AppendFormat("overlay: {0}, ", actionOptions.Overlay);
-
-				if (!string.IsNullOrWhiteSpace(actionOptions.OnClose))
-					javaScriptBuilder.AppendFormat("onClose: {0}, ", actionOptions.OnClose);
-
-				JqGridNavigatorFormActionOptions formActionOptions = actionOptions as JqGridNavigatorFormActionOptions;
-				if (formActionOptions != null)
-				{
-					AppendNavigatorFormActionOptions(formActionOptions, javaScriptBuilder);
-
-					IJqGridNavigatorPageableFormActionOptions pageableFormActionOptions = formActionOptions as IJqGridNavigatorPageableFormActionOptions;
-					if (pageableFormActionOptions != null)
-						AppendNavigatorPageableFormActionOptions(pageableFormActionOptions, javaScriptBuilder);
-
-					JqGridNavigatorModifyActionOptions modifyActionOptions = formActionOptions as JqGridNavigatorModifyActionOptions;
-					if (modifyActionOptions != null)
-					{
-						AppendNavigatorModifyActionOptions(modifyActionOptions, javaScriptBuilder);
-						JqGridNavigatorEditActionOptions editActionOptions = modifyActionOptions as JqGridNavigatorEditActionOptions;
-						if (editActionOptions != null)
-							AppendNavigatorEditActionOptions(editActionOptions, javaScriptBuilder);
-						else
-							AppendNavigatorDeleteActionOptions(modifyActionOptions as JqGridNavigatorDeleteActionOptions, javaScriptBuilder);
-					}
-					else
-						AppendNavigatorViewActionOptions(formActionOptions as JqGridNavigatorViewActionOptions, javaScriptBuilder);
-				}
-				else
-					AppendNavigatorSearchActionOptions(actionOptions as JqGridNavigatorSearchActionOptions, javaScriptBuilder);
-
-			}
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				if (!string.IsNullOrEmpty(optionsName))
-					javaScriptBuilder.Append(" }, ");
-				else
-					javaScriptBuilder.Append(" }");
-			}
-			else if (!string.IsNullOrEmpty(optionsName))
-			{
-				int optionsNameLength = optionsName.Length + 2;
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - optionsNameLength, optionsNameLength);
-			}
-			else
-				javaScriptBuilder.Append("}");
-		}
-
-		private static void AppendNavigatorFormActionOptions(JqGridNavigatorFormActionOptions formActionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (!string.IsNullOrWhiteSpace(formActionOptions.BeforeInitData))
-				javaScriptBuilder.AppendFormat("beforeInitData: {0}, ", formActionOptions.BeforeInitData);
-
-			if (!string.IsNullOrWhiteSpace(formActionOptions.BeforeShowForm))
-				javaScriptBuilder.AppendFormat("beforeShowForm: {0}, ", formActionOptions.BeforeShowForm);
-		}
-
-		private static void AppendNavigatorPageableFormActionOptions(IJqGridNavigatorPageableFormActionOptions pageableFormActionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (!pageableFormActionOptions.NavigationKeys.IsDefault())
-				javaScriptBuilder.AppendFormat("navkeys: [{0}, {1}, {2}], ", pageableFormActionOptions.NavigationKeys.Enabled.ToString().ToLower(), (int)pageableFormActionOptions.NavigationKeys.RecordUp, (int)pageableFormActionOptions.NavigationKeys.RecordDown);
-
-			if (!pageableFormActionOptions.ViewPagerButtons)
-				javaScriptBuilder.Append("viewPagerButtons: false, ");
-
-			if (pageableFormActionOptions.RecreateForm)
-				javaScriptBuilder.Append("recreateForm: true, ");
-		}
-
-		private static void AppendNavigatorModifyActionOptions(JqGridNavigatorModifyActionOptions modifyActionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (!string.IsNullOrWhiteSpace(modifyActionOptions.Url))
-				javaScriptBuilder.AppendFormat("url: '{0}', ", modifyActionOptions.Url);
-
-			if (modifyActionOptions.MethodType != JqGridMethodTypes.Post)
-				javaScriptBuilder.Append("mtype: 'GET', ");
-
-			if (!modifyActionOptions.ReloadAfterSubmit)
-				javaScriptBuilder.Append("reloadAfterSubmit: false, ");
-
-			if (!string.IsNullOrWhiteSpace(modifyActionOptions.AfterShowForm))
-				javaScriptBuilder.AppendFormat("afterShowForm: {0}, ", modifyActionOptions.AfterShowForm);
-
-			if (!string.IsNullOrWhiteSpace(modifyActionOptions.AfterSubmit))
-				javaScriptBuilder.AppendFormat("afterSubmit: {0}, ", modifyActionOptions.AfterSubmit);
-
-			if (!string.IsNullOrWhiteSpace(modifyActionOptions.BeforeSubmit))
-				javaScriptBuilder.AppendFormat("beforeSubmit: {0}, ", modifyActionOptions.BeforeSubmit);
-
-			if (!string.IsNullOrWhiteSpace(modifyActionOptions.OnClickSubmit))
-				javaScriptBuilder.AppendFormat("onclickSubmit: {0}, ", modifyActionOptions.OnClickSubmit);
-
-			if (!string.IsNullOrWhiteSpace(modifyActionOptions.ErrorTextFormat))
-				javaScriptBuilder.AppendFormat("errorTextFormat: {0}, ", modifyActionOptions.ErrorTextFormat);
-		}
-
-		private static void AppendNavigatorEditActionOptions(JqGridNavigatorEditActionOptions editActionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (editActionOptions.Width != 300)
-				javaScriptBuilder.AppendFormat("width: {0}, ", editActionOptions.Width);
-
-			JavaScriptSerializer serializer = new JavaScriptSerializer();
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.ExtraDataScript))
-				javaScriptBuilder.AppendFormat("editData: {0},", editActionOptions.ExtraDataScript).AppendLine();
-			else if (editActionOptions.ExtraData != null)
-				javaScriptBuilder.AppendFormat("editData: {0}, ", serializer.Serialize(editActionOptions.ExtraData));
-
-			if (editActionOptions.AjaxOptions != null)
-				javaScriptBuilder.AppendFormat("ajaxEditOptions: {0}, ", serializer.Serialize(editActionOptions.AjaxOptions));
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.SerializeData))
-				javaScriptBuilder.AppendFormat("serializeEditData: {0}, ", editActionOptions.SerializeData);
-
-			if (editActionOptions.AddedRowPosition != JqGridNewRowPositions.First)
-				javaScriptBuilder.Append("addedrow: 'last', ");
-
-			if (!editActionOptions.ClearAfterAdd)
-				javaScriptBuilder.Append("clearAfterAdd: false, ");
-
-			if (editActionOptions.CloseAfterAdd)
-				javaScriptBuilder.Append("closeAfterAdd: true, ");
-
-			if (editActionOptions.CloseAfterEdit)
-				javaScriptBuilder.Append("closeAfterEdit: true, ");
-
-			if (editActionOptions.CheckOnSubmit)
-				javaScriptBuilder.Append("checkOnSubmit: true, ");
-
-			if (editActionOptions.CheckOnUpdate)
-				javaScriptBuilder.Append("checkOnUpdate: true, ");
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.TopInfo))
-				javaScriptBuilder.AppendFormat("topinfo: '{0}', ", editActionOptions.TopInfo);
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.BottomInfo))
-				javaScriptBuilder.AppendFormat("bottominfo: '{0}', ", editActionOptions.BottomInfo);
-
-			if (editActionOptions.SaveKeyEnabled || (editActionOptions.SaveKey != (char)13))
-				javaScriptBuilder.AppendFormat("savekey: [{0}, {1}], ", editActionOptions.SaveKeyEnabled.ToString().ToLower(), (int)editActionOptions.SaveKey);
-
-			if (!editActionOptions.SaveButtonIcon.Equals(JqGridFormButtonIcon.SaveIcon))
-				javaScriptBuilder.AppendFormat("saveicon: [{0}, '{1}', '{2}'], ", editActionOptions.SaveButtonIcon.Enabled.ToString().ToLower(), editActionOptions.SaveButtonIcon.Position.ToString().ToLower(), editActionOptions.SaveButtonIcon.Class);
-
-			if (!editActionOptions.CloseButtonIcon.Equals(JqGridFormButtonIcon.CloseIcon))
-				javaScriptBuilder.AppendFormat("closeicon: [{0}, '{1}', '{2}'], ", editActionOptions.CloseButtonIcon.Enabled.ToString().ToLower(), editActionOptions.CloseButtonIcon.Position.ToString().ToLower(), editActionOptions.CloseButtonIcon.Class);
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.AfterClickPgButtons))
-				javaScriptBuilder.AppendFormat("afterclickPgButtons: {0}, ", editActionOptions.AfterClickPgButtons);
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.AfterComplete))
-				javaScriptBuilder.AppendFormat("afterComplete: {0}, ", editActionOptions.AfterComplete);
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.BeforeCheckValues))
-				javaScriptBuilder.AppendFormat("beforeCheckValues: {0}, ", editActionOptions.BeforeCheckValues);
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.OnClickPgButtons))
-				javaScriptBuilder.AppendFormat("onclickPgButtons: {0}, ", editActionOptions.OnClickPgButtons);
-
-			if (!string.IsNullOrWhiteSpace(editActionOptions.OnInitializeForm))
-				javaScriptBuilder.AppendFormat("onInitializeForm: {0}, ", editActionOptions.OnInitializeForm);
-		}
-
-		private static void AppendNavigatorDeleteActionOptions(JqGridNavigatorDeleteActionOptions deleteActionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (deleteActionOptions.Width != 240)
-				javaScriptBuilder.AppendFormat("width: {0}, ", deleteActionOptions.Width);
-
-			JavaScriptSerializer serializer = new JavaScriptSerializer();
-
-			if (!string.IsNullOrWhiteSpace(deleteActionOptions.ExtraDataScript))
-				javaScriptBuilder.AppendFormat("delData: {0},", deleteActionOptions.ExtraDataScript).AppendLine();
-			else if (deleteActionOptions.ExtraData != null)
-				javaScriptBuilder.AppendFormat("delData: {0}, ", serializer.Serialize(deleteActionOptions.ExtraData));
-
-			if (deleteActionOptions.AjaxOptions != null)
-				javaScriptBuilder.AppendFormat("ajaxDelOptions: {0}, ", serializer.Serialize(deleteActionOptions.AjaxOptions));
-
-			if (!string.IsNullOrWhiteSpace(deleteActionOptions.SerializeData))
-				javaScriptBuilder.AppendFormat("serializeDelData: {0}, ", deleteActionOptions.SerializeData);
-
-			if (!deleteActionOptions.DeleteButtonIcon.Equals(JqGridFormButtonIcon.DeleteIcon))
-				javaScriptBuilder.AppendFormat("delicon: [{0}, '{1}', '{2}'], ", deleteActionOptions.DeleteButtonIcon.Enabled.ToString().ToLower(), deleteActionOptions.DeleteButtonIcon.Position.ToString().ToLower(), deleteActionOptions.DeleteButtonIcon.Class);
-
-			if (!deleteActionOptions.CancelButtonIcon.Equals(JqGridFormButtonIcon.CancelIcon))
-				javaScriptBuilder.AppendFormat("cancelicon: [{0}, '{1}', '{2}'], ", deleteActionOptions.CancelButtonIcon.Enabled.ToString().ToLower(), deleteActionOptions.CancelButtonIcon.Position.ToString().ToLower(), deleteActionOptions.CancelButtonIcon.Class);
-		}
-
-		private static void AppendNavigatorViewActionOptions(JqGridNavigatorViewActionOptions viewActionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (viewActionOptions.Width != 0)
-				javaScriptBuilder.AppendFormat("width: {0}, ", viewActionOptions.Width);
-
-			if (viewActionOptions.LabelsWidth != "30%")
-				javaScriptBuilder.AppendFormat("labelswidth: '{0}', ", viewActionOptions.LabelsWidth);
-
-			if (!viewActionOptions.CloseButtonIcon.Equals(JqGridFormButtonIcon.CloseIcon))
-				javaScriptBuilder.AppendFormat("closeicon: [{0}, '{1}', '{2}'], ", viewActionOptions.CloseButtonIcon.Enabled.ToString().ToLower(), viewActionOptions.CloseButtonIcon.Position.ToString().ToLower(), viewActionOptions.CloseButtonIcon.Class);
-		}
-
-		private static void AppendNavigatorSearchActionOptions(JqGridNavigatorSearchActionOptions searchActionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (searchActionOptions.Width != 450)
-				javaScriptBuilder.AppendFormat("width: {0}, ", searchActionOptions.Width);
-
-			if (!string.IsNullOrWhiteSpace(searchActionOptions.AfterRedraw))
-				javaScriptBuilder.AppendFormat("afterRedraw: {0}, ", searchActionOptions.AfterRedraw);
-
-			if (!string.IsNullOrWhiteSpace(searchActionOptions.AfterShowSearch))
-				javaScriptBuilder.AppendFormat("afterShowSearch: {0}, ", searchActionOptions.AfterShowSearch);
-
-			if (!string.IsNullOrWhiteSpace(searchActionOptions.BeforeShowSearch))
-				javaScriptBuilder.AppendFormat("beforeShowSearch: {0}, ", searchActionOptions.BeforeShowSearch);
-
-			if (!string.IsNullOrEmpty(searchActionOptions.Caption))
-				javaScriptBuilder.AppendFormat("caption: '{0}', ", searchActionOptions.Caption);
-
-			if (searchActionOptions.CloseAfterSearch)
-				javaScriptBuilder.Append("closeAfterSearch: true, ");
-
-			if (searchActionOptions.CloseAfterReset)
-				javaScriptBuilder.Append("closeAfterReset: true, ");
-
-			if (!searchActionOptions.ErrorCheck)
-				javaScriptBuilder.Append("errorcheck: false, ");
-
-			if (!string.IsNullOrEmpty(searchActionOptions.SearchText))
-				javaScriptBuilder.AppendFormat("Find: '{0}', ", searchActionOptions.SearchText);
-
-			if (searchActionOptions.AdvancedSearching)
-				javaScriptBuilder.Append("multipleSearch: true, ");
-
-			if (searchActionOptions.AdvancedSearchingWithGroups)
-				javaScriptBuilder.Append("multipleGroup: true, ");
-
-			if (!searchActionOptions.CloneSearchRowOnAdd)
-				javaScriptBuilder.Append("cloneSearchRowOnAdd: false, ");
-
-			if (!string.IsNullOrWhiteSpace(searchActionOptions.OnInitializeSearch))
-				javaScriptBuilder.AppendFormat("onInitializeSearch: {0}, ", searchActionOptions.OnInitializeSearch);
-
-			if (!string.IsNullOrWhiteSpace(searchActionOptions.OnReset))
-				javaScriptBuilder.AppendFormat("onReset: {0}, ", searchActionOptions.OnReset);
-
-			if (!string.IsNullOrWhiteSpace(searchActionOptions.OnSearch))
-				javaScriptBuilder.AppendFormat("onSearch: {0}, ", searchActionOptions.OnSearch);
-
-			if (searchActionOptions.RecreateFilter)
-				javaScriptBuilder.Append("recreateFilter: true, ");
-
-			if (!string.IsNullOrEmpty(searchActionOptions.ResetText))
-				javaScriptBuilder.AppendFormat("Reset: '{0}', ", searchActionOptions.ResetText);
-
-			AppendSearchOperators(searchActionOptions.SearchOperators, javaScriptBuilder);
-
-			if (searchActionOptions.ShowOnLoad)
-				javaScriptBuilder.Append("showOnLoad: true, ");
-
-			if (searchActionOptions.ShowQuery)
-				javaScriptBuilder.Append("showQuery: true, ");
-
-			if (!string.IsNullOrEmpty(searchActionOptions.Layer))
-				javaScriptBuilder.AppendFormat("layer: '{0}', ", searchActionOptions.Layer);
-
-			if (searchActionOptions.Templates != null && searchActionOptions.Templates.Count > 0)
-			{
-				JavaScriptSerializer serializer = new JavaScriptSerializer();
-				serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
-
-				javaScriptBuilder.Append("tmplNames: [],");
-				int templateNameIndex = javaScriptBuilder.Length - 2;
-				javaScriptBuilder.Append("tmplFilters: [");
-				foreach (KeyValuePair<string, JqGridRequestSearchingFilters> template in searchActionOptions.Templates)
-				{
-					javaScriptBuilder.Insert(templateNameIndex, "'" + template.Key + "', ");
-					templateNameIndex += template.Key.Length + 4;
-					javaScriptBuilder.Append(serializer.Serialize(template.Value) + ", ");
-				}
-				javaScriptBuilder.Remove(templateNameIndex - 2, 2);
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append("],");
-			}
-		}
-
-		private void AppendNavigatorButton(string navigatorPagerSelector, JqGridNavigatorButtonOptions buttonOptions, StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.AppendFormat(".jqGrid('navButtonAdd', {0}, {{ ", navigatorPagerSelector);
-			if (buttonOptions.Caption != JqGridNavigatorDefaults.ButtonCaption)
-				javaScriptBuilder.AppendFormat("caption: '{0}', ", buttonOptions.Caption);
-
-			if (buttonOptions.Icon != JqGridNavigatorDefaults.ButtonIcon)
-				javaScriptBuilder.AppendFormat("buttonicon: '{0}', ", buttonOptions.Icon);
-
-			if (!string.IsNullOrWhiteSpace(buttonOptions.OnClick))
-				javaScriptBuilder.AppendFormat("onClickButton: {0}, ", buttonOptions.OnClick);
-
-			if (buttonOptions.Position != JqGridNavigatorButtonPositions.Last)
-				javaScriptBuilder.Append("position: 'first', ");
-
-			if (!string.IsNullOrEmpty(buttonOptions.ToolTip))
-				javaScriptBuilder.AppendFormat("title: '{0}', ", buttonOptions.ToolTip);
-
-			if (buttonOptions.Cursor != JqGridNavigatorDefaults.ButtonCursor)
-				javaScriptBuilder.AppendFormat("cursor: '{0}', ", buttonOptions.Cursor);
-
-			if (!string.IsNullOrWhiteSpace(buttonOptions.Id))
-				javaScriptBuilder.AppendFormat("id: '{0}', ", buttonOptions.Id);
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" })");
-			}
-			else
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 4, 4);
-				javaScriptBuilder.Append(")");
-			}
-		}
-
-		private void AppendNavigatorSeparator(string navigatorPagerSelector, JqGridNavigatorSeparatorOptions separatorOptions, StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.AppendFormat(".jqGrid('navSeparatorAdd', {0}, {{ ", navigatorPagerSelector);
-
-			if (separatorOptions.Class != JqGridNavigatorDefaults.SeparatorClass)
-				javaScriptBuilder.AppendFormat("sepclass: '{0}', ", separatorOptions.Class);
-
-			if (!string.IsNullOrEmpty(separatorOptions.Content))
-				javaScriptBuilder.AppendFormat("sepcontent: '{0}', ", separatorOptions.Content);
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" })");
-			}
-			else
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 4, 4);
-				javaScriptBuilder.Append(")");
-			}
-		}
-
-		private void AppendInlineNavigator(StringBuilder javaScriptBuilder)
-		{
-			string navigatorPagerSelector = _navigatorOptions.Pager == JqGridNavigatorPagers.Top ? TopPagerSelector : PagerSelector;
-
-			javaScriptBuilder.AppendFormat(".jqGrid('inlineNav', {0}, ", navigatorPagerSelector).AppendLine();
-
-			AppendInlineNavigatorOptions(javaScriptBuilder);
-
-			javaScriptBuilder.Append(")");
-		}
-
-		private void AppendInlineNavigatorOptions(StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.Append("{ ");
-
-			AppendBaseNavigatorOptions(_inlineNavigatorOptions, javaScriptBuilder);
-
-			if (!_inlineNavigatorOptions.Save)
-				javaScriptBuilder.Append("save: false, ");
-
-			if (_inlineNavigatorOptions.SaveIcon != JqGridNavigatorDefaults.SaveIcon)
-				javaScriptBuilder.AppendFormat("saveicon: '{0}', ", _inlineNavigatorOptions.SaveIcon);
-
-			if (!string.IsNullOrEmpty(_inlineNavigatorOptions.SaveText))
-				javaScriptBuilder.AppendFormat("savetext: '{0}', ", _inlineNavigatorOptions.SaveText);
-
-			if (_inlineNavigatorOptions.SaveToolTip != JqGridNavigatorDefaults.SaveToolTip)
-				javaScriptBuilder.AppendFormat("savetitle: '{0}', ", _inlineNavigatorOptions.SaveToolTip);
-
-			if (!_inlineNavigatorOptions.Cancel)
-				javaScriptBuilder.Append("cancel: false, ");
-
-			if (_inlineNavigatorOptions.CancelIcon != JqGridNavigatorDefaults.CancelIcon)
-				javaScriptBuilder.AppendFormat("cancelicon: '{0}', ", _inlineNavigatorOptions.CancelIcon);
-
-			if (!string.IsNullOrEmpty(_inlineNavigatorOptions.CancelText))
-				javaScriptBuilder.AppendFormat("canceltext: '{0}', ", _inlineNavigatorOptions.CancelText);
-
-			if (_inlineNavigatorOptions.CancelToolTip != JqGridNavigatorDefaults.CancelToolTip)
-				javaScriptBuilder.AppendFormat("canceltitle: '{0}', ", _inlineNavigatorOptions.CancelToolTip);
-
-			AppendInlineNavigatorAddActionOptions(_inlineNavigatorOptions.AddActionOptions, javaScriptBuilder);
-			AppendInlineNavigatorActionOptions("editParams", _inlineNavigatorOptions.ActionOptions, javaScriptBuilder);
-
-			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-			{
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-				javaScriptBuilder.Append(" }");
-			}
-			else
-				javaScriptBuilder.Append("}");
-		}
-
-		private static void AppendInlineNavigatorActionOptions(string actionName, JqGridInlineNavigatorActionOptions actionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (actionOptions != null)
-			{
-				javaScriptBuilder.AppendFormat("{0}: {{ ", actionName);
-
-				if (actionOptions.Keys)
-					javaScriptBuilder.Append("keys: true, ");
-
-				if (!string.IsNullOrWhiteSpace(actionOptions.OnEditFunction))
-					javaScriptBuilder.AppendFormat("oneditfunc: {0}, ", actionOptions.OnEditFunction);
-
-				if (!string.IsNullOrWhiteSpace(actionOptions.SuccessFunction))
-					javaScriptBuilder.AppendFormat("successfunc: {0}, ", actionOptions.SuccessFunction);
-
-				if (!string.IsNullOrWhiteSpace(actionOptions.Url))
-					javaScriptBuilder.AppendFormat("url: '{0}', ", actionOptions.Url);
-
-				if (!string.IsNullOrWhiteSpace(actionOptions.ExtraParamScript))
-					javaScriptBuilder.AppendFormat("extraparam: {0}, ", actionOptions.ExtraParamScript);
-				else if (actionOptions.ExtraParam != null)
-				{
-					JavaScriptSerializer serializer = new JavaScriptSerializer();
-					javaScriptBuilder.AppendFormat("extraparam: {0}, ", serializer.Serialize(actionOptions.ExtraParam));
-				}
-
-				if (!string.IsNullOrWhiteSpace(actionOptions.AfterSaveFunction))
-					javaScriptBuilder.AppendFormat("aftersavefunc: {0}, ", actionOptions.AfterSaveFunction);
-
-				if (!string.IsNullOrWhiteSpace(actionOptions.ErrorFunction))
-					javaScriptBuilder.AppendFormat("errorfunc: {0}, ", actionOptions.ErrorFunction);
-
-				if (!string.IsNullOrWhiteSpace(actionOptions.AfterRestoreFunction))
-					javaScriptBuilder.AppendFormat("afterrestorefunc: {0}, ", actionOptions.AfterRestoreFunction);
-
-				if (!actionOptions.RestoreAfterError)
-					javaScriptBuilder.Append("restoreAfterError: false, ");
-
-				if (actionOptions.MethodType != JqGridMethodTypes.Post)
-					javaScriptBuilder.Append("mtype: 'GET', ");
-
-				if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-				{
-					javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-					javaScriptBuilder.Append(" }, ");
-				}
-				else
-				{
-					int actionNameLength = actionName.Length + 4;
-					javaScriptBuilder.Remove(javaScriptBuilder.Length - actionNameLength, actionNameLength);
-				}
-			}
-		}
-
-		private static void AppendInlineNavigatorAddActionOptions(JqGridInlineNavigatorAddActionOptions actionOptions, StringBuilder javaScriptBuilder)
-		{
-			if (actionOptions != null)
-			{
-				javaScriptBuilder.Append("addParams: { ");
-
-				if (actionOptions.RowId != JqGridNavigatorDefaults.NewRowId)
-					javaScriptBuilder.AppendFormat("rowID: '{0}', ", actionOptions.RowId);
-
-				if (actionOptions.InitData != null)
-				{
-					JavaScriptSerializer serializer = new JavaScriptSerializer();
-					javaScriptBuilder.AppendFormat("initdata: {0}, ", serializer.Serialize(actionOptions.InitData));
-				}
-
-				if (actionOptions.Position != JqGridNewRowPositions.First)
-					javaScriptBuilder.AppendFormat("position: 'last', ");
-
-				if (actionOptions.UseDefaultValues)
-					javaScriptBuilder.Append("useDefValues: true, ");
-
-				if (actionOptions.UseFormatter)
-					javaScriptBuilder.Append("useFormatter: true, ");
-
-				AppendInlineNavigatorActionOptions("addRowParams", actionOptions.Options, javaScriptBuilder);
-
-				if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-				{
-					javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-					javaScriptBuilder.Append(" }, ");
-				}
-				else
-				{
-					javaScriptBuilder.Remove(javaScriptBuilder.Length - 13, 13);
-				}
-			}
-		}
-
-		private void AppendFilterToolbar(StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.Append(".jqGrid('filterToolbar'");
-
-			if (_filterToolbarOptions != null)
-			{
-				javaScriptBuilder.Append(", { ");
-
-				AppendFilterOptions(_filterToolbarOptions, javaScriptBuilder);
-
-				if (_filterToolbarOptions.DefaultSearchOperator != JqGridSearchOperators.Bw)
-					javaScriptBuilder.AppendFormat("defaultSearch: '{0}',", _filterToolbarOptions.DefaultSearchOperator.ToString().ToLower());
-
-				if (_filterToolbarOptions.GroupingOperator != JqGridSearchGroupingOperators.And)
-					javaScriptBuilder.Append("groupOp: 'OR',");
-
-				if (!_filterToolbarOptions.SearchOnEnter)
-					javaScriptBuilder.Append("searchOnEnter: false,");
-
-				if (_filterToolbarOptions.SearchOperators)
-					javaScriptBuilder.Append("searchOperators: true,");
-
-				if (_filterToolbarOptions.OperandToolTip != JqGridFilterToolbarDefaults.OperandToolTip)
-					javaScriptBuilder.AppendFormat("operandTitle: '{0}',", _filterToolbarOptions.OperandToolTip);
-
-				if (_filterToolbarOptions.Operands != null && _filterToolbarOptions.Operands.Count > 0 && _filterToolbarOptions.Operands != JqGridFilterToolbarDefaults.Operands)
-				{
-					int javaScriptBuilderPosition = javaScriptBuilder.Length;
-
-					foreach (KeyValuePair<JqGridSearchOperators, string> operand in _filterToolbarOptions.Operands)
-					{
-						string defaultShortText;
-						if (JqGridFilterToolbarDefaults.Operands.TryGetValue(operand.Key, out defaultShortText) && operand.Value != defaultShortText)
-							javaScriptBuilder.AppendFormat("'{0}':'{1}',", operand.Key.ToString().ToLower(), operand.Value);
-					}
-
-					if (javaScriptBuilderPosition != javaScriptBuilder.Length)
-					{
-						javaScriptBuilder.Insert(javaScriptBuilderPosition, "operands: {");
-						javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-						javaScriptBuilder.Append("},");
-					}
-				}
-
-				if (_filterToolbarOptions.StringResult)
-					javaScriptBuilder.Append("stringResult: true,");
-
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-				javaScriptBuilder.Append(" }");
-			}
-
-			javaScriptBuilder.Append(")");
-		}
-
-		private void AppendFilterGrid(StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.AppendFormat("$({0}).jqGrid('filterGrid', {1}, {{", FilterGridSelector, GridSelector).AppendLine();
-			javaScriptBuilder.AppendLine("gridModel: false, gridNames: false,");
-
-			javaScriptBuilder.AppendLine("filterModel: [");
-
-			int lastGridModelIndex = _filterGridModel.Count - 1;
-			for (int gridModelIndex = 0; gridModelIndex < _filterGridModel.Count; gridModelIndex++)
-			{
-				JqGridFilterGridRowModel gridRowModel = _filterGridModel[gridModelIndex];
-				javaScriptBuilder.AppendFormat("{{ label: '{0}', name: '{1}', ", gridRowModel.Label, gridRowModel.ColumnName);
-
-				if (!string.IsNullOrWhiteSpace(gridRowModel.DefaultValue))
-					javaScriptBuilder.AppendFormat("defval: '{0}', ", gridRowModel.DefaultValue);
-
-				if (!string.IsNullOrWhiteSpace(gridRowModel.SelectUrl))
-					javaScriptBuilder.AppendFormat("surl: '{0}', ", gridRowModel.SelectUrl);
-
-				javaScriptBuilder.AppendFormat("stype: '{0}' }}", gridRowModel.SearchType.ToString().ToLower());
-
-				if (lastGridModelIndex == gridModelIndex)
-					javaScriptBuilder.AppendLine();
-				else
-					javaScriptBuilder.AppendLine(",");
-			}
-
-			javaScriptBuilder.Append("]");
-
-			if (_filterGridOptions != null)
-			{
-				javaScriptBuilder.AppendLine(",");
-				AppendFilterOptions(_filterGridOptions, javaScriptBuilder);
-
-				if (!string.IsNullOrWhiteSpace(_filterGridOptions.ButtonsClass))
-					javaScriptBuilder.AppendFormat("buttonclass: '{0}',", _filterGridOptions.ButtonsClass);
-
-				if (_filterGridOptions.ClearEnabled.HasValue)
-					javaScriptBuilder.AppendFormat("enableClear: {0},", _filterGridOptions.ClearEnabled.Value.ToString().ToLower());
-
-				if (!string.IsNullOrWhiteSpace(_filterGridOptions.ClearText))
-					javaScriptBuilder.AppendFormat("clearButton: '{0}',", _filterGridOptions.ClearText);
-
-				if (!string.IsNullOrWhiteSpace(_filterGridOptions.FormClass))
-					javaScriptBuilder.AppendFormat("formclass: '{0}',", _filterGridOptions.FormClass);
-
-				if (_filterGridOptions.MarkSearched.HasValue)
-					javaScriptBuilder.AppendFormat("marksearched: {0},", _filterGridOptions.MarkSearched.Value.ToString().ToLower());
-
-				if (_filterGridOptions.SearchEnabled.HasValue)
-					javaScriptBuilder.AppendFormat("enableSearch: {0},", _filterGridOptions.SearchEnabled.Value.ToString().ToLower());
-
-				if (!string.IsNullOrWhiteSpace(_filterGridOptions.SearchText))
-					javaScriptBuilder.AppendFormat("searchButton: '{0}',", _filterGridOptions.SearchText);
-
-				if (!string.IsNullOrWhiteSpace(_filterGridOptions.TableClass))
-					javaScriptBuilder.AppendFormat("tableclass: '{0}',", _filterGridOptions.TableClass);
-
-				if (_filterGridOptions.Type.HasValue)
-					javaScriptBuilder.AppendFormat("formtype: '{0}',", _filterGridOptions.Type.Value.ToString().ToLower());
-
-				if (!string.IsNullOrWhiteSpace(_filterGridOptions.Url))
-					javaScriptBuilder.AppendFormat("url: '{0}',", _filterGridOptions.Url);
-
-				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-			}
-
-			javaScriptBuilder.AppendLine("});");
-		}
-
-		private static void AppendFilterOptions(JqGridFilterOptions options, StringBuilder javaScriptBuilder)
-		{
-			if (options != null)
-			{
-				if (!string.IsNullOrWhiteSpace(options.AfterClear))
-					javaScriptBuilder.AppendFormat("afterClear: {0},", options.AfterClear);
-
-				if (!string.IsNullOrWhiteSpace(options.AfterSearch))
-					javaScriptBuilder.AppendFormat("afterSearch: {0},", options.AfterSearch);
-
-				if (options.AutoSearch.HasValue)
-					javaScriptBuilder.AppendFormat("autosearch: {0},", options.AutoSearch.Value.ToString().ToLower());
-
-				if (!string.IsNullOrWhiteSpace(options.BeforeClear))
-					javaScriptBuilder.AppendFormat("beforeClear: {0},", options.BeforeClear);
-
-				if (!string.IsNullOrWhiteSpace(options.BeforeSearch))
-					javaScriptBuilder.AppendFormat("beforeSearch: {0},", options.BeforeSearch);
-			}
-		}
-
-		private void AppendFooterData(StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.Append(".jqGrid('footerData', 'set', { ");
-
-			foreach (var footerValue in _footerData)
-				javaScriptBuilder.AppendFormat(" {0}: '{1}', ", footerValue.Key, Convert.ToString(footerValue.Value));
-
-			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-			javaScriptBuilder.AppendFormat(" }}, {0})", _footerDataUseFormatters.ToString().ToLower());
-		}
-
-		private void AppendGroupHeaders(StringBuilder javaScriptBuilder)
-		{
-			javaScriptBuilder.Append(".jqGrid('setGroupHeaders', { ");
-
-			if (_groupHeadersUseColSpanStyle)
-				javaScriptBuilder.Append("useColSpanStyle: true, ");
-
-			javaScriptBuilder.Append("groupHeaders: [ ");
-			foreach (JqGridGroupHeader groupHeader in _groupHeaders)
-				javaScriptBuilder.AppendFormat("{{ startColumnName: '{0}', numberOfColumns: {1}, titleText: '{2}' }}, ", groupHeader.StartColumn, groupHeader.NumberOfColumns, groupHeader.Title);
-			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2).Append(" ]");
-
-			javaScriptBuilder.Append("})");
-		}
-
-		private static void AppendColumnLabelOptions(string columnName, JqGridColumnLabelOptions options, StringBuilder javaScriptBuilder)
-		{
-			if (options == null) return;
-			var serializer = new JavaScriptSerializer();
-			javaScriptBuilder.AppendFormat(".jqGrid('setLabel', '{0}', ", columnName);
-			javaScriptBuilder.AppendFormat("'{0}', ", string.IsNullOrWhiteSpace(options.Label) ? string.Empty : options.Label);
-
-			if (string.IsNullOrWhiteSpace(options.Class))
-			{
-				if (options.CssStyles != null)
-					javaScriptBuilder.AppendFormat("{0}, ", serializer.Serialize(options.CssStyles));
-				else if (options.HtmlAttributes != null)
-					javaScriptBuilder.Append("null, ");
-			}
-			else
-				javaScriptBuilder.AppendFormat("'{0}', ", options.Class);
-
-			if (options.HtmlAttributes != null)
-				javaScriptBuilder.AppendFormat("{0}, ", serializer.Serialize(options.HtmlAttributes));
-
-			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-			javaScriptBuilder.Append(" )");
-		}
-
-		private static IDictionary<string, object> AnonymousObjectToDictionary(object anonymousObject)
-		{
-			Dictionary<string, object> dictionary = new Dictionary<string, object>();
-
-			if (anonymousObject != null)
-			{
-				foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(anonymousObject))
-					dictionary.Add(property.Name, property.GetValue(anonymousObject));
-			}
-
-			return dictionary;
-		}
-		#endregion
-
-		#region Fluent API
-		/// <summary>
-		/// Adds column with actions predefined formatter.
-		/// </summary>
-		/// <param name="name">Name for the column.</param>
-		/// <param name="position">Position of the column.</param>
-		/// <param name="width">Width of the column.</param>
-		/// <param name="editButton">Value indicating if edit button is enabled.</param>
-		/// <param name="deleteButton">Value indicating if delete button is enabled.</param>
-		/// <param name="useFormEditing">Value indicating if form editing should be used instead of inline editing.</param>
-		/// <param name="inlineEditingOptions">Options for inline editing (RestoreAfterError and MethodType options are ignored in this context).</param>
-		/// <param name="formEditingOptions">Options for form editing.</param>
-		/// <param name="deleteOptions">Options for deleting.</param>
-		/// <returns>JqGridHelper instance.</returns>
-		/// <remarks>It is adviced to set JqGridResponse.JsonReader.RepeatItems to false if you want to use this method, otherwise jqGrid will not skip this column while mapping data.</remarks>
-		public JqGridHelper<TModel> AddActionsColumn(string name, int position = 0, int width = 60, bool editButton = true, bool deleteButton = true, bool useFormEditing = false, JqGridInlineNavigatorActionOptions inlineEditingOptions = null, JqGridNavigatorEditActionOptions formEditingOptions = null, JqGridNavigatorDeleteActionOptions deleteOptions = null)
-		{
-			JqGridColumnModel actionsColumnModel = new JqGridColumnModel(name);
-			actionsColumnModel.Width = width;
-			actionsColumnModel.Resizable = false;
-			actionsColumnModel.Searchable = false;
-			actionsColumnModel.Sortable = false;
-			actionsColumnModel.Viewable = false;
-			actionsColumnModel.Formatter = new SettedString(true, JqGridColumnPredefinedFormatters.Actions);
-			actionsColumnModel.FormatterOptions = new JqGridColumnFormatterOptions()
-			{
-				EditButton = editButton,
-				DeleteButton = deleteButton,
-				UseFormEditing = useFormEditing,
-				InlineEditingOptions = inlineEditingOptions,
-				FormEditingOptions = formEditingOptions,
-				DeleteOptions = deleteOptions
-			};
-
-			if (position <= 0)
-			{
-				_options.ColumnsNames.Insert(0, string.Empty);
-				_options.ColumnsModels.Insert(0, actionsColumnModel);
-			}
-			else if (position >= _options.ColumnsModels.Count)
-			{
-				_options.ColumnsNames.Add(string.Empty);
-				_options.ColumnsModels.Add(actionsColumnModel);
-			}
-			else
-			{
-				_options.ColumnsNames.Insert(position, string.Empty);
-				_options.ColumnsModels.Insert(position, actionsColumnModel);
-			}
-
-			return this;
-		}
-
-		/// <summary>
-		/// Enables Navigator for this JqGridHelper instance.
-		/// </summary>
-		/// <param name="options">The options for the Navigator.</param>
-		/// <param name="editActionOptions">The options for the edit action.</param>
-		/// <param name="addActionOptions">The options for the add action.</param>
-		/// <param name="deleteActionOptions">The options for the delete action.</param>
-		/// <param name="searchActionOptions">The options for the search action.</param>
-		/// <param name="viewActionOptions">The options for the view action.</param>
-		/// <returns>JqGridHelper instance with enabled Navigator.</returns>
-		/// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
-		public JqGridHelper<TModel> Navigator(JqGridNavigatorOptions options, JqGridNavigatorEditActionOptions editActionOptions = null, JqGridNavigatorEditActionOptions addActionOptions = null, JqGridNavigatorDeleteActionOptions deleteActionOptions = null, JqGridNavigatorSearchActionOptions searchActionOptions = null, JqGridNavigatorViewActionOptions viewActionOptions = null)
-		{
-			_navigatorOptions = options ?? throw new ArgumentNullException(nameof(options));
-			_navigatorEditActionOptions = editActionOptions;
-			_navigatorAddActionOptions = addActionOptions;
-			_navigatorDeleteActionOptions = deleteActionOptions;
-			_navigatorSearchActionOptions = searchActionOptions;
-			_navigatorViewActionOptions = viewActionOptions;
-
-			return this;
-		}
-
-		/// <summary>
-		/// Enables Inline Navigator for this JqGridHelper instance.
-		/// </summary>
-		/// <param name="options">The options for the Inline Navigator.</param>
-		/// <returns>JqGridHelper instance with enabled Inline Navigator.</returns>
-		/// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
-		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-		public JqGridHelper<TModel> InlineNavigator(JqGridInlineNavigatorOptions options)
-		{
-			if (_navigatorOptions == null)
-				throw new InvalidOperationException("In order to call InlineNavigator method you must call Navigator method first.");
-			_inlineNavigatorOptions = options ?? throw new ArgumentNullException(nameof(options));
-
-			return this;
-		}
-
-		/// <summary>
-		/// Adds button to this JqGridHelper instance Navigator.
-		/// </summary>
-		/// <param name="caption">The caption for the button.</param>
-		/// <param name="icon">The icon (form UI theme images) for the button. If this is set to "none" only text will appear.</param>
-		/// <param name="onClick">The function for button click action.</param>
-		/// <param name="position">The position where the button will be added.</param>
-		/// <param name="toolTip">The tooltip for the button.</param>
-		/// <param name="cursor">The value which determines the cursor when user mouseover the button.</param>
-		/// <param name="cloneToTop">The value which defines if the button added to the bottom pager should be coppied to the top pager.</param>
-		/// <returns>JqGridHelper instance.</returns>
-		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-		public JqGridHelper<TModel> AddNavigatorButton(string caption = JqGridNavigatorDefaults.ButtonCaption, string icon = JqGridNavigatorDefaults.ButtonIcon, string onClick = null, JqGridNavigatorButtonPositions position = JqGridNavigatorButtonPositions.Last, string toolTip = "", string cursor = JqGridNavigatorDefaults.ButtonCursor, bool cloneToTop = false)
-		{
-			if (_navigatorOptions == null)
-				throw new InvalidOperationException("In order to call AddNavigatorButton method you must call Navigator method first.");
-
-			_navigatorControlsOptions.Add(new JqGridNavigatorButtonOptions()
-			{
-				CloneToTop = cloneToTop,
-				Caption = caption,
-				Icon = icon,
-				OnClick = onClick,
-				Position = position,
-				ToolTip = toolTip,
-				Cursor = cursor
-			});
-
-			return this;
-		}
-
-		/// <summary>
-		/// Adds button to this JqGridHelper instance Navigator.
-		/// </summary>
-		/// <param name="options">The options for the button.</param>
-		/// <returns>JqGridHelper instance.</returns>
-		/// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
-		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-		public JqGridHelper<TModel> AddNavigatorButton(JqGridNavigatorButtonOptions options)
-		{
-			if (options == null)
-				throw new ArgumentNullException(nameof(options));
-
-			if (_navigatorOptions == null)
-				throw new InvalidOperationException("In order to call AddNavigatorButton method you must call Navigator method first.");
-
-			_navigatorControlsOptions.Add(options);
-
-			return this;
-		}
-
-		/// <summary>
-		/// Adds separator to this JqGridHelper instance Navigator.
-		/// </summary>
-		/// <param name="class">The class for the separator.</param>
-		/// <param name="content">The content for the separator.</param>
-		/// <param name="cloneToTop">The value which defines if the separator added to the bottom pager should be coppied to the top pager.</param>
-		/// <returns>JqGridHelper instance.</returns>
-		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-		public JqGridHelper<TModel> AddNavigatorSeparator(string @class = JqGridNavigatorDefaults.SeparatorClass, string content = "", bool cloneToTop = false)
-		{
-			if (_navigatorOptions == null)
-				throw new InvalidOperationException("In order to call AddNavigatorSeparator method you must call Navigator method first.");
-
-			_navigatorControlsOptions.Add(new JqGridNavigatorSeparatorOptions()
-			{
-				CloneToTop = cloneToTop,
-				Class = @class,
-				Content = content
-			});
-
-			return this;
-		}
-
-		/// <summary>
-		/// Adds separator to this JqGridHelper instance Navigator.
-		/// </summary>
-		/// <param name="options">The options for the separator.</param>
-		/// <returns>JqGridHelper instance.</returns>
-		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-		public JqGridHelper<TModel> AddNavigatorSeparator(JqGridNavigatorSeparatorOptions options)
-		{
-			if (options == null)
-				throw new ArgumentNullException(nameof(options));
-
-			if (_navigatorOptions == null)
-				throw new InvalidOperationException("In order to call AddNavigatorSeparator method you must call Navigator method first.");
-
-			_navigatorControlsOptions.Add(options);
-
-			return this;
-		}
-
-		/// <summary>
-		/// Enables filter toolbar for this JqGridHelper instance.
-		/// </summary>
-		/// <param name="options">The options for the filter toolbar.</param>
-		/// <returns>JqGridHelper instance with enabled filter toolbar.</returns>
-		public JqGridHelper<TModel> FilterToolbar(JqGridFilterToolbarOptions options = null)
-		{
-			_filterToolbar = true;
-			_filterToolbarOptions = options;
-
-			return this;
-		}
-
-		/// <summary>
-		/// Enables filter grid for this JqGridHelper instance.
-		/// </summary>
-		/// <param name="model">The model for the filter grid (if null, the model will be build based on ColumnsModels and ColumnsNames).</param>
-		/// <param name="options">The options for the filter grid.</param>
-		/// <returns>JqGridHelper instance with enabled filter grid.</returns>
-		/// <exception cref="System.InvalidOperationException">The filter grid model has not been provided and the automatic generation is not possible because the count of items in ColumnsModel  is different from ColumnsNames.</exception>
-		public JqGridHelper<TModel> FilterGrid(List<JqGridFilterGridRowModel> model = null, JqGridFilterGridOptions options = null)
-		{
-			if (model == null)
-			{
-				if (_options.ColumnsModels.Count != _options.ColumnsNames.Count)
-					throw new InvalidOperationException("Can't build filter grid model because ColumnsModels.Count is not equal to ColumnsNames.Count");
-
-				_filterGridModel = new List<JqGridFilterGridRowModel>();
-				for (var i = 0; i < _options.ColumnsModels.Count; i++)
-				{
-					if (_options.ColumnsModels[i].Searchable.GetValueOrDefault())
-					{
-						_filterGridModel.Add(new JqGridFilterGridRowModel(_options.ColumnsModels[i].Name, _options.ColumnsNames[i])
-						{
-							DefaultValue = _options.ColumnsModels[i].SearchOptions != null ? _options.ColumnsModels[i].SearchOptions.DefaultValue : string.Empty,
-							SearchType = _options.ColumnsModels[i].SearchType,
-							SelectUrl = _options.ColumnsModels[i].SearchOptions != null ? _options.ColumnsModels[i].SearchOptions.DataUrl : string.Empty
-						});
-					}
-				}
-			}
-			else
-				_filterGridModel = model;
-			_filterGridOptions = options;
-
-			return this;
-		}
-
-		/// <summary>
-		/// Sets data on footer of this JqGridHelper instance (requires footerEnabled = true).
-		/// </summary>
-		/// <param name="data">The object with values for the footer. Should have names which are the same as names from ColumnsModels.</param>
-		/// <param name="useFormatters">The value indicating if the formatters from columns should be used for footer.</param>
-		/// <returns>JqGridHelper instance with footer data.</returns>
-		public JqGridHelper<TModel> SetFooterData(object data, bool useFormatters = true)
-		{
-			return SetFooterData(AnonymousObjectToDictionary(data), useFormatters);
-		}
-
-		/// <summary>
-		/// Sets data on footer of this JqGridHelper instance (requires footerEnabled = true).
-		/// </summary>
-		/// <param name="data">The dictionary with values for the footer. Should have keys which are the same as names from ColumnsModels.</param>
-		/// <param name="useFormatters">The value indicating if the formatters from columns should be used for footer.</param>
-		/// <returns>JqGridHelper instance with footer data.</returns>
-		public JqGridHelper<TModel> SetFooterData(IDictionary<string, object> data, bool useFormatters = true)
-		{
-			_footerData = data;
-			_footerDataUseFormatters = useFormatters;
-			return this;
-		}
-
-		/// <summary>
-		/// Sets grouping headers for this JqGridHelper instance.
-		/// </summary>
-		/// <param name="groupHeaders">Settings for grouping headers.</param>
-		/// <param name="useColSpanStyle">The value which determines if the non grouping header cell should have cell above it (false), or the column should be treated as one combining boot (true).</param>
-		/// <returns>JqGridHelper instance with grouping header.</returns>
-		/// <exception cref="System.InvalidOperationException">Columns sorting (reordering) is enabled. </exception>
-		public JqGridHelper<TModel> SetGroupHeaders(IEnumerable<JqGridGroupHeader> groupHeaders, bool useColSpanStyle = false)
-		{
-			if (_options.Sortable.GetValueOrDefault())
-				throw new InvalidOperationException("Header grouping can not be set-up when columns sorting (reordering) is enabled.");
-
-			_groupHeaders = groupHeaders;
-			_groupHeadersUseColSpanStyle = useColSpanStyle;
-			return this;
-		}
-
-		/// <summary>
-		/// Sets frozen columns for this JqGridHelper instance.
-		/// </summary>
-		/// <returns>JqGridHelper instance with frozen columns.</returns>
-		/// <exception cref="System.InvalidOperationException">
-		/// <list type="bullet">
-		/// <item><description>TreeGrid is enabled.</description></item>
-		/// <item><description>SubGrid is enabled.</description></item>
-		/// <item><description>Columns sorting (reordering) is enabled.</description></item>
-		/// <item><description>Dynamic scrolling is enabled.</description></item>
-		/// <item><description>Data grouping is enabled.</description></item>
-		/// </list> 
-		/// </exception>
-		public JqGridHelper<TModel> SetFrozenColumns()
-		{
-			if (_options.TreeGridEnabled.GetValueOrDefault())
-				throw new InvalidOperationException("Frozen columns can not be set-up when TreeGrid is enabled.");
-
-			if (_options.SubgridEnabled.GetValueOrDefault())
-				throw new InvalidOperationException("Frozen columns can not be set-up when SubGrid is enabled.");
-
-			if (_options.Sortable.GetValueOrDefault())
-				throw new InvalidOperationException("Frozen columns can not be set-up when columns sorting (reordering) is enabled.");
-
-			if (_options.DynamicScrollingMode != JqGridDynamicScrollingModes.Disabled)
-				throw new InvalidOperationException("Frozen columns can not be set-up when dynamic scrolling is enabled.");
-
-			if (_options.GroupingEnabled.GetValueOrDefault())
-				throw new InvalidOperationException("Frozen columns can not be set-up when data grouping is enabled.");
-
-			_setFrozenColumns = true;
-			return this;
-		}
-
-		/// <summary>
-		/// Sets some column options with dynamic data, that we can't set in attributes
-		/// </summary>
-		/// <param name="column">Name of column</param>
-		/// <param name="model">Model with data to set</param>
-		/// <returns>This JqGridHelper</returns>
-		/// <exception cref="ArgumentNullException">If column and/or model not defined</exception>
-		/// <exception cref="KeyNotFoundException">If column doesn't exist in model</exception>
-		public JqGridHelper<TModel> ExtendColumnOptions(string column, JqGridExtendColumnModel model)
-		{
-			if (string.IsNullOrWhiteSpace(column))
-				throw new ArgumentNullException(nameof(column));
-			if (_options.ColumnsModels.All(m => m.Name != column))
-				throw new KeyNotFoundException("This column doesn't exist in model.");
-			if (model == null)
-				throw new ArgumentNullException(nameof(model));
-
-			var columnModel = _options.ColumnsModels.Single(c => c.Name == column);
-
-			if (model.IsEditOptionsPostDataSetted)
-				columnModel.EditOptions.PostData = model.EditOptionsPostData;
-
-			if (model.IsEditOptionsHtmlAttributesSetted)
-				columnModel.EditOptions.HtmlAttributes = model.EditOptionsHtmlAttributes;
-
-			if (model.IsEditOptionsValueDictionarySetted)
-				columnModel.EditOptions.ValueDictionary = model.EditOptionsValueDictionary;
-
-			if (model.IsLabelOptionsHtmlAttributesSetted)
-				columnModel.LabelOptions.HtmlAttributes = model.LabelOptionsHtmlAttributes;
-
-			if (model.IsLabelOptionsCssStylesSetted)
-				columnModel.LabelOptions.CssStyles = model.LabelOptionsCssStyles;
-
-			if (model.IsSearchOptionsHtmlAttributesSetted)
-				columnModel.SearchOptions.HtmlAttributes = model.SearchOptionsHtmlAttributes;
-
-			if (model.IsSearchOptionsValueDictionarySetted)
-				columnModel.SearchOptions.ValueDictionary = model.SearchOptionsValueDictionary;
-
-			return this;
-		}
-		#endregion
-	}
+    /// <summary>
+    /// Helper class for generating jqGrid HMTL and JavaScript
+    /// </summary>
+    /// <typeparam name="TModel">Type of model for this grid</typeparam>
+    public class JqGridHelper<TModel> : IJqGridHelper
+    {
+        #region Fields
+        private JqGridOptions _options;
+        private JqGridInlineNavigatorOptions _inlineNavigatorOptions;
+        private JqGridNavigatorOptions _navigatorOptions;
+        private JqGridNavigatorActionOptions _navigatorEditActionOptions;
+        private JqGridNavigatorActionOptions _navigatorAddActionOptions;
+        private JqGridNavigatorActionOptions _navigatorDeleteActionOptions;
+        private JqGridNavigatorActionOptions _navigatorSearchActionOptions;
+        private JqGridNavigatorActionOptions _navigatorViewActionOptions;
+        private List<JqGridNavigatorControlOptions> _navigatorControlsOptions = new List<JqGridNavigatorControlOptions>();
+        private bool _filterToolbar = false;
+        private JqGridFilterToolbarOptions _filterToolbarOptions;
+        private List<JqGridFilterGridRowModel> _filterGridModel;
+        private JqGridFilterGridOptions _filterGridOptions;
+        private IDictionary<string, object> _footerData = null;
+        private bool _footerDataUseFormatters = true;
+        private bool _groupHeadersUseColSpanStyle = false;
+        private IEnumerable<JqGridGroupHeader> _groupHeaders = null;
+        private bool _setFrozenColumns = false;
+        private bool _asSubgrid = false;
+        private object _subgridHelper = null;
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// Gets the grid identifier.
+        /// </summary>
+        public string Id => _options.Id;
+
+        private string GridSelector => _asSubgrid ? "'#' + subgridTableId" : $"'#{Id}'";
+
+        /// <summary>
+        /// Gets the grid pager identifier.
+        /// </summary>
+        public string PagerId => _options.Id + "Pager";
+
+        private string TopPagerSelector => _asSubgrid ? "'#' + subgridTableId + '_toppager'" : $"'#{Id}_toppager'";
+
+        private string PagerSelector => _asSubgrid ? "'#' + subgridPagerId" : $"'#{PagerId}'";
+
+        /// <summary>
+        /// Gets the filter grid (div) placeholder identifier.
+        /// </summary>
+        public string FilterGridId => _options.Id + "Search";
+
+        private string FilterGridSelector => _asSubgrid ? "'#' + subgridFilterGridId" : $"'#{FilterGridId}'";
+
+        #endregion
+
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridHelper class.
+        /// </summary>
+        /// <param name="id">Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div (id='{0}Search') and in JavaScript.</param>
+        /// <param name="afterInsertRow">The function for event which is raised after every inserted row.</param>
+        /// <param name="afterEditCell">The function for event which is raised after the edited cell is edited.</param>
+        /// <param name="afterRestoreCell">The function for event which is raised after calling the method restoreCell or the user press ESC leaving the changes.</param>
+        /// <param name="afterSaveCell">The function for event which is raised after the cell has been successfully saved.</param>
+        /// <param name="afterSubmitCell">The function for event which is raised after the cell and other data is posted to the server.</param>
+        /// <param name="altClass">The class that is used for alternate rows.</param>
+        /// <param name="altRows">The value indicating if the grid should be "zebra-striped".</param>
+        /// <param name="autoEncode">The value indicating if the grid should auto encode/decode the data.</param>
+        /// <param name="autoWidth">The value indicating if the grid width will be recalculated automatically to the width of the parent element.</param>
+        /// <param name="beforeRequest">The function for event which is raised before requesting any data.</param>
+        /// <param name="beforeSelectRow">The function for event which is raised when the user click on the row, but before selecting it.</param>
+        /// <param name="beforeEditCell">The function for event which is raised before editing the cell.</param>
+        /// <param name="beforeSaveCell">The function for event which is raised before validation of values if any.</param>
+        /// <param name="beforeSubmitCell">The function for event which is raised before submit the cell content to the server.</param>
+        /// <param name="beforeProcessing">This function for event which is raised before proccesing the data returned from the server.</param>
+        /// <param name="caption">The caption for the grid.</param>
+        /// <param name="cellLayout">The padding plus border width of the cell.</param>
+        /// <param name="cellEditingEnabled">The value indicating if cell editing is enabled.</param>
+        /// <param name="cellEditingSubmitMode">The cell editing submit mode.</param>
+        /// <param name="cellEditingUrl">The URL for cell editing submit.</param>
+        /// <param name="dataString">The string of data which will be used when DataType is set to JqGridDataTypes.XmlString or JqGridDataTypes.JsonString.</param>
+        /// <param name="dataType">The type of information to expect to represent data in the grid.</param>
+        /// <param name="deepEmpty">The value indicating if jqGrid should be using jQuery.empty for the the row and all its children elements.</param>
+        /// <param name="direction">The language direction in grid.</param>
+        /// <param name="dynamicScrollingMode">The value which defines if dynamic scrolling is enabled.</param>
+        /// <param name="dynamicScrollingTimeout">The timeout (in miliseconds) if DynamicScrollingMode is set to JqGridDynamicScrollingModes.HoldVisibleRows.</param>
+        /// <param name="editingUrl">The url for inline and form editing</param>
+        /// <param name="emptyRecords">The information to be displayed when the returned (or the current) number of records is zero.</param>
+        /// <param name="expandColumnClick">The value which defines whether the tree is expanded and/or collapsed when user clicks on the text of the expanded column, not only on the image.</param>
+        /// <param name="expandColumn">The name of column which should be used to expand the tree grid.</param>
+        /// <param name="errorCell">The function for event which is raised when there is a server error while saving cell.</param>
+        /// <param name="formatCell">The function for event which allows formatting the cell content before editing.</param>
+        /// <param name="footerEnabled">The value indicating if the footer table (with one row) will be placed below the grid records and above the pager.</param>
+        /// <param name="gridView">The value indicating if all the data should be inserted into DOM with one jQuery call.</param>
+        /// <param name="groupingEnabled">The value indicating if the grouping is enabled.</param>
+        /// <param name="groupingView">The grouping view options.</param>
+        /// <param name="height">The height of the grid in pixels (default 'auto').</param>
+        /// <param name="headerTitles">The value which defines whether the title attribute is added to the column headers.</param>
+        /// <param name="hidden">The value which defines whether the grid is initialy hidden (no data loaded, only caption layer is shown). Takes effect only if the caption is not empty string and hiddenEnabled is true.</param>
+        /// <param name="hoverRows">The value which defines whether the mouse hovering over the grid data rows is enabled</param>
+        /// <param name="ignoreCase">The value which defines whether the local searching is case-sensitive.</param>
+        /// <param name="hiddenEnabled">The value which defines whether the show/hide grid button is enabled. Takes effect only if the caption is not empty string.</param>
+        /// <param name="jsonReader">The JSON reader for the grid.</param>
+        /// <param name="loadBeforeSend">The function for pre-callback to modify the XMLHttpRequest object before it is sent.</param>
+        /// <param name="loadError">The function for event which is raised after the request fails.</param>
+        /// <param name="loadComplete">The function for event which is raised immediately after every server request.</param>
+        /// <param name="loadOnce">The value which defines whether the grid should load the data only once and all further manipulationsshould be done on the client side.</param>
+        /// <param name="methodType">The type of request to make.</param>
+        /// <param name="multiKey">The key which should be pressed when the user makes multiselection.</param>
+        /// <param name="multiBoxOnly">The value which defines whether the multiselection is done only when the checkbox is clicked.</param>
+        /// <param name="multiSelect">The value which defines whether the multiselection is enabled.</param>
+        /// <param name="multiSelectWidth">The width of the multiselect colum.</param>
+        /// <param name="multiSort">The value which defines whether the sorting by multiple columns is enabled.</param>
+        /// <param name="gridComplete">The function for event which is raised after all the data is loaded into the grid and all other processes are complete.</param>
+        /// <param name="onCellSelect">The function for event which is raised when user clicks on particular cell in the grid.</param>
+        /// <param name="onDoubleClickRow">The function for event which is raised immediately after row was double clicked.</param>
+        /// <param name="onHeaderClick">The function for event which is raised after clicking to hide or show grid.</param>
+        /// <param name="onInitGrid">The function for event which is raised only once before populating the data.</param>
+        /// <param name="onPaging">The function for event which is raised before populating the data after page index/size change.</param>
+        /// <param name="onRightClickRow">The function for event which is raised immediately after row was right clicked.</param>
+        /// <param name="onSelectAll">The function for event which is raised when MultipleSelect option is true and user clicks on the header checkbox.</param>
+        /// <param name="onSelectCell">The function for event which is raised after the cell is selected for editing.</param>
+        /// <param name="onSelectRow">The function for event which is raised immediately after row was clicked.</param>
+        /// <param name="onSortCol">The function for event which is raised immediately after sortable column was clicked and before sorting the data.</param>
+        /// <param name="pager">If grid should use a pager bar to navigate through the records.</param>
+        /// <param name="parametersNames">The customized names for jqGrid request parameters.</param>
+        /// <param name="postData">The additional data which will be added to the request.</param>
+        /// <param name="postDataScript">The JavaScript which will dynamically generate the additional data which will be added to the request (this property takes precedence over postData).</param>
+        /// <param name="resizeStart">The function for event which is raised when user starts resizing a column.</param>
+        /// <param name="resizeStop">The function for event which is raised after the column is resized.</param>
+        /// <param name="rowAttributes">The function which can add attributes to the row during the creation of the data (dynamically).</param>
+        /// <param name="rowsList">The array to construct a select box element in the pager in which user can change the number of the visible rows.</param>
+        /// <param name="rowsNumber">How many records should be displayed in the grid.</param>
+        /// <param name="rowsNumbers">The value which defines whether a new column, which purpose is to count the number of available rows, should be added at left of the grid.</param>
+        /// <param name="rowsNumbersWidth">The width of the row number column.</param>
+        /// <param name="shrinkToFit">The value which defines whether the columns width should be recalculated to fit the width of the grid.</param>
+        /// <param name="scrollOffset">The width of vertical scrollbar.</param>
+        /// <param name="serializeCellData">The function for event which can serialize the data passed to the ajax request when the cell is being saved.</param>
+        /// <param name="serializeGridData">The function for event which can serialize the data passed to the ajax request.</param>
+        /// <param name="serializeSubGridData">The function for event which can serialize the data passed to the subgrid ajax request.</param>
+        /// <param name="sortable">The value which defines whether the columns can be reordered by dragging and dropping them with the mouse.</param>
+        /// <param name="sortingName">The initial sorting column index, when  using data returned from server.</param>
+        /// <param name="sortingOrder">The initial sorting order, when  using data returned from server.</param>
+        /// <param name="styleUI">The CSS framework.</param>
+        /// <param name="subgridEnabled">The value which defines if subgrid is enabled.</param>
+        /// <param name="subgridModel">The subgrid model.</param>
+        /// <param name="subgridHelper">The subgrid helper for "Subgrid as Grid" scenario. If this option has value, the SugridModel, SubgridUrl and SubGridRowExpanded options are ignored. It will also add additional parameter 'id' to the request.</param>
+        /// <param name="subgridUrl">The url for subgrid data requests.</param>
+        /// <param name="subgridColumnWidth">The width of subgrid expand/colapse column.</param>
+        /// <param name="subGridBeforeExpand">The function for event which is raised just before expanding the subgrid.</param>
+        /// <param name="subGridRowColapsed">The function for event which is raised when the user clicks on the plus icon of the grid.</param>
+        /// <param name="subGridRowExpanded">The function for event which is raised when the user clicks on the minus icon of the grid.</param>
+        /// <param name="topPager">The value indicating if jqGrid should place a pager element at top of the grid below the caption (if available).</param>
+        /// <param name="treeGridEnabled">The value which defines if TreeGrid is enabled.</param>
+        /// <param name="treeGridModel">The model for TreeGrid.</param>
+        /// <param name="url">The url for data requests.</param>
+        /// <param name="userDataOnFooter">The value indicating if the values from user data should be placed on footer.</param>
+        /// <param name="viewRecords">If grid should display the beginning and ending record number out of the total number of records in the query.</param>
+        /// <param name="width">The width of the grid in pixels.</param>
+        /// <param name="compatibilityMode">The compatibility mode.</param>
+        [Obsolete("Now this constructor creates more redurant JavaScript code. Use new constructor with JqGridOption parameter")]
+        public JqGridHelper(string id, string afterInsertRow = null, string afterEditCell = null, string afterRestoreCell = null, string afterSaveCell = null, string afterSubmitCell = null, string altClass = JqGridOptionsDefaults.AltClass, bool altRows = false, bool autoEncode = false, bool autoWidth = false, string beforeRequest = null, string beforeSelectRow = null, string beforeEditCell = null, string beforeSaveCell = null, string beforeSubmitCell = null, string beforeProcessing = null, string caption = null, int cellLayout = JqGridOptionsDefaults.CellLayout, bool cellEditingEnabled = false, JqGridCellEditingSubmitModes cellEditingSubmitMode = JqGridCellEditingSubmitModes.remote, string cellEditingUrl = null, string dataString = null, JqGridDataTypes dataType = JqGridDataTypes.Xml, bool deepEmpty = false, JqGridLanguageDirections direction = JqGridLanguageDirections.Ltr, JqGridDynamicScrollingModes dynamicScrollingMode = JqGridDynamicScrollingModes.Disabled, int dynamicScrollingTimeout = 200, string editingUrl = null, string emptyRecords = JqGridOptionsDefaults.EmptyRecords, bool expandColumnClick = true, string expandColumn = null, int? height = null, string errorCell = null, string formatCell = null, bool footerEnabled = false, bool gridView = false, bool groupingEnabled = false, JqGridGroupingView groupingView = null, bool headerTitles = false, bool hidden = false, bool hiddenEnabled = true, bool hoverRows = true, bool ignoreCase = false, JqGridJsonReader jsonReader = null, string loadBeforeSend = null, string loadError = null, string loadComplete = null, bool loadOnce = false, JqGridMethodTypes methodType = JqGridMethodTypes.Default, JqGridMultiKeys multiKey = JqGridMultiKeys.Default, bool multiBoxOnly = false, bool multiSelect = false, int multiSelectWidth = 20, bool multiSort = false, string gridComplete = null, string onCellSelect = null, string onDoubleClickRow = null, string onHeaderClick = null, string onInitGrid = null, string onPaging = null, string onRightClickRow = null, string onSelectAll = null, string onSelectCell = null, string onSelectRow = null, string onSortCol = null, bool pager = false, JqGridParametersNames parametersNames = null, object postData = null, string postDataScript = null, string resizeStart = null, string resizeStop = null, string rowAttributes = null, List<int> rowsList = null, int rowsNumber = 20, bool rowsNumbers = false, int rowsNumbersWidth = 25, bool shrinkToFit = true, int scrollOffset = 18, string serializeCellData = null, string serializeGridData = null, string serializeSubGridData = null, bool sortable = false, string sortingName = "", JqGridSortingOrders sortingOrder = JqGridSortingOrders.Asc, JqGridStyleUIOptions styleUI = JqGridStyleUIOptions.jQueryUI, bool subgridEnabled = false, JqGridSubgridModel subgridModel = null, object subgridHelper = null, string subgridUrl = null, int subgridColumnWidth = 20, string subGridBeforeExpand = null, string subGridRowColapsed = null, string subGridRowExpanded = null, bool topPager = false, bool treeGridEnabled = false, JqGridTreeGridModels treeGridModel = JqGridTreeGridModels.Nested, string url = null, bool userDataOnFooter = false, bool viewRecords = false, int? width = null, JqGridCompatibilityModes compatibilityMode = JqGridCompatibilityModes.JqGrid)
+            : this(new JqGridOptions<TModel>(id) { CompatibilityMode = compatibilityMode, AfterInsertRow = afterInsertRow, AfterEditCell = afterEditCell, AfterRestoreCell = afterRestoreCell, AfterSaveCell = afterSaveCell, AfterSubmitCell = afterSubmitCell, AltClass = altClass, AltRows = altRows, AutoEncode = autoEncode, AutoWidth = autoWidth, BeforeRequest = beforeRequest, BeforeSelectRow = beforeSelectRow, BeforeEditCell = beforeEditCell, BeforeSaveCell = beforeSaveCell, BeforeSubmitCell = beforeSubmitCell, BeforeProcessing = beforeProcessing, Caption = caption, CellLayout = cellLayout, CellEditingEnabled = cellEditingEnabled, CellEditingSubmitMode = cellEditingSubmitMode, CellEditingUrl = cellEditingUrl, DataString = dataString, DataType = dataType, DeepEmpty = deepEmpty, Direction = direction, DynamicScrollingMode = dynamicScrollingMode, DynamicScrollingTimeout = dynamicScrollingTimeout, EditingUrl = editingUrl, EmptyRecords = emptyRecords, ExpandColumnClick = expandColumnClick, ExpandColumn = expandColumn, ErrorCell = errorCell, FormatCell = formatCell, FooterEnabled = footerEnabled, GridView = gridView, GroupingEnabled = groupingEnabled, GroupingView = groupingView, Height = height, HeaderTitles = headerTitles, Hidden = hidden, HiddenEnabled = hiddenEnabled, HoverRows = hoverRows, IgnoreCase = ignoreCase, JsonReader = jsonReader, LoadBeforeSend = loadBeforeSend, LoadError = loadError, LoadComplete = loadComplete, LoadOnce = loadOnce, MethodType = methodType, MultiBoxOnly = multiBoxOnly, MultiKey = multiKey, MultiSelect = multiSelect, MultiSelectWidth = multiSelectWidth, MultiSort = multiSort, GridComplete = gridComplete, OnCellSelect = onCellSelect, OnDoubleClickRow = onDoubleClickRow, OnHeaderClick = onHeaderClick, OnInitGrid = onInitGrid, OnPaging = onPaging, OnRightClickRow = onRightClickRow, OnSelectAll = onSelectAll, OnSelectRow = onSelectRow, OnSelectCell = onSelectCell, OnSortCol = onSortCol, Pager = pager, ParametersNames = parametersNames, PostData = postData, PostDataScript = postDataScript, RowAttributes = rowAttributes, RowsList = rowsList, RowsNumber = rowsNumber, RowsNumbers = rowsNumbers, RowsNumbersWidth = rowsNumbersWidth, ShrinkToFit = shrinkToFit, ScrollOffset = scrollOffset, SerializeCellData = serializeCellData, SerializeGridData = serializeGridData, SerializeSubGridData = serializeSubGridData, Sortable = sortable, SortingName = sortingName, SortingOrder = sortingOrder, StyleUI = styleUI, SubgridEnabled = subgridEnabled, SubgridModel = subgridModel, SubgridUrl = subgridUrl, SubgridColumnWidth = subgridColumnWidth, SubGridBeforeExpand = subGridBeforeExpand, SubGridRowColapsed = subGridRowColapsed, SubGridRowExpanded = subGridRowExpanded, TopPager = topPager, TreeGridEnabled = treeGridEnabled, TreeGridModel = treeGridModel, Url = url, UserDataOnFooter = userDataOnFooter, ViewRecords = viewRecords, Width = width }, subgridHelper)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the JqGridHelper class.
+        /// </summary>
+        /// <param name="options">Options for the grid</param>
+        /// <param name="subgridHelper">The subgrid helper for "Subgrid as Grid" scenario. If this option has value, the SugridModel, SubgridUrl and SubGridRowExpanded options are ignored. It will also add additional parameter 'id' to the request.</param>
+        public JqGridHelper(JqGridOptions options, object subgridHelper = null)
+        {
+            _options = options;
+            _options.SetModel(typeof(TModel));
+
+            if (subgridHelper != null)
+            {
+                Type subgridHelperType = subgridHelper.GetType();
+                if (!subgridHelperType.IsGenericType || subgridHelperType.GetGenericTypeDefinition() != typeof(JqGridHelper<>))
+                    throw new ArgumentException("The object must be of type JqGridHelper<T>.", nameof(subgridHelper));
+                _subgridHelper = subgridHelper;
+            }
+        }
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Returns the HTML that is used to render the table placeholder for the grid. 
+        /// </summary>
+        /// <returns>The HTML that represents the table placeholder for jqGrid</returns>
+        public MvcHtmlString GetTableHtml()
+        {
+            return MvcHtmlString.Create($"<table id='{Id}'></table>");
+        }
+
+        /// <summary>
+        /// Returns the HTML that is used to render the pager (div) placeholder for the grid. 
+        /// </summary>
+        /// <returns>The HTML that represents the pager (div) placeholder for jqGrid</returns>
+        public MvcHtmlString GetPagerHtml()
+        {
+            return MvcHtmlString.Create($"<div id='{PagerId}'></div>");
+        }
+
+        /// <summary>
+        /// Returns the HTML that is used to render the filter grid (div) placeholder for the grid. 
+        /// </summary>
+        /// <returns>The HTML that represents the filter grid (div) placeholder for jqGrid</returns>
+        public MvcHtmlString GetFilterGridHtml()
+        {
+            return MvcHtmlString.Create($"<div id='{FilterGridId}'></div>");
+        }
+
+        /// <summary>
+        /// Returns the HTML that is used to render the table placeholder for the grid with pager placeholder below it and filter grid (if enabled) placeholder above it.
+        /// </summary>
+        /// <returns>The HTML that represents the table placeholder for jqGrid with pager placeholder below i</returns>
+        public MvcHtmlString GetHtml()
+        {
+            if (_filterGridModel != null && _options.Pager)
+                return MvcHtmlString.Create(GetFilterGridHtml().ToHtmlString() + GetTableHtml().ToHtmlString() + GetPagerHtml().ToHtmlString());
+            if (_filterGridModel != null)
+                return MvcHtmlString.Create(GetFilterGridHtml().ToHtmlString() + GetTableHtml().ToHtmlString());
+            if (_options.Pager)
+                return MvcHtmlString.Create(GetTableHtml().ToHtmlString() + GetPagerHtml().ToHtmlString());
+            return GetTableHtml();
+        }
+
+        /// <summary>
+        /// Return the JavaScript that is used to initialize jqGrid with given options.
+        /// </summary>
+        /// <returns>The JavaScript that initializes jqGrid with give options</returns>
+        /// <exception cref="System.InvalidOperationException">
+        /// <list type="bullet">
+        /// <item><description>TreeGrid and data grouping are both enabled.</description></item>
+        /// <item><description>Rows numbers and data grouping are both enabled.</description></item>
+        /// <item><description>Dynamic scrolling and data grouping are both enabled.</description></item>
+        /// <item><description>TreeGrid and GridView are both enabled.</description></item>
+        /// <item><description>SubGrid and GridView are both enabled.</description></item>
+        /// <item><description>AfterInsertRow event and GridView are both enabled.</description></item>
+        /// </list> 
+        /// </exception>
+        public MvcHtmlString GetJavaScript()
+        {
+            ValidateLimitations();
+
+            StringBuilder javaScriptBuilder = new StringBuilder();
+
+            javaScriptBuilder.AppendFormat("$({0}).jqGrid({{", GridSelector).AppendLine();
+            AppendColumnsNames(javaScriptBuilder);
+            AppendColumnsModels(javaScriptBuilder);
+            AppendOptions(javaScriptBuilder);
+            javaScriptBuilder.Append("})");
+
+            foreach (JqGridColumnModel columnModel in _options.ColumnsModels)
+            {
+                if (columnModel.LabelOptions != null)
+                    AppendColumnLabelOptions(columnModel.Name, columnModel.LabelOptions, javaScriptBuilder);
+            }
+
+            if (_options.FooterEnabled.GetValueOrDefault() && _footerData != null && _footerData.Any())
+                AppendFooterData(javaScriptBuilder);
+
+            if (_navigatorOptions != null)
+                AppendNavigator(javaScriptBuilder);
+
+            if (_inlineNavigatorOptions != null)
+                AppendInlineNavigator(javaScriptBuilder);
+
+            if (_filterToolbar)
+                AppendFilterToolbar(javaScriptBuilder);
+
+            if (_groupHeaders != null && _groupHeaders.Any())
+                AppendGroupHeaders(javaScriptBuilder);
+
+            if (_setFrozenColumns)
+                javaScriptBuilder.Append(".jqGrid('setFrozenColumns')");
+
+            javaScriptBuilder.AppendLine(";");
+
+            if (_filterGridModel != null)
+                AppendFilterGrid(javaScriptBuilder);
+
+            return MvcHtmlString.Create(javaScriptBuilder.ToString());
+        }
+
+        internal string GetSubGridRowExpanded()
+        {
+            _asSubgrid = true;
+
+            StringBuilder subGridRowExpandedBuilder = new StringBuilder();
+            subGridRowExpandedBuilder.AppendLine("function(subgridId, rowId) {");
+
+            if (_filterGridModel != null)
+            {
+                subGridRowExpandedBuilder.AppendLine("var subgridFilterGridId = subgridId + '_s';");
+                subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<div id=\"' + subgridFilterGridId + '\"></div>');");
+            }
+
+            subGridRowExpandedBuilder.AppendLine("var subgridTableId = subgridId + '_t';");
+            subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<table id=\"' + subgridTableId + '\"></table>');");
+
+            if (_options.Pager)
+            {
+                subGridRowExpandedBuilder.AppendLine("var subgridPagerId = subgridId + '_p';");
+                subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<div id=\"' + subgridPagerId + '\"></div>');");
+            }
+
+            subGridRowExpandedBuilder.AppendLine(GetJavaScript().ToString());
+
+            subGridRowExpandedBuilder.Append("}");
+            return subGridRowExpandedBuilder.ToString();
+        }
+
+        private void ValidateLimitations()
+        {
+            if (_options.TreeGridEnabled.GetValueOrDefault() && _options.GroupingEnabled.GetValueOrDefault())
+                throw new InvalidOperationException("TreeGrid and data grouping can not be enabled at the same time.");
+
+            if (_options.RowsNumbers.GetValueOrDefault() && _options.GroupingEnabled.GetValueOrDefault())
+                throw new InvalidOperationException("Rows numbers and data grouping can not be enabled at the same time.");
+
+            if (_options.DynamicScrollingMode != JqGridDynamicScrollingModes.Disabled && _options.GroupingEnabled.GetValueOrDefault())
+                throw new InvalidOperationException("Dynamic scrolling and data grouping can not be enabled at the same time.");
+
+            if (_options.TreeGridEnabled.GetValueOrDefault() && _options.GridView.GetValueOrDefault())
+                throw new InvalidOperationException("TreeGrid and GridView can not be enabled at the same time.");
+
+            if (_options.SubgridEnabled.GetValueOrDefault() && _options.GridView.GetValueOrDefault())
+                throw new InvalidOperationException("SubGrid and GridView can not be enabled at the same time.");
+
+            if (!string.IsNullOrWhiteSpace(_options.AfterInsertRow) && _options.GridView.GetValueOrDefault())
+                throw new InvalidOperationException("AfterInsertRow event and GridView can not be enabled at the same time.");
+        }
+
+        private void AppendColumnsNames(StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.Append("colNames: [");
+
+            foreach (string columnName in _options.ColumnsNames)
+                javaScriptBuilder.AppendFormat("'{0}',", columnName);
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 1] == ',')
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+
+            javaScriptBuilder.AppendLine("],");
+        }
+
+        private void AppendColumnsModels(StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.AppendLine("colModel: [");
+
+            int lastColumnModelIndex = _options.ColumnsModels.Count - 1;
+            for (int columnModelIndex = 0; columnModelIndex < _options.ColumnsModels.Count; columnModelIndex++)
+            {
+                JqGridColumnModel columnModel = _options.ColumnsModels[columnModelIndex];
+                javaScriptBuilder.Append("{ ");
+
+                if (columnModel.Alignment != JqGridAlignments.Default)
+                    javaScriptBuilder.AppendFormat("align: '{0}', ", columnModel.Alignment.ToString().ToLower());
+
+                if (columnModel.Index?.IsSetted ?? false)
+                    javaScriptBuilder.AppendFormat("index: '{0}', ", columnModel.Index.Value);
+
+                if (columnModel.CellAttributes?.IsSetted ?? false)
+                    javaScriptBuilder.AppendFormat("cellattr: {0}, ", columnModel.CellAttributes.Value);
+
+                if (columnModel.Classes?.IsSetted ?? false)
+                    javaScriptBuilder.AppendFormat("classes: '{0}', ", columnModel.Classes.Value);
+
+                if (columnModel.DateFormat?.IsSetted ?? false)
+                    javaScriptBuilder.AppendFormat("datefmt: '{0}', ", columnModel.DateFormat.Value);
+
+                if (columnModel.Editable.HasValue)
+                {
+                    javaScriptBuilder.AppendFormat("editable: {0}, ", columnModel.Editable.Value.ToString().ToLower());
+                    if (columnModel.Editable.Value)
+                    {
+                        if (columnModel.EditType != JqGridColumnEditTypes.Default)
+                            javaScriptBuilder.AppendFormat("edittype: '{0}', ", columnModel.EditType.ToString().ToLower());
+                        AppendEditOptions(columnModel.EditOptions, javaScriptBuilder);
+                        AppendColumnRules("editrules", columnModel.EditRules, javaScriptBuilder);
+                        AppendFormOptions(columnModel.FormOptions, javaScriptBuilder);
+                    }
+                }
+
+                if (columnModel.Fixed.HasValue)
+                    javaScriptBuilder.AppendFormat("fixed: {0}, ", columnModel.Fixed.ToString().ToLower());
+
+                if (columnModel.Frozen.HasValue)
+                    javaScriptBuilder.AppendFormat("frozen: {0}, ", columnModel.Frozen.ToString().ToLower());
+
+                if (columnModel.Formatter?.IsSetted ?? false)
+                {
+                    javaScriptBuilder.AppendFormat("formatter: {0}, ", columnModel.Formatter.Value);
+                    AppendFormatterOptions(columnModel.Formatter.Value, columnModel.FormatterOptions, javaScriptBuilder);
+                    if (columnModel.UnFormatter?.IsSetted ?? false)
+                        javaScriptBuilder.AppendFormat("unformat: {0}, ", columnModel.UnFormatter.Value);
+                }
+
+                if (columnModel.InitialSortingOrder != JqGridSortingOrders.Default)
+                    javaScriptBuilder.AppendFormat("firstsortorder: '{0}', ", columnModel.InitialSortingOrder.ToString().ToLower());
+
+                if (columnModel.Hidden.HasValue)
+                    javaScriptBuilder.AppendFormat("hidden: {0}, ", columnModel.Hidden.Value.ToString().ToLower());
+
+                if (columnModel.HideInDialog.HasValue)
+                    javaScriptBuilder.AppendFormat("hidedlg: {0}, ", columnModel.HideInDialog.Value.ToString().ToLower());
+
+                if (!string.IsNullOrWhiteSpace(columnModel.JsonMapping))
+                    javaScriptBuilder.AppendFormat("jsonmap: '{0}', ", columnModel.JsonMapping);
+
+                if (columnModel.Key.HasValue)
+                    javaScriptBuilder.AppendFormat("key: {0}, ", columnModel.Key.Value.ToString().ToLower());
+
+                if (columnModel.Resizable.HasValue)
+                    javaScriptBuilder.AppendFormat("resizable: {0}, ", columnModel.Resizable.Value.ToString().ToLower());
+
+                if (columnModel.Searchable.HasValue)
+                {
+                    javaScriptBuilder.AppendFormat("search: {0}, ", columnModel.Searchable.Value.ToString().ToLower());
+                    if (columnModel.Searchable.Value)
+                    {
+                        if (columnModel.SearchType != JqGridColumnSearchTypes.Default)
+                            javaScriptBuilder.AppendFormat("stype: '{0}', ", columnModel.SearchType.ToString().ToLower());
+                        AppendSearchOptions(columnModel.SearchOptions, javaScriptBuilder);
+                        AppendColumnRules("searchrules", columnModel.SearchRules, javaScriptBuilder);
+                    }
+                }
+
+                if (_options.GroupingEnabled.GetValueOrDefault())
+                {
+                    if (columnModel.SummaryType.HasValue)
+                    {
+                        if (columnModel.SummaryType.Value != JqGridColumnSummaryTypes.Custom)
+                            javaScriptBuilder.AppendFormat("summaryType: '{0}', ", columnModel.SummaryType.Value.ToString().ToLower());
+                        else
+                            javaScriptBuilder.AppendFormat("summaryType: {0}, ", columnModel.SummaryFunction);
+                    }
+
+                    if (columnModel.SummaryTemplate?.IsSetted ?? false)
+                        javaScriptBuilder.AppendFormat("summaryTpl: '{0}', ", columnModel.SummaryTemplate.Value);
+                }
+
+                if (columnModel.Sortable.HasValue)
+                {
+                    javaScriptBuilder.AppendFormat("sortable: {0}, ", columnModel.Sortable.Value.ToString().ToLower());
+                    if (columnModel.Sortable.Value && columnModel.SortType != JqGridColumnSortTypes.Default)
+                    {
+                        if (columnModel.SortType == JqGridColumnSortTypes.Function && (columnModel.SortFunction?.IsSetted ?? false))
+                            javaScriptBuilder.AppendFormat("sorttype: {0}, ", columnModel.SortFunction);
+                        else if (columnModel.SortType != JqGridColumnSortTypes.Function)
+                            javaScriptBuilder.AppendFormat("sorttype: '{0}', ", columnModel.SortType.ToString().ToLower());
+
+                    }
+                }
+
+                if (columnModel.Title.HasValue)
+                    javaScriptBuilder.AppendFormat("title: {0}, ", columnModel.Title.Value.ToString().ToLower());
+
+                if (columnModel.Width.HasValue)
+                    javaScriptBuilder.AppendFormat("width: {0}, ", columnModel.Width.Value);
+
+                if (columnModel.Viewable.HasValue)
+                    javaScriptBuilder.AppendFormat("viewable: {0}, ", columnModel.Viewable.ToString().ToLower());
+
+                if (!string.IsNullOrWhiteSpace(columnModel.XmlMapping))
+                    javaScriptBuilder.AppendFormat("xmlmap: '{0}', ", columnModel.XmlMapping);
+
+                javaScriptBuilder.AppendFormat("name: '{0}' }}", columnModel.Name);
+
+                if (lastColumnModelIndex == columnModelIndex)
+                    javaScriptBuilder.AppendLine();
+                else
+                    javaScriptBuilder.AppendLine(",");
+            }
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 1);
+
+            javaScriptBuilder.AppendLine("],");
+        }
+
+        private void AppendEditOptions(JqGridColumnEditOptions editOptions, StringBuilder javaScriptBuilder)
+        {
+            if (editOptions != null)
+            {
+                JavaScriptSerializer serializer = new JavaScriptSerializer();
+                javaScriptBuilder.Append("editoptions: { ");
+
+                if (editOptions.IsCustomElementFunctionSetted)
+                    javaScriptBuilder.AppendFormat("custom_element: {0}, ", editOptions.CustomElementFunction);
+
+                if (editOptions.IsCustomValueFunctionSetted)
+                    javaScriptBuilder.AppendFormat("custom_value: {0}, ", editOptions.CustomValueFunction);
+
+                if (editOptions.InternalDataEvents != null)
+                {
+                    if (editOptions.DataEvents == null)
+                        editOptions.DataEvents = new List<JqGridColumnDataEvent>();
+
+                    foreach (JqGridColumnDataEvent dataEvent in editOptions.InternalDataEvents)
+                        editOptions.DataEvents.Add(new JqGridColumnDataEvent(dataEvent.Type, string.Format(dataEvent.Function, _options.Id)));
+                }
+                AppendElementOptions(editOptions, serializer, javaScriptBuilder);
+
+                if (editOptions.NullIfEmpty.HasValue)
+                    javaScriptBuilder.AppendFormat("NullIfEmpty: {0}, ", editOptions.NullIfEmpty.Value.ToString().ToLower());
+
+                if (editOptions.HtmlAttributes != null && editOptions.HtmlAttributes.Any())
+                {
+                    string htmlAttributesSerialized = serializer.Serialize(editOptions.HtmlAttributes);
+                    javaScriptBuilder.AppendFormat("{0}, ", htmlAttributesSerialized.Substring(1, htmlAttributesSerialized.Length - 2));
+                }
+
+                if (editOptions.IsPostDataScriptsSetted)
+                    javaScriptBuilder.AppendFormat("postData: {0}, ", editOptions.PostDataScript);
+                else if (editOptions.PostData != null)
+                {
+                    serializer = new JavaScriptSerializer();
+                    javaScriptBuilder.AppendFormat("postData: {0}, ", serializer.Serialize(editOptions.PostData));
+                }
+
+                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+                {
+                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                    javaScriptBuilder.Append(" }, ");
+                }
+                else
+                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 15, 15);
+            }
+        }
+
+        private void AppendElementOptions(JqGridColumnElementOptions elementOptions, JavaScriptSerializer serializer, StringBuilder javaScriptBuilder)
+        {
+            if (elementOptions.IsBuildSelectSetted)
+                javaScriptBuilder.AppendFormat("buildSelect: {0}, ", elementOptions.BuildSelect);
+
+            if (elementOptions.DataEvents != null && elementOptions.DataEvents.Any())
+            {
+                javaScriptBuilder.Append("dataEvents: [ ");
+                foreach (JqGridColumnDataEvent dataEvent in elementOptions.DataEvents)
+                {
+                    if (dataEvent.Data == null)
+                        javaScriptBuilder.AppendFormat("{{ type: '{0}', fn: {1} }}, ", dataEvent.Type, dataEvent.Function);
+                    else
+                        javaScriptBuilder.AppendFormat("{{ type: '{0}', data: {1}, fn: {2} }}, ", dataEvent.Type, serializer.Serialize(dataEvent.Data), dataEvent.Function);
+                }
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" ], ");
+            }
+
+            if (elementOptions.JQueryUIWidgetDataInitRenderer != null)
+                javaScriptBuilder.AppendFormat("dataInit: {0}, ", elementOptions.JQueryUIWidgetDataInitRenderer(_options.CompatibilityMode, GridSelector));
+            else if (elementOptions.IsDataInitSetted)
+                javaScriptBuilder.AppendFormat("dataInit: {0}, ", elementOptions.DataInit);
+
+            if (elementOptions.IsDataUrlSetted)
+                javaScriptBuilder.AppendFormat("dataUrl: '{0}', ", elementOptions.DataUrl);
+
+            if (elementOptions.IsDefaultValueSetted)
+                javaScriptBuilder.AppendFormat("defaultValue: '{0}', ", elementOptions.DefaultValue);
+
+            if (elementOptions.IsValueSetted)
+                javaScriptBuilder.AppendFormat("value: '{0}', ", elementOptions.Value);
+            else if (elementOptions.ValueDictionary != null)
+                javaScriptBuilder.AppendFormat("value: {0}, ", serializer.Serialize(elementOptions.ValueDictionary));
+        }
+
+        private static void AppendColumnRules(string rulesName, JqGridColumnRules rules, StringBuilder javaScriptBuilder)
+        {
+            if (rules == null) return;
+            javaScriptBuilder.AppendFormat("{0}: {{ ", rulesName);
+
+            if (rules.Custom.HasValue)
+            {
+                javaScriptBuilder.AppendFormat("custom: {0}, ", rules.Custom.Value.ToString().ToLower());
+
+                if (rules.IsCustomFunctionSetted)
+                    javaScriptBuilder.AppendFormat("custom_func: {0}, ", rules.CustomFunction);
+            }
+
+            if (rules.Date.HasValue)
+                javaScriptBuilder.AppendFormat("date: {0}, ", rules.Date.Value.ToString().ToLower());
+
+            if (rules.EditHidden.HasValue)
+                javaScriptBuilder.AppendFormat("edithidden: {0}, ", rules.EditHidden.Value.ToString().ToLower());
+
+            if (rules.Email.HasValue)
+                javaScriptBuilder.AppendFormat("email: {0}, ", rules.Email.Value.ToString().ToLower());
+
+            if (rules.Integer)
+                javaScriptBuilder.Append("integer: true, ");
+
+            if (rules.MaxValue.HasValue)
+                javaScriptBuilder.AppendFormat("maxValue: {0}, ", rules.MaxValue.Value);
+
+            if (rules.MinValue.HasValue)
+                javaScriptBuilder.AppendFormat("minValue: {0}, ", rules.MinValue.Value);
+
+            if (rules.Number)
+                javaScriptBuilder.Append("number: true, ");
+
+            if (rules.Required.HasValue)
+                javaScriptBuilder.AppendFormat("required: {0}, ", rules.Required.Value.ToString().ToLower());
+
+            if (rules.Time.HasValue)
+                javaScriptBuilder.AppendFormat("time: {0}, ", rules.Time.Value.ToString().ToLower());
+
+            if (rules.Url.HasValue)
+                javaScriptBuilder.AppendFormat("url: {0}, ", rules.Url.Value.ToString().ToLower());
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" }, ");
+            }
+            else
+            {
+                int rulesNameLength = rulesName.Length + 4;
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - rulesNameLength, rulesNameLength);
+            }
+        }
+
+        private static void AppendFormOptions(JqGridColumnFormOptions formOptions, StringBuilder javaScriptBuilder)
+        {
+            if (formOptions == null) return;
+            javaScriptBuilder.Append("formoptions: { ");
+
+            if (formOptions.ColumnPosition.HasValue)
+                javaScriptBuilder.AppendFormat("colpos: {0},", formOptions.ColumnPosition.Value);
+
+            if (formOptions.IsElementPrefixSetted)
+                javaScriptBuilder.AppendFormat("elmprefix: '{0}',", formOptions.ElementPrefix);
+
+            if (formOptions.IsElementSuffixSetted)
+                javaScriptBuilder.AppendFormat("elmsuffix: '{0}',", formOptions.ElementSuffix);
+
+            if (formOptions.IsLabelSetted)
+                javaScriptBuilder.AppendFormat("label: '{0}',", formOptions.Label);
+
+            if (formOptions.RowPosition.HasValue)
+                javaScriptBuilder.AppendFormat("rowpos: {0},", formOptions.RowPosition.Value);
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 1] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+                javaScriptBuilder.Append(" }, ");
+            }
+            else
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 15, 15);
+        }
+
+        private static void AppendFormatterOptions(string formatter, JqGridColumnFormatterOptions formatterOptions, StringBuilder javaScriptBuilder)
+        {
+            if (formatterOptions == null || formatterOptions.IsDefault(formatter)) return;
+            javaScriptBuilder.Append("formatoptions: { ");
+
+            switch (formatter)
+            {
+                case JqGridColumnPredefinedFormatters.Integer:
+                    javaScriptBuilder.AppendFormat("{0}{1}", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
+                    break;
+                case JqGridColumnPredefinedFormatters.Number:
+                    javaScriptBuilder.AppendFormat("{0}{1}{2}{3}", !formatterOptions.DecimalPlaces.HasValue ? string.Empty : $"decimalPlaces: {formatterOptions.DecimalPlaces.Value}, ", !formatterOptions.IsDecimalSeparatorSetted ? string.Empty : $"decimalSeparator: '{formatterOptions.DecimalSeparator}', ", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
+                    break;
+                case JqGridColumnPredefinedFormatters.Currency:
+                    javaScriptBuilder.AppendFormat("{0}{1}{2}{3}{4}{5}", !formatterOptions.DecimalPlaces.HasValue ? string.Empty : $"decimalPlaces: {formatterOptions.DecimalPlaces.Value}, ", !formatterOptions.IsDecimalSeparatorSetted ? string.Empty : $"decimalSeparator: '{formatterOptions.DecimalSeparator}', ", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsPrefixSetted ? string.Empty : $"prefix: '{formatterOptions.Prefix}', ", !formatterOptions.IsSuffixSetted ? string.Empty : $"suffix: '{formatterOptions.Suffix}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
+                    break;
+                case JqGridColumnPredefinedFormatters.Date:
+                    javaScriptBuilder.AppendFormat("{0}{1}", !formatterOptions.IsSourceFormatSetted ? string.Empty : $"srcformat: '{formatterOptions.SourceFormat}', ", !formatterOptions.IsOutputFormatSetted ? string.Empty : $"newformat: '{formatterOptions.OutputFormat}', ");
+                    break;
+                case JqGridColumnPredefinedFormatters.Link:
+                    javaScriptBuilder.AppendFormat("target: '{0}', ", formatterOptions.Target);
+                    break;
+                case JqGridColumnPredefinedFormatters.ShowLink:
+                    javaScriptBuilder.AppendFormat("{0}{1}{2}{3}{4}", !formatterOptions.IsBaseLinkUrlSetted ? string.Empty : $"baseLinkUrl: '{formatterOptions.BaseLinkUrl}', ", !formatterOptions.IsShowActionSetted ? string.Empty : $"showAction: '{formatterOptions.ShowAction}', ", !formatterOptions.IsAddParamSetted ? string.Empty : $"addParam: '{formatterOptions.AddParam}', ", !formatterOptions.IsTargetSetted ? string.Empty : $"target: '{formatterOptions.Target}', ", !formatterOptions.IsIdNameSetted ? string.Empty : $"idName: '{formatterOptions.IdName}', ");
+                    break;
+                case JqGridColumnPredefinedFormatters.CheckBox:
+                    javaScriptBuilder.Append("disabled: false, ");
+                    break;
+                case JqGridColumnPredefinedFormatters.Actions:
+                    javaScriptBuilder.AppendFormat("{0}{1}{2}", formatterOptions.EditButton ? string.Empty : "editbutton: false, ", formatterOptions.DeleteButton ? string.Empty : "delbutton: false, ", !formatterOptions.UseFormEditing ? string.Empty : "editformbutton: true, ");
+
+                    if (formatterOptions.EditButton)
+                    {
+                        if (!formatterOptions.UseFormEditing && formatterOptions.InlineEditingOptions != null)
+                        {
+                            if (formatterOptions.InlineEditingOptions.Keys)
+                                javaScriptBuilder.Append("keys: true, ");
+
+                            if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.OnEditFunction))
+                                javaScriptBuilder.AppendFormat("onEdit: {0}, ", formatterOptions.InlineEditingOptions.OnEditFunction);
+
+                            if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.SuccessFunction))
+                                javaScriptBuilder.AppendFormat("onSuccess: {0}, ", formatterOptions.InlineEditingOptions.SuccessFunction);
+
+                            if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.Url))
+                                javaScriptBuilder.AppendFormat("url: '{0}', ", formatterOptions.InlineEditingOptions.Url);
+
+                            if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.ExtraParamScript))
+                                javaScriptBuilder.AppendFormat("extraparam: {0}, ", formatterOptions.InlineEditingOptions.ExtraParamScript);
+                            else if (formatterOptions.InlineEditingOptions.ExtraParam != null)
+                            {
+                                JavaScriptSerializer serializer = new JavaScriptSerializer();
+                                javaScriptBuilder.AppendFormat("extraparam: {0}, ", serializer.Serialize(formatterOptions.InlineEditingOptions.ExtraParam));
+                            }
+
+                            if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.AfterSaveFunction))
+                                javaScriptBuilder.AppendFormat("afterSave: {0}, ", formatterOptions.InlineEditingOptions.AfterSaveFunction);
+
+                            if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.ErrorFunction))
+                                javaScriptBuilder.AppendFormat("onError: {0}, ", formatterOptions.InlineEditingOptions.ErrorFunction);
+
+                            if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.AfterRestoreFunction))
+                                javaScriptBuilder.AppendFormat("afterRestore: {0}, ", formatterOptions.InlineEditingOptions.AfterRestoreFunction);
+
+                            if (!formatterOptions.InlineEditingOptions.RestoreAfterError)
+                                javaScriptBuilder.Append("restoreAfterError: false, ");
+
+                            if (formatterOptions.InlineEditingOptions.MethodType != JqGridMethodTypes.Post)
+                                javaScriptBuilder.Append("mtype: 'GET', ");
+                        }
+                        else if (formatterOptions.UseFormEditing && formatterOptions.FormEditingOptions != null)
+                            AppendNavigatorActionOptions("editOptions: ", formatterOptions.FormEditingOptions, javaScriptBuilder);
+                    }
+
+                    if (formatterOptions.DeleteButton && formatterOptions.DeleteOptions != null)
+                        AppendNavigatorActionOptions("delOptions: ", formatterOptions.DeleteOptions, javaScriptBuilder);
+                    break;
+            }
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" }, ");
+            }
+            else
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 17, 17);
+        }
+
+        private void AppendSearchOptions(JqGridColumnSearchOptions searchOptions, StringBuilder javaScriptBuilder)
+        {
+            if (searchOptions == null) return;
+            JavaScriptSerializer serializer = new JavaScriptSerializer();
+            javaScriptBuilder.Append("searchoptions: { ");
+
+            AppendElementOptions(searchOptions, serializer, javaScriptBuilder);
+
+            if (searchOptions.HtmlAttributes != null && searchOptions.HtmlAttributes.Count > 0)
+                javaScriptBuilder.AppendFormat("attr: {0}, ", serializer.Serialize(searchOptions.HtmlAttributes));
+
+            if (searchOptions.ClearSearch.HasValue)
+                javaScriptBuilder.AppendFormat("clearSearch: {0}, ", searchOptions.ClearSearch.Value.ToString().ToLower());
+
+            if (searchOptions.SearchHidden.HasValue)
+                javaScriptBuilder.AppendFormat("searchhidden: {0}, ", searchOptions.SearchHidden.Value.ToString().ToLower());
+
+            AppendSearchOperators(searchOptions.SearchOperators, javaScriptBuilder);
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" }, ");
+            }
+            else
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 17, 17);
+        }
+
+        private static void AppendSearchOperators(JqGridSearchOperators? searchOperators, StringBuilder javaScriptBuilder)
+        {
+            if (searchOperators.HasValue && searchOperators.Value != JqGridSearchOperators.Default)
+            {
+                javaScriptBuilder.Append("sopt: [ ");
+                foreach (JqGridSearchOperators searchOperator in Enum.GetValues(typeof(JqGridSearchOperators)))
+                {
+                    if (searchOperator == JqGridSearchOperators.Default) continue;
+                    if (searchOperator != JqGridSearchOperators.EqualOrNotEqual && searchOperator != JqGridSearchOperators.NoTextOperators && searchOperator != JqGridSearchOperators.TextOperators && (searchOperators.Value & searchOperator) == searchOperator)
+                        javaScriptBuilder.AppendFormat("'{0}',", Enum.GetName(typeof(JqGridSearchOperators), searchOperator).ToLower());
+                }
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+                javaScriptBuilder.Append("], ");
+            }
+        }
+
+        private void AppendOptions(StringBuilder javaScriptBuilder)
+        {
+            if (_options.IsAfterInsertRowSetted)
+                javaScriptBuilder.AppendFormat("afterInsertRow: {0},", _options.AfterInsertRow.ToNullString()).AppendLine();
+
+            if (_options.IsAfterEditCellSetted)
+                javaScriptBuilder.AppendFormat("afterEditCell: {0},", _options.AfterEditCell.ToNullString()).AppendLine();
+
+            if (_options.IsAfterRestoreCellSetted)
+                javaScriptBuilder.AppendFormat("afterRestoreCell: {0},", _options.AfterRestoreCell.ToNullString()).AppendLine();
+
+            if (_options.IsAfterSaveCellSetted)
+                javaScriptBuilder.AppendFormat("afterSaveCell: {0},", _options.AfterSaveCell.ToNullString()).AppendLine();
+
+            if (_options.IsAfterSumbitCellSetted)
+                javaScriptBuilder.AppendFormat("afterSubmitCell: {0},", _options.AfterSubmitCell.ToNullString()).AppendLine();
+
+            if (_options.IsAltClassSetted)
+                javaScriptBuilder.AppendFormat("altclass: '{0}',", _options.AltClass.ToNullString()).AppendLine();
+
+            if (_options.AltRows.HasValue)
+                javaScriptBuilder.AppendFormat("altRows: {0},", _options.AltRows.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.AutoEncode.HasValue)
+                javaScriptBuilder.AppendFormat("autoencode: {0},", _options.AutoEncode.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.AutoWidth.HasValue)
+                javaScriptBuilder.AppendFormat("autowidth: {0},", _options.AutoWidth.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.IsBeforeRequestSetted)
+                javaScriptBuilder.AppendFormat("beforeRequest: {0},", _options.BeforeRequest.ToNullString()).AppendLine();
+
+            if (_options.IsBeforeSelectRowSetted)
+                javaScriptBuilder.AppendFormat("beforeSelectRow: {0},", _options.BeforeSelectRow.ToNullString()).AppendLine();
+
+            if (_options.IsBeforeEditCellSetted)
+                javaScriptBuilder.AppendFormat("beforeEditCell: {0},", _options.BeforeEditCell.ToNullString()).AppendLine();
+
+            if (_options.IsBeforeSaveCellSetted)
+                javaScriptBuilder.AppendFormat("beforeSaveCell: {0},", _options.BeforeSaveCell.ToNullString()).AppendLine();
+
+            if (_options.IsBeforeSubmitCellSetted)
+                javaScriptBuilder.AppendFormat("beforeSubmitCell: {0},", _options.BeforeSubmitCell.ToNullString()).AppendLine();
+
+            if (_options.IsBeforeProcessingSetted)
+                javaScriptBuilder.AppendFormat("beforeProcessing: {0},", _options.BeforeProcessing.ToNullString()).AppendLine();
+
+            if (_options.CellLayout.HasValue)
+                javaScriptBuilder.AppendFormat("cellLayout: {0},", _options.CellLayout.Value).AppendLine();
+
+            if (_options.CellEditingEnabled.HasValue)
+            {
+                javaScriptBuilder.AppendFormat("cellEdit: {0},", _options.CellEditingEnabled.Value.ToString().ToLower()).AppendLine();
+                if (_options.CellEditingEnabled.Value)
+                {
+                    if (_options.CellEditingSubmitMode != JqGridCellEditingSubmitModes.Default)
+                        javaScriptBuilder.AppendFormat("cellsubmit: '{0}',", _options.CellEditingSubmitMode).AppendLine();
+
+                    if (_options.IsCellEditingUrlSetted)
+                        javaScriptBuilder.AppendFormat("cellurl: '{0}',", _options.CellEditingUrl.ToNullString()).AppendLine();
+                }
+            }
+
+            if (_options.IsCaptionSetted)
+                javaScriptBuilder.AppendFormat("caption: '{0}',", _options.Caption.ToNullString()).AppendLine();
+
+            if (_options.HiddenEnabled.HasValue)
+                javaScriptBuilder.AppendFormat("hidegrid: {0},", _options.HiddenEnabled.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.Hidden.HasValue)
+                javaScriptBuilder.AppendFormat("hiddengrid: {0},", _options.Hidden.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.IsUsedDataString)
+                javaScriptBuilder.AppendFormat("datastr: '{0}',", _options.DataString).AppendLine();
+            else if (_asSubgrid)
+            {
+                if (_options.Url.Contains("?"))
+                    javaScriptBuilder.AppendFormat("url: '{0}&id=' + encodeURIComponent(rowId),", _options.Url).AppendLine();
+                else
+                    javaScriptBuilder.AppendFormat("url: '{0}?id=' + encodeURIComponent(rowId),", _options.Url).AppendLine();
+            }
+            else
+                javaScriptBuilder.AppendFormat("url: '{0}',", _options.Url).AppendLine();
+
+            if (_options.DataType != JqGridDataTypes.Default)
+                javaScriptBuilder.AppendFormat("datatype: '{0}',", _options.DataType.ToString().ToLower()).AppendLine();
+
+            if (_options.DeepEmpty.HasValue)
+                javaScriptBuilder.AppendFormat("deepempty: {0},", _options.DeepEmpty.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.Direction != JqGridLanguageDirections.Default)
+                javaScriptBuilder.AppendFormat("direction: '{0}',", _options.Direction.ToString().ToLower()).AppendLine();
+
+            if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.Disabled)
+                javaScriptBuilder.Append("scroll: false,").AppendLine();
+            else if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldAllRows)
+                javaScriptBuilder.Append("scroll: true,").AppendLine();
+            else if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldVisibleRows)
+            {
+                javaScriptBuilder.Append("scroll: 10,").AppendLine();
+                if (_options.DynamicScrollingTimeout.HasValue)
+                    javaScriptBuilder.AppendFormat("scrollTimeout: {0},", _options.DynamicScrollingTimeout.Value).AppendLine();
+            }
+
+            if (_options.IsEmptyRecordsSetted)
+                javaScriptBuilder.AppendFormat("emptyrecords: '{0}',", _options.EmptyRecords.ToNullString()).AppendLine();
+
+            if (_options.IsEditingUrlSetted)
+                javaScriptBuilder.AppendFormat("editurl: '{0}',", _options.EditingUrl.ToNullString()).AppendLine();
+
+            if (_options.IsErrorCellSetted)
+                javaScriptBuilder.AppendFormat("errorCell: {0},", _options.ErrorCell.ToNullString()).AppendLine();
+
+            if (_options.IsFormatCellSetted)
+                javaScriptBuilder.AppendFormat("formatCell: {0},", _options.FormatCell.ToNullString()).AppendLine();
+
+            if (_options.FooterEnabled.HasValue)
+                javaScriptBuilder.AppendFormat("footerrow: {0},", _options.FooterEnabled.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.UserDataOnFooter.HasValue)
+                javaScriptBuilder.AppendFormat("userDataOnFooter: {0},", _options.UserDataOnFooter.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.GridView.HasValue)
+                javaScriptBuilder.AppendFormat("gridview: {0},", _options.GridView.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.GroupingEnabled.HasValue)
+            {
+                javaScriptBuilder.AppendFormat("grouping: {0},", _options.GroupingEnabled.Value.ToString().ToLower()).AppendLine();
+                if (_options.GroupingEnabled.Value)
+                    AppendGroupingView(javaScriptBuilder);
+            }
+
+            if (_options.HeaderTitles.HasValue)
+                javaScriptBuilder.AppendFormat("headertitles: {0},", _options.HeaderTitles.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.HoverRows.HasValue)
+                javaScriptBuilder.AppendFormat("hoverrows: {0},", _options.HoverRows.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.IgnoreCase.HasValue)
+                javaScriptBuilder.AppendFormat("ignoreCase: {0},", _options.IgnoreCase.Value.ToString().ToLower()).AppendLine();
+
+            AppendJsonReader(javaScriptBuilder);
+
+            if (_options.IsLoadBeforeSendSetted)
+                javaScriptBuilder.AppendFormat("loadBeforeSend: {0},", _options.LoadBeforeSend.ToNullString()).AppendLine();
+
+            if (_options.IsLoadCompleteSetted)
+                javaScriptBuilder.AppendFormat("loadComplete: {0},", _options.LoadComplete.ToNullString()).AppendLine();
+
+            if (_options.IsLoadErrorSetted)
+                javaScriptBuilder.AppendFormat("loadError: {0},", _options.LoadError.ToNullString()).AppendLine();
+
+            if (_options.LoadOnce.HasValue)
+                javaScriptBuilder.AppendFormat("loadonce: {0},", _options.LoadOnce.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.MethodType != JqGridMethodTypes.Default)
+                javaScriptBuilder.AppendFormat("mtype: '{0}',", _options.MethodType.ToString().ToUpper()).AppendLine();
+
+            if (_options.MultiKey != JqGridMultiKeys.Default)
+                if (_options.MultiKey == JqGridMultiKeys.Disable)
+                    javaScriptBuilder.Append("multikey: null,").AppendLine();
+                else
+                    javaScriptBuilder.AppendFormat("multikey: '{0}Key',", _options.MultiKey.ToString().ToLower()).AppendLine();
+
+            if (_options.MultiBoxOnly.HasValue)
+                javaScriptBuilder.AppendFormat("multiboxonly: {0},", _options.MultiBoxOnly.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.MultiSelect.HasValue)
+                javaScriptBuilder.AppendFormat("multiselect: {0},", _options.MultiSelect.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.MultiSelectWidth.HasValue)
+                javaScriptBuilder.AppendFormat("multiselectWidth: {0},", _options.MultiSelectWidth.Value).AppendLine();
+
+            if (_options.MultiSort.HasValue)
+                javaScriptBuilder.AppendFormat("multiSort: {0},", _options.MultiSort.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.IsGridCompleteSetted)
+                javaScriptBuilder.AppendFormat("gridComplete: {0},", _options.GridComplete.ToNullString()).AppendLine();
+
+            if (_options.IsOnCellSelectSetted)
+                javaScriptBuilder.AppendFormat("onCellSelect: {0},", _options.OnCellSelect.ToNullString()).AppendLine();
+
+            if (_options.IsOnDoubleClickRowSetted)
+                javaScriptBuilder.AppendFormat("ondblClickRow: {0},", _options.OnDoubleClickRow.ToNullString()).AppendLine();
+
+            if (_options.IsOnHeaderClickSetted)
+                javaScriptBuilder.AppendFormat("onHeaderClick: {0},", _options.OnHeaderClick.ToNullString()).AppendLine();
+
+            if (_options.IsOnInitGridSetted)
+                javaScriptBuilder.AppendFormat("onInitGrid: {0},", _options.OnInitGrid.ToNullString()).AppendLine();
+
+            if (_options.IsOnPagingSetted)
+                javaScriptBuilder.AppendFormat("onPaging: {0},", _options.OnPaging.ToNullString()).AppendLine();
+
+            if (_options.IsOnRightClickRowSetted)
+                javaScriptBuilder.AppendFormat("onRightClickRow: {0},", _options.OnRightClickRow.ToNullString()).AppendLine();
+
+            if (_options.IsOnSelectAllSetted)
+                javaScriptBuilder.AppendFormat("onSelectAll: {0},", _options.OnSelectAll.ToNullString()).AppendLine();
+
+            if (_options.IsOnSelectCellSetted)
+                javaScriptBuilder.AppendFormat("onSelectCell: {0},", _options.OnSelectCell.ToNullString()).AppendLine();
+
+            if (_options.IsOnSelectRowSetted)
+                javaScriptBuilder.AppendFormat("onSelectRow: {0},", _options.OnSelectRow.ToNullString()).AppendLine();
+
+            if (_options.IsOnSortColSetted)
+                javaScriptBuilder.AppendFormat("onSortCol: {0},", _options.OnSortCol.ToNullString()).AppendLine();
+
+            if (_options.Pager)
+                javaScriptBuilder.AppendFormat("pager: {0},", PagerSelector).AppendLine();
+
+            AppendParametersNames(javaScriptBuilder);
+
+            if (_options.IsPostDataScriptSetted)
+                javaScriptBuilder.AppendFormat("postData: {0},", string.IsNullOrWhiteSpace(_options.PostDataScript) ? "{}" : _options.PostDataScript).AppendLine();
+            else if (_options.IsPostDataSetted)
+            {
+                JavaScriptSerializer serializer = new JavaScriptSerializer();
+                if (_options.PostData == null)
+                    javaScriptBuilder.Append("postData: {},");
+                else
+                    javaScriptBuilder.AppendFormat("postData: {0},", serializer.Serialize(_options.PostData));
+            }
+
+            if (_options.IsResizeStartSetted)
+                javaScriptBuilder.AppendFormat("resizeStart: {0},", _options.ResizeStart.ToNullString()).AppendLine();
+
+            if (_options.IsResizeStopSetted)
+                javaScriptBuilder.AppendFormat("resizeStop: {0},", _options.ResizeStop.ToNullString()).AppendLine();
+
+            if (_options.IsRowAttributesSetted)
+                javaScriptBuilder.AppendFormat("rowattr: {0},", _options.RowAttributes.ToNullString()).AppendLine();
+
+            if (_options.RowsList != null && _options.RowsList.Any())
+            {
+                javaScriptBuilder.Append("rowList: [");
+                javaScriptBuilder.Append(string.Join(",", _options.RowsList));
+                javaScriptBuilder.Append("],").AppendLine();
+            }
+
+            if (_options.RowsNumber.HasValue)
+                javaScriptBuilder.AppendFormat("rowNum: {0},", _options.RowsNumber.Value).AppendLine();
+
+            if (_options.RowsNumbers.HasValue)
+                javaScriptBuilder.AppendFormat("rownumbers: {0},", _options.RowsNumbers.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.RowsNumbersWidth.HasValue)
+                javaScriptBuilder.AppendFormat("rownumWidth: {0},", _options.RowsNumbersWidth.Value).AppendLine();
+
+            if (_options.ColumnsRemaping != null && _options.ColumnsRemaping.Any())
+            {
+                javaScriptBuilder.Append("remapColumns: [");
+                javaScriptBuilder.Append(string.Join(",", _options.ColumnsRemaping));
+                javaScriptBuilder.Append("],").AppendLine();
+            }
+
+            if (_options.ShrinkToFit.HasValue)
+                javaScriptBuilder.AppendFormat("shrinkToFit: {0},", _options.ShrinkToFit.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.ScrollOffset.HasValue)
+                javaScriptBuilder.AppendFormat("scrollOffset: {0},", _options.ScrollOffset.Value).AppendLine();
+
+            if (_options.IsSerializeCellDataSetted)
+                javaScriptBuilder.AppendFormat("serializeCellData: {0},", _options.SerializeCellData.ToNullString()).AppendLine();
+
+            if (_options.IsSerializeGridDataSetted)
+                javaScriptBuilder.AppendFormat("serializeGridData: {0},", _options.SerializeGridData.ToNullString()).AppendLine();
+
+            if (_options.IsSerializeSubGridDataSetted)
+                javaScriptBuilder.AppendFormat("serializeSubGridData: {0},", _options.SerializeSubGridData.ToNullString()).AppendLine();
+
+            if (_options.Sortable.HasValue)
+                javaScriptBuilder.AppendFormat("sortable: {0},", _options.Sortable.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.IsSortingNameSetted)
+                javaScriptBuilder.AppendFormat("sortname: '{0}',", _options.SortingName.ToNullString()).AppendLine();
+
+            if (_options.SortingOrder != JqGridSortingOrders.Default)
+                javaScriptBuilder.AppendFormat("sortorder: '{0}',", _options.SortingOrder.ToString().ToLower()).AppendLine();
+
+            if (_options.StyleUI != JqGridStyleUIOptions.Default)
+                javaScriptBuilder.AppendFormat("styleUI: '{0}',", _options.StyleUI.ToString()).AppendLine();
+
+            if (_options.IconSet != JqGridBootstrap4IconSet.Default)
+                javaScriptBuilder.AppendFormat("iconSet: '{0}',", _options.IconSet);
+
+            if (_options.SubgridEnabled.HasValue)
+            {
+                javaScriptBuilder.AppendFormat("subGrid: {0},", _options.SubgridEnabled.Value.ToString().ToLower()).AppendLine();
+
+                if (_options.SubgridColumnWidth.HasValue)
+                    javaScriptBuilder.AppendFormat("subGridWidth: {0},", _options.SubgridColumnWidth.Value).AppendLine();
+
+                if (_options.IsSubGridBeforeExpandSetted)
+                    javaScriptBuilder.AppendFormat("subGridBeforeExpand: {0},", _options.SubGridBeforeExpand.ToNullString()).AppendLine();
+
+                if (_subgridHelper != null)
+                {
+                    Type subgridHelperType = _subgridHelper.GetType();
+                    javaScriptBuilder.AppendFormat("subGridRowExpanded: {0},", subgridHelperType.GetMethod("GetSubGridRowExpanded", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).Invoke(_subgridHelper, null)).AppendLine();
+                }
+                else
+                {
+                    AppendSubgridModel(javaScriptBuilder);
+
+                    if (_options.IsSubgridUrlSetted)
+                        javaScriptBuilder.AppendFormat("subGridUrl: '{0}',", _options.SubgridUrl.ToNullString()).AppendLine();
+
+
+                    if (_options.IsSubGridRowExpandedSetted)
+                        javaScriptBuilder.AppendFormat("subGridRowExpanded: {0},", _options.SubGridRowExpanded.ToNullString()).AppendLine();
+                }
+
+                if (_options.IsSubGridRowColapsedSetted)
+                    javaScriptBuilder.AppendFormat("subGridRowColapsed: {0},", _options.SubGridRowColapsed.ToNullString()).AppendLine();
+            }
+
+            if (_options.TopPager.HasValue)
+                javaScriptBuilder.AppendFormat("toppager: {0},", _options.TopPager.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.TreeGridEnabled.HasValue)
+            {
+                javaScriptBuilder.AppendFormat("treeGrid: {0},", _options.TreeGridEnabled.Value.ToString().ToLower()).AppendLine();
+                if (_options.TreeGridEnabled.Value)
+                {
+
+                    if (_options.ExpandColumnClick.HasValue)
+                        javaScriptBuilder.AppendFormat("ExpandColClick: {0},", _options.ExpandColumnClick.Value.ToString().ToLower()).AppendLine();
+
+                    if (_options.IsExpandColumnSetted)
+                        javaScriptBuilder.AppendFormat("ExpandColumn: '{0}',", _options.ExpandColumn.ToNullString()).AppendLine();
+
+                    if (_options.TreeGridModel != JqGridTreeGridModels.Default)
+                        javaScriptBuilder.AppendFormat("treeGridModel: '{0}',", _options.TreeGridModel.ToString().ToLower()).AppendLine();
+                }
+            }
+
+            if (_options.ViewRecords.HasValue)
+                javaScriptBuilder.AppendFormat("viewrecords: {0},", _options.ViewRecords.Value.ToString().ToLower()).AppendLine();
+
+            if (_options.Width.HasValue)
+                javaScriptBuilder.AppendFormat("width: {0},", _options.Width.Value).AppendLine();
+
+            if (_options.Height.HasValue)
+                javaScriptBuilder.AppendFormat("height: {0}", _options.Height.Value).AppendLine();
+            else
+                javaScriptBuilder.AppendLine("height: '100%'");
+        }
+
+        private void AppendJsonReader(StringBuilder javaScriptBuilder)
+        {
+            if (_options.JsonReader == null || _options.JsonReader.IsGlobal) return;
+            javaScriptBuilder.Append("jsonReader: { ");
+
+            if (_options.JsonReader.Records != JqGridResponse.JsonReader.Records)
+                javaScriptBuilder.AppendFormat("root: '{0}', ", _options.JsonReader.Records);
+
+            if (_options.JsonReader.PageIndex != JqGridResponse.JsonReader.PageIndex)
+                javaScriptBuilder.AppendFormat("page: '{0}', ", _options.JsonReader.PageIndex);
+
+            if (_options.JsonReader.TotalPagesCount != JqGridResponse.JsonReader.TotalPagesCount)
+                javaScriptBuilder.AppendFormat("total: '{0}', ", _options.JsonReader.TotalPagesCount);
+
+            if (_options.JsonReader.TotalRecordsCount != JqGridResponse.JsonReader.TotalRecordsCount)
+                javaScriptBuilder.AppendFormat("records: '{0}', ", _options.JsonReader.TotalRecordsCount);
+
+            if (_options.JsonReader.RepeatItems != JqGridResponse.JsonReader.RepeatItems)
+                javaScriptBuilder.AppendFormat("repeatitems: {0}, ", _options.JsonReader.RepeatItems.ToString().ToLower());
+
+            if (_options.JsonReader.RecordValues != JqGridOptionsDefaults.ResponseRecordValues)
+                javaScriptBuilder.AppendFormat("cell: '{0}', ", _options.JsonReader.RecordValues);
+
+            if (_options.JsonReader.RecordId != JqGridResponse.JsonReader.RecordId)
+                javaScriptBuilder.AppendFormat("id: '{0}', ", _options.JsonReader.RecordId);
+
+            if (_options.JsonReader.UserData != JqGridResponse.JsonReader.UserData)
+                javaScriptBuilder.AppendFormat("userdata: '{0}', ", _options.JsonReader.UserData);
+
+            if (!_options.JsonReader.SubgridReader.IsGlobal)
+            {
+                javaScriptBuilder.Append("subgrid: { ");
+
+                if (_options.JsonReader.SubgridReader.Records != JqGridResponse.JsonReader.SubgridReader.Records)
+                    javaScriptBuilder.AppendFormat("root: '{0}', ", _options.JsonReader.SubgridReader.Records);
+
+                if (_options.JsonReader.SubgridReader.RepeatItems != JqGridResponse.JsonReader.SubgridReader.RepeatItems)
+                    javaScriptBuilder.AppendFormat("repeatitems: {0}, ", _options.JsonReader.SubgridReader.RepeatItems.ToString().ToLower());
+
+                if (_options.JsonReader.SubgridReader.RecordValues != JqGridResponse.JsonReader.SubgridReader.RecordValues)
+                    javaScriptBuilder.AppendFormat("cell: '{0}', ", _options.JsonReader.SubgridReader.RecordValues);
+
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" }, ");
+            }
+
+            javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+            javaScriptBuilder.Append(" }, ").AppendLine();
+        }
+
+        private void AppendParametersNames(StringBuilder javaScriptBuilder)
+        {
+            if (_options.ParametersNames == null || _options.ParametersNames.IsGlobal) return;
+            javaScriptBuilder.Append("prmNames: { ");
+
+            if (_options.ParametersNames.PageIndex != JqGridRequest.ParameterNames.PageIndex)
+                javaScriptBuilder.AppendFormat("page: '{0}', ", _options.ParametersNames.PageIndex);
+
+            if (_options.ParametersNames.RecordsCount != JqGridRequest.ParameterNames.RecordsCount)
+                javaScriptBuilder.AppendFormat("rows: '{0}', ", _options.ParametersNames.RecordsCount);
+
+            if (_options.ParametersNames.SortingName != JqGridRequest.ParameterNames.SortingName)
+                javaScriptBuilder.AppendFormat("sort: '{0}', ", _options.ParametersNames.SortingName);
+
+            if (_options.ParametersNames.SortingOrder != JqGridRequest.ParameterNames.SortingOrder)
+                javaScriptBuilder.AppendFormat("order: '{0}', ", _options.ParametersNames.SortingOrder);
+
+            if (_options.ParametersNames.Searching != JqGridRequest.ParameterNames.Searching)
+                javaScriptBuilder.AppendFormat("search: '{0}', ", _options.ParametersNames.Searching);
+
+            if (_options.ParametersNames.Id != JqGridRequest.ParameterNames.Id)
+                javaScriptBuilder.AppendFormat("id: '{0}', ", _options.ParametersNames.Id);
+
+            if (_options.ParametersNames.Operator != JqGridRequest.ParameterNames.Operator)
+                javaScriptBuilder.AppendFormat("oper: '{0}', ", _options.ParametersNames.Operator);
+
+            if (_options.ParametersNames.EditOperator != JqGridRequest.ParameterNames.EditOperator)
+                javaScriptBuilder.AppendFormat("editoper: '{0}', ", _options.ParametersNames.EditOperator);
+
+            if (_options.ParametersNames.AddOperator != JqGridRequest.ParameterNames.AddOperator)
+                javaScriptBuilder.AppendFormat("addoper: '{0}', ", _options.ParametersNames.AddOperator);
+
+            if (_options.ParametersNames.DeleteOperator != JqGridRequest.ParameterNames.DeleteOperator)
+                javaScriptBuilder.AppendFormat("deloper: '{0}', ", _options.ParametersNames.DeleteOperator);
+
+            if (_options.ParametersNames.SubgridId != JqGridRequest.ParameterNames.SubgridId)
+                javaScriptBuilder.AppendFormat("subgridid: '{0}', ", _options.ParametersNames.SubgridId);
+
+            if (_options.ParametersNames.PagesCount != JqGridRequest.ParameterNames.PagesCount)
+                javaScriptBuilder.AppendFormat("npage: '{0}', ", _options.ParametersNames.PagesCount);
+
+            if (_options.ParametersNames.TotalRows != JqGridRequest.ParameterNames.TotalRows)
+                javaScriptBuilder.AppendFormat("totalrows: '{0}', ", _options.ParametersNames.TotalRows);
+
+            javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+            javaScriptBuilder.Append(" }, ").AppendLine();
+        }
+
+        private void AppendGroupingView(StringBuilder javaScriptBuilder)
+        {
+            if (_options.GroupingView == null) return;
+            javaScriptBuilder.Append("groupingView: { ");
+
+            if (_options.GroupingView.Fields != null && _options.GroupingView.Fields.Length > 0)
+            {
+                javaScriptBuilder.Append("groupField: [");
+                foreach (string field in _options.GroupingView.Fields)
+                    javaScriptBuilder.AppendFormat("'{0}', ", field);
+                javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+            }
+
+            if (_options.GroupingView.Orders != null && _options.GroupingView.Orders.Length > 0 && _options.GroupingView.Orders.Contains(JqGridSortingOrders.Desc))
+            {
+                javaScriptBuilder.Append("groupOrder: [");
+                foreach (JqGridSortingOrders order in _options.GroupingView.Orders)
+                    javaScriptBuilder.AppendFormat("'{0}', ", order.ToString().ToLower());
+                javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+            }
+
+            if (_options.GroupingView.Texts != null && _options.GroupingView.Texts.Length > 0)
+            {
+                javaScriptBuilder.Append("groupText: [");
+                foreach (string text in _options.GroupingView.Texts)
+                    javaScriptBuilder.AppendFormat("'{0}', ", text);
+                javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+            }
+
+            if (_options.GroupingView.Summary != null && _options.GroupingView.Summary.Length > 0 && _options.GroupingView.Summary.Contains(true))
+            {
+                javaScriptBuilder.Append("groupSummary: [");
+                foreach (bool summary in _options.GroupingView.Summary)
+                    javaScriptBuilder.AppendFormat("{0}, ", summary.ToString().ToLower());
+                javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+            }
+
+            if (_options.GroupingView.ColumnShow != null && _options.GroupingView.ColumnShow.Length > 0 && _options.GroupingView.ColumnShow.Contains(false))
+            {
+                javaScriptBuilder.Append("groupColumnShow: [");
+                foreach (bool columnShow in _options.GroupingView.ColumnShow)
+                    javaScriptBuilder.AppendFormat("{0}, ", columnShow.ToString().ToLower());
+                javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+            }
+
+            if (_options.GroupingView.IsInTheSameGroupCallbacks != null && _options.GroupingView.IsInTheSameGroupCallbacks.Length > 0)
+            {
+                javaScriptBuilder.Append("isInTheSameGroup: [");
+                foreach (string isInTheSameGroupCallback in _options.GroupingView.IsInTheSameGroupCallbacks)
+                    javaScriptBuilder.AppendFormat("{0}, ", isInTheSameGroupCallback);
+                javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+            }
+
+            if (_options.GroupingView.FormatDisplayFieldCallbacks != null && _options.GroupingView.FormatDisplayFieldCallbacks.Length > 0)
+            {
+                javaScriptBuilder.Append("formatDisplayField: [");
+                foreach (string formatDisplayFieldCallback in _options.GroupingView.FormatDisplayFieldCallbacks)
+                    javaScriptBuilder.AppendFormat("{0}, ", formatDisplayFieldCallback);
+                javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+            }
+
+            if (_options.GroupingView.SummaryOnHide)
+                javaScriptBuilder.Append("showSummaryOnHide: true, ");
+
+            if (_options.GroupingView.DataSorted)
+                javaScriptBuilder.Append("groupDataSorted: true, ");
+
+            if (_options.GroupingView.Collapse)
+                javaScriptBuilder.Append("groupCollapse: true, ");
+
+            if (_options.GroupingView.PlusIcon != JqGridOptionsDefaults.GroupingPlusIcon)
+                javaScriptBuilder.AppendFormat("plusicon: '{0}', ", _options.GroupingView.PlusIcon);
+
+            if (_options.GroupingView.MinusIcon != JqGridOptionsDefaults.GroupingMinusIcon)
+                javaScriptBuilder.AppendFormat("minusicon: '{0}', ", _options.GroupingView.MinusIcon);
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" }, ").AppendLine();
+            }
+            else
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 16, 16);
+        }
+
+        private void AppendSubgridModel(StringBuilder javaScriptBuilder)
+        {
+            if (_options.SubgridModel == null) return;
+            javaScriptBuilder.AppendLine("subGridModel: [{ ");
+
+            javaScriptBuilder.Append("name: [");
+            foreach (string columnName in _options.SubgridModel.ColumnsNames)
+                javaScriptBuilder.AppendFormat("'{0}',", columnName);
+            if (_options.SubgridModel.ColumnsNames.Any())
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+            javaScriptBuilder.AppendLine("],");
+
+            javaScriptBuilder.Append("align: [");
+            foreach (JqGridAlignments alignments in _options.SubgridModel.ColumnsAlignments)
+            {
+                JqGridAlignments align = alignments == JqGridAlignments.Default ? JqGridAlignments.Left : alignments;
+                javaScriptBuilder.AppendFormat("'{0}',", align.ToString().ToLower());
+            }
+
+            if (_options.SubgridModel.ColumnsAlignments.Any())
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+            javaScriptBuilder.AppendLine("],");
+
+            javaScriptBuilder.Append("width: [");
+            foreach (int width in _options.SubgridModel.ColumnsWidths)
+                javaScriptBuilder.AppendFormat("{0},", width);
+            if (_options.SubgridModel.ColumnsWidths.Any())
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+            javaScriptBuilder.AppendLine("]");
+
+            javaScriptBuilder.AppendLine(" }],");
+        }
+
+        private void AppendNavigator(StringBuilder javaScriptBuilder)
+        {
+            string navigatorPagerSelector = _navigatorOptions.Pager == JqGridNavigatorPagers.Top ? TopPagerSelector : PagerSelector;
+            javaScriptBuilder.AppendFormat(".jqGrid('navGrid', {0},", navigatorPagerSelector).AppendLine();
+            AppendNavigatorOptions(javaScriptBuilder);
+
+            if (_navigatorEditActionOptions != null || _navigatorAddActionOptions != null || _navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
+            {
+                javaScriptBuilder.AppendLine(",");
+                AppendNavigatorActionOptions(string.Empty, _navigatorEditActionOptions, javaScriptBuilder);
+                if (_navigatorAddActionOptions != null || _navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
+                {
+                    javaScriptBuilder.AppendLine(",");
+                    AppendNavigatorActionOptions(string.Empty, _navigatorAddActionOptions, javaScriptBuilder);
+                    if (_navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
+                    {
+                        javaScriptBuilder.AppendLine(",");
+                        AppendNavigatorActionOptions(string.Empty, _navigatorDeleteActionOptions, javaScriptBuilder);
+                        if (_navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
+                        {
+                            javaScriptBuilder.AppendLine(",");
+                            AppendNavigatorActionOptions(string.Empty, _navigatorSearchActionOptions, javaScriptBuilder);
+                            if (_navigatorViewActionOptions != null)
+                            {
+                                javaScriptBuilder.AppendLine(",");
+                                AppendNavigatorActionOptions(string.Empty, _navigatorViewActionOptions, javaScriptBuilder);
+                            }
+                        }
+                    }
+                }
+            }
+
+            javaScriptBuilder.Append(")");
+
+            foreach (JqGridNavigatorControlOptions controlOptions in _navigatorControlsOptions)
+            {
+                if (controlOptions is JqGridNavigatorButtonOptions buttonOptions)
+                {
+                    AppendNavigatorButton(navigatorPagerSelector, buttonOptions, javaScriptBuilder);
+                    if (_navigatorOptions.Pager == JqGridNavigatorPagers.Standard && controlOptions.CloneToTop)
+                        AppendNavigatorButton(TopPagerSelector, buttonOptions, javaScriptBuilder);
+                }
+                else if (controlOptions is JqGridNavigatorSeparatorOptions separatorOptions)
+                {
+                    AppendNavigatorSeparator(navigatorPagerSelector, separatorOptions, javaScriptBuilder);
+                    if (_navigatorOptions.Pager == JqGridNavigatorPagers.Standard && controlOptions.CloneToTop)
+                        AppendNavigatorSeparator(TopPagerSelector, separatorOptions, javaScriptBuilder);
+                }
+            }
+        }
+
+        private static void AppendBaseNavigatorOptions(JqGridNavigatorOptionsBase baseNavigatorOptions, StringBuilder javaScriptBuilder)
+        {
+            if (!baseNavigatorOptions.Add)
+                javaScriptBuilder.Append("add: false, ");
+
+            if (baseNavigatorOptions.AddIcon != JqGridNavigatorDefaults.AddIcon)
+                javaScriptBuilder.AppendFormat("addicon: '{0}', ", baseNavigatorOptions.AddIcon);
+
+            if (!string.IsNullOrEmpty(baseNavigatorOptions.AddText))
+                javaScriptBuilder.AppendFormat("addtext: '{0}', ", baseNavigatorOptions.AddText);
+
+            if (baseNavigatorOptions.AddToolTip != JqGridNavigatorDefaults.AddToolTip)
+                javaScriptBuilder.AppendFormat("addtitle: '{0}', ", baseNavigatorOptions.AddToolTip);
+
+            if (!baseNavigatorOptions.Edit)
+                javaScriptBuilder.Append("edit: false, ");
+
+            if (baseNavigatorOptions.EditIcon != JqGridNavigatorDefaults.EditIcon)
+                javaScriptBuilder.AppendFormat("editicon: '{0}', ", baseNavigatorOptions.EditIcon);
+
+            if (!string.IsNullOrEmpty(baseNavigatorOptions.EditText))
+                javaScriptBuilder.AppendFormat("edittext: '{0}', ", baseNavigatorOptions.EditText);
+
+            if (baseNavigatorOptions.EditToolTip != JqGridNavigatorDefaults.EditToolTip)
+                javaScriptBuilder.AppendFormat("edittitle: '{0}', ", baseNavigatorOptions.EditToolTip);
+
+            if (baseNavigatorOptions.Position != JqGridAlignments.Left)
+                javaScriptBuilder.AppendFormat("position: '{0}', ", baseNavigatorOptions.Position.ToString().ToLower());
+        }
+
+        private void AppendNavigatorOptions(StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.Append("{ ");
+
+            AppendBaseNavigatorOptions(_navigatorOptions, javaScriptBuilder);
+
+            if (_navigatorOptions.AlertCaption != JqGridNavigatorDefaults.AlertCaption)
+                javaScriptBuilder.AppendFormat("alertcap: '{0}', ", _navigatorOptions.AlertCaption);
+
+            if (_navigatorOptions.AlertText != JqGridNavigatorDefaults.AlertText)
+                javaScriptBuilder.AppendFormat("alerttext: '{0}', ", _navigatorOptions.AlertText);
+
+            if (_navigatorOptions.CloneToTop)
+                javaScriptBuilder.Append("cloneToTop: true, ");
+
+            if (!_navigatorOptions.CloseOnEscape)
+                javaScriptBuilder.Append("closeOnEscape: false, ");
+
+            if (!_navigatorOptions.Delete)
+                javaScriptBuilder.Append("del: false, ");
+
+            if (_navigatorOptions.DeleteIcon != JqGridNavigatorDefaults.DeleteIcon)
+                javaScriptBuilder.AppendFormat("delicon: '{0}', ", _navigatorOptions.DeleteIcon);
+
+            if (!string.IsNullOrEmpty(_navigatorOptions.DeleteText))
+                javaScriptBuilder.AppendFormat("deltext: '{0}', ", _navigatorOptions.DeleteText);
+
+            if (_navigatorOptions.DeleteToolTip != JqGridNavigatorDefaults.DeleteToolTip)
+                javaScriptBuilder.AppendFormat("deltitle: '{0}', ", _navigatorOptions.DeleteToolTip);
+
+            if (!_navigatorOptions.Refresh)
+                javaScriptBuilder.Append("refresh: false, ");
+
+            if (_navigatorOptions.RefreshIcon != JqGridNavigatorDefaults.RefreshIcon)
+                javaScriptBuilder.AppendFormat("refreshicon: '{0}', ", _navigatorOptions.RefreshIcon);
+
+            if (!string.IsNullOrEmpty(_navigatorOptions.RefreshText))
+                javaScriptBuilder.AppendFormat("refreshtext: '{0}', ", _navigatorOptions.RefreshText);
+
+            if (_navigatorOptions.RefreshToolTip != JqGridNavigatorDefaults.RefreshToolTip)
+                javaScriptBuilder.AppendFormat("refreshtitle: '{0}', ", _navigatorOptions.RefreshToolTip);
+
+            if (_navigatorOptions.RefreshMode != JqGridRefreshModes.FirstPage)
+                javaScriptBuilder.Append("refreshstate: 'current', ");
+
+            if (!string.IsNullOrWhiteSpace(_navigatorOptions.AfterRefresh))
+                javaScriptBuilder.AppendFormat("afterRefresh: {0}, ", _navigatorOptions.AfterRefresh);
+
+            if (!string.IsNullOrWhiteSpace(_navigatorOptions.BeforeRefresh))
+                javaScriptBuilder.AppendFormat("beforeRefresh: {0}, ", _navigatorOptions.BeforeRefresh);
+
+            if (!_navigatorOptions.Search)
+                javaScriptBuilder.Append("search: false, ");
+
+            if (_navigatorOptions.SearchIcon != JqGridNavigatorDefaults.SearchIcon)
+                javaScriptBuilder.AppendFormat("searchicon: '{0}', ", _navigatorOptions.SearchIcon);
+
+            if (!string.IsNullOrEmpty(_navigatorOptions.SearchText))
+                javaScriptBuilder.AppendFormat("searchtext: '{0}', ", _navigatorOptions.SearchText);
+
+            if (_navigatorOptions.SearchToolTip != JqGridNavigatorDefaults.SearchToolTip)
+                javaScriptBuilder.AppendFormat("searchtitle: '{0}', ", _navigatorOptions.SearchToolTip);
+
+            if (_navigatorOptions.View)
+                javaScriptBuilder.Append("view: true, ");
+
+            if (_navigatorOptions.ViewIcon != JqGridNavigatorDefaults.ViewIcon)
+                javaScriptBuilder.AppendFormat("viewicon: '{0}', ", _navigatorOptions.ViewIcon);
+
+            if (!string.IsNullOrEmpty(_navigatorOptions.ViewText))
+                javaScriptBuilder.AppendFormat("viewtext: '{0}', ", _navigatorOptions.ViewText);
+
+            if (_navigatorOptions.ViewToolTip != JqGridNavigatorDefaults.ViewToolTip)
+                javaScriptBuilder.AppendFormat("viewtitle: '{0}', ", _navigatorOptions.ViewToolTip);
+
+            if (!string.IsNullOrWhiteSpace(_navigatorOptions.AddFunction))
+                javaScriptBuilder.AppendFormat("addfunc: {0}, ", _navigatorOptions.AddFunction);
+
+            if (!string.IsNullOrWhiteSpace(_navigatorOptions.EditFunction))
+                javaScriptBuilder.AppendFormat("editfunc: {0}, ", _navigatorOptions.EditFunction);
+
+            if (!string.IsNullOrWhiteSpace(_navigatorOptions.DeleteFunction))
+                javaScriptBuilder.AppendFormat("delfunc: {0}, ", _navigatorOptions.DeleteFunction);
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" }");
+            }
+            else
+                javaScriptBuilder.Append("}");
+        }
+
+        private static void AppendNavigatorActionOptions(string optionsName, JqGridNavigatorActionOptions actionOptions, StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.AppendFormat("{0}{{ ", optionsName);
+
+            if (actionOptions != null)
+            {
+                if (actionOptions.Left != 0)
+                    javaScriptBuilder.AppendFormat("left: {0}, ", actionOptions.Left);
+
+                if (actionOptions.Top != 0)
+                    javaScriptBuilder.AppendFormat("top: {0}, ", actionOptions.Top);
+
+                if (actionOptions.DataWidth.HasValue)
+                    javaScriptBuilder.AppendFormat("datawidth: {0}, ", actionOptions.DataWidth.Value);
+
+                if (actionOptions.Height.HasValue)
+                    javaScriptBuilder.AppendFormat("height: {0}, ", actionOptions.Height.Value);
+
+                if (actionOptions.DataHeight.HasValue)
+                    javaScriptBuilder.AppendFormat("dataheight: {0}, ", actionOptions.DataHeight.Value);
+
+                if (actionOptions.Modal)
+                    javaScriptBuilder.Append("modal: true, ");
+
+                if (!actionOptions.Dragable)
+                    javaScriptBuilder.Append("drag: false, ");
+
+                if (!actionOptions.Resizable)
+                    javaScriptBuilder.Append("resize: false, ");
+
+                if (!actionOptions.UseJqModal)
+                    javaScriptBuilder.Append("jqModal: false, ");
+
+                if (actionOptions.CloseOnEscape)
+                    javaScriptBuilder.Append("closeOnEscape: true, ");
+
+                if (actionOptions.Overlay != 30)
+                    javaScriptBuilder.AppendFormat("overlay: {0}, ", actionOptions.Overlay);
+
+                if (!string.IsNullOrWhiteSpace(actionOptions.OnClose))
+                    javaScriptBuilder.AppendFormat("onClose: {0}, ", actionOptions.OnClose);
+
+                JqGridNavigatorFormActionOptions formActionOptions = actionOptions as JqGridNavigatorFormActionOptions;
+                if (formActionOptions != null)
+                {
+                    AppendNavigatorFormActionOptions(formActionOptions, javaScriptBuilder);
+
+                    IJqGridNavigatorPageableFormActionOptions pageableFormActionOptions = formActionOptions as IJqGridNavigatorPageableFormActionOptions;
+                    if (pageableFormActionOptions != null)
+                        AppendNavigatorPageableFormActionOptions(pageableFormActionOptions, javaScriptBuilder);
+
+                    JqGridNavigatorModifyActionOptions modifyActionOptions = formActionOptions as JqGridNavigatorModifyActionOptions;
+                    if (modifyActionOptions != null)
+                    {
+                        AppendNavigatorModifyActionOptions(modifyActionOptions, javaScriptBuilder);
+                        JqGridNavigatorEditActionOptions editActionOptions = modifyActionOptions as JqGridNavigatorEditActionOptions;
+                        if (editActionOptions != null)
+                            AppendNavigatorEditActionOptions(editActionOptions, javaScriptBuilder);
+                        else
+                            AppendNavigatorDeleteActionOptions(modifyActionOptions as JqGridNavigatorDeleteActionOptions, javaScriptBuilder);
+                    }
+                    else
+                        AppendNavigatorViewActionOptions(formActionOptions as JqGridNavigatorViewActionOptions, javaScriptBuilder);
+                }
+                else
+                    AppendNavigatorSearchActionOptions(actionOptions as JqGridNavigatorSearchActionOptions, javaScriptBuilder);
+
+            }
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                if (!string.IsNullOrEmpty(optionsName))
+                    javaScriptBuilder.Append(" }, ");
+                else
+                    javaScriptBuilder.Append(" }");
+            }
+            else if (!string.IsNullOrEmpty(optionsName))
+            {
+                int optionsNameLength = optionsName.Length + 2;
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - optionsNameLength, optionsNameLength);
+            }
+            else
+                javaScriptBuilder.Append("}");
+        }
+
+        private static void AppendNavigatorFormActionOptions(JqGridNavigatorFormActionOptions formActionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (!string.IsNullOrWhiteSpace(formActionOptions.BeforeInitData))
+                javaScriptBuilder.AppendFormat("beforeInitData: {0}, ", formActionOptions.BeforeInitData);
+
+            if (!string.IsNullOrWhiteSpace(formActionOptions.BeforeShowForm))
+                javaScriptBuilder.AppendFormat("beforeShowForm: {0}, ", formActionOptions.BeforeShowForm);
+        }
+
+        private static void AppendNavigatorPageableFormActionOptions(IJqGridNavigatorPageableFormActionOptions pageableFormActionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (!pageableFormActionOptions.NavigationKeys.IsDefault())
+                javaScriptBuilder.AppendFormat("navkeys: [{0}, {1}, {2}], ", pageableFormActionOptions.NavigationKeys.Enabled.ToString().ToLower(), (int)pageableFormActionOptions.NavigationKeys.RecordUp, (int)pageableFormActionOptions.NavigationKeys.RecordDown);
+
+            if (!pageableFormActionOptions.ViewPagerButtons)
+                javaScriptBuilder.Append("viewPagerButtons: false, ");
+
+            if (pageableFormActionOptions.RecreateForm)
+                javaScriptBuilder.Append("recreateForm: true, ");
+        }
+
+        private static void AppendNavigatorModifyActionOptions(JqGridNavigatorModifyActionOptions modifyActionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (!string.IsNullOrWhiteSpace(modifyActionOptions.Url))
+                javaScriptBuilder.AppendFormat("url: '{0}', ", modifyActionOptions.Url);
+
+            if (modifyActionOptions.MethodType != JqGridMethodTypes.Post)
+                javaScriptBuilder.Append("mtype: 'GET', ");
+
+            if (!modifyActionOptions.ReloadAfterSubmit)
+                javaScriptBuilder.Append("reloadAfterSubmit: false, ");
+
+            if (!string.IsNullOrWhiteSpace(modifyActionOptions.AfterShowForm))
+                javaScriptBuilder.AppendFormat("afterShowForm: {0}, ", modifyActionOptions.AfterShowForm);
+
+            if (!string.IsNullOrWhiteSpace(modifyActionOptions.AfterSubmit))
+                javaScriptBuilder.AppendFormat("afterSubmit: {0}, ", modifyActionOptions.AfterSubmit);
+
+            if (!string.IsNullOrWhiteSpace(modifyActionOptions.BeforeSubmit))
+                javaScriptBuilder.AppendFormat("beforeSubmit: {0}, ", modifyActionOptions.BeforeSubmit);
+
+            if (!string.IsNullOrWhiteSpace(modifyActionOptions.OnClickSubmit))
+                javaScriptBuilder.AppendFormat("onclickSubmit: {0}, ", modifyActionOptions.OnClickSubmit);
+
+            if (!string.IsNullOrWhiteSpace(modifyActionOptions.ErrorTextFormat))
+                javaScriptBuilder.AppendFormat("errorTextFormat: {0}, ", modifyActionOptions.ErrorTextFormat);
+        }
+
+        private static void AppendNavigatorEditActionOptions(JqGridNavigatorEditActionOptions editActionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (editActionOptions.Width != 300)
+                javaScriptBuilder.AppendFormat("width: {0}, ", editActionOptions.Width);
+
+            JavaScriptSerializer serializer = new JavaScriptSerializer();
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.ExtraDataScript))
+                javaScriptBuilder.AppendFormat("editData: {0},", editActionOptions.ExtraDataScript).AppendLine();
+            else if (editActionOptions.ExtraData != null)
+                javaScriptBuilder.AppendFormat("editData: {0}, ", serializer.Serialize(editActionOptions.ExtraData));
+
+            if (editActionOptions.AjaxOptions != null)
+                javaScriptBuilder.AppendFormat("ajaxEditOptions: {0}, ", serializer.Serialize(editActionOptions.AjaxOptions));
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.SerializeData))
+                javaScriptBuilder.AppendFormat("serializeEditData: {0}, ", editActionOptions.SerializeData);
+
+            if (editActionOptions.AddedRowPosition != JqGridNewRowPositions.First)
+                javaScriptBuilder.Append("addedrow: 'last', ");
+
+            if (!editActionOptions.ClearAfterAdd)
+                javaScriptBuilder.Append("clearAfterAdd: false, ");
+
+            if (editActionOptions.CloseAfterAdd)
+                javaScriptBuilder.Append("closeAfterAdd: true, ");
+
+            if (editActionOptions.CloseAfterEdit)
+                javaScriptBuilder.Append("closeAfterEdit: true, ");
+
+            if (editActionOptions.CheckOnSubmit)
+                javaScriptBuilder.Append("checkOnSubmit: true, ");
+
+            if (editActionOptions.CheckOnUpdate)
+                javaScriptBuilder.Append("checkOnUpdate: true, ");
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.TopInfo))
+                javaScriptBuilder.AppendFormat("topinfo: '{0}', ", editActionOptions.TopInfo);
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.BottomInfo))
+                javaScriptBuilder.AppendFormat("bottominfo: '{0}', ", editActionOptions.BottomInfo);
+
+            if (editActionOptions.SaveKeyEnabled || (editActionOptions.SaveKey != (char)13))
+                javaScriptBuilder.AppendFormat("savekey: [{0}, {1}], ", editActionOptions.SaveKeyEnabled.ToString().ToLower(), (int)editActionOptions.SaveKey);
+
+            if (!editActionOptions.SaveButtonIcon.Equals(JqGridFormButtonIcon.SaveIcon))
+                javaScriptBuilder.AppendFormat("saveicon: [{0}, '{1}', '{2}'], ", editActionOptions.SaveButtonIcon.Enabled.ToString().ToLower(), editActionOptions.SaveButtonIcon.Position.ToString().ToLower(), editActionOptions.SaveButtonIcon.Class);
+
+            if (!editActionOptions.CloseButtonIcon.Equals(JqGridFormButtonIcon.CloseIcon))
+                javaScriptBuilder.AppendFormat("closeicon: [{0}, '{1}', '{2}'], ", editActionOptions.CloseButtonIcon.Enabled.ToString().ToLower(), editActionOptions.CloseButtonIcon.Position.ToString().ToLower(), editActionOptions.CloseButtonIcon.Class);
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.AfterClickPgButtons))
+                javaScriptBuilder.AppendFormat("afterclickPgButtons: {0}, ", editActionOptions.AfterClickPgButtons);
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.AfterComplete))
+                javaScriptBuilder.AppendFormat("afterComplete: {0}, ", editActionOptions.AfterComplete);
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.BeforeCheckValues))
+                javaScriptBuilder.AppendFormat("beforeCheckValues: {0}, ", editActionOptions.BeforeCheckValues);
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.OnClickPgButtons))
+                javaScriptBuilder.AppendFormat("onclickPgButtons: {0}, ", editActionOptions.OnClickPgButtons);
+
+            if (!string.IsNullOrWhiteSpace(editActionOptions.OnInitializeForm))
+                javaScriptBuilder.AppendFormat("onInitializeForm: {0}, ", editActionOptions.OnInitializeForm);
+        }
+
+        private static void AppendNavigatorDeleteActionOptions(JqGridNavigatorDeleteActionOptions deleteActionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (deleteActionOptions.Width != 240)
+                javaScriptBuilder.AppendFormat("width: {0}, ", deleteActionOptions.Width);
+
+            JavaScriptSerializer serializer = new JavaScriptSerializer();
+
+            if (!string.IsNullOrWhiteSpace(deleteActionOptions.ExtraDataScript))
+                javaScriptBuilder.AppendFormat("delData: {0},", deleteActionOptions.ExtraDataScript).AppendLine();
+            else if (deleteActionOptions.ExtraData != null)
+                javaScriptBuilder.AppendFormat("delData: {0}, ", serializer.Serialize(deleteActionOptions.ExtraData));
+
+            if (deleteActionOptions.AjaxOptions != null)
+                javaScriptBuilder.AppendFormat("ajaxDelOptions: {0}, ", serializer.Serialize(deleteActionOptions.AjaxOptions));
+
+            if (!string.IsNullOrWhiteSpace(deleteActionOptions.SerializeData))
+                javaScriptBuilder.AppendFormat("serializeDelData: {0}, ", deleteActionOptions.SerializeData);
+
+            if (!deleteActionOptions.DeleteButtonIcon.Equals(JqGridFormButtonIcon.DeleteIcon))
+                javaScriptBuilder.AppendFormat("delicon: [{0}, '{1}', '{2}'], ", deleteActionOptions.DeleteButtonIcon.Enabled.ToString().ToLower(), deleteActionOptions.DeleteButtonIcon.Position.ToString().ToLower(), deleteActionOptions.DeleteButtonIcon.Class);
+
+            if (!deleteActionOptions.CancelButtonIcon.Equals(JqGridFormButtonIcon.CancelIcon))
+                javaScriptBuilder.AppendFormat("cancelicon: [{0}, '{1}', '{2}'], ", deleteActionOptions.CancelButtonIcon.Enabled.ToString().ToLower(), deleteActionOptions.CancelButtonIcon.Position.ToString().ToLower(), deleteActionOptions.CancelButtonIcon.Class);
+        }
+
+        private static void AppendNavigatorViewActionOptions(JqGridNavigatorViewActionOptions viewActionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (viewActionOptions.Width != 0)
+                javaScriptBuilder.AppendFormat("width: {0}, ", viewActionOptions.Width);
+
+            if (viewActionOptions.LabelsWidth != "30%")
+                javaScriptBuilder.AppendFormat("labelswidth: '{0}', ", viewActionOptions.LabelsWidth);
+
+            if (!viewActionOptions.CloseButtonIcon.Equals(JqGridFormButtonIcon.CloseIcon))
+                javaScriptBuilder.AppendFormat("closeicon: [{0}, '{1}', '{2}'], ", viewActionOptions.CloseButtonIcon.Enabled.ToString().ToLower(), viewActionOptions.CloseButtonIcon.Position.ToString().ToLower(), viewActionOptions.CloseButtonIcon.Class);
+        }
+
+        private static void AppendNavigatorSearchActionOptions(JqGridNavigatorSearchActionOptions searchActionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (searchActionOptions.Width != 450)
+                javaScriptBuilder.AppendFormat("width: {0}, ", searchActionOptions.Width);
+
+            if (!string.IsNullOrWhiteSpace(searchActionOptions.AfterRedraw))
+                javaScriptBuilder.AppendFormat("afterRedraw: {0}, ", searchActionOptions.AfterRedraw);
+
+            if (!string.IsNullOrWhiteSpace(searchActionOptions.AfterShowSearch))
+                javaScriptBuilder.AppendFormat("afterShowSearch: {0}, ", searchActionOptions.AfterShowSearch);
+
+            if (!string.IsNullOrWhiteSpace(searchActionOptions.BeforeShowSearch))
+                javaScriptBuilder.AppendFormat("beforeShowSearch: {0}, ", searchActionOptions.BeforeShowSearch);
+
+            if (!string.IsNullOrEmpty(searchActionOptions.Caption))
+                javaScriptBuilder.AppendFormat("caption: '{0}', ", searchActionOptions.Caption);
+
+            if (searchActionOptions.CloseAfterSearch)
+                javaScriptBuilder.Append("closeAfterSearch: true, ");
+
+            if (searchActionOptions.CloseAfterReset)
+                javaScriptBuilder.Append("closeAfterReset: true, ");
+
+            if (!searchActionOptions.ErrorCheck)
+                javaScriptBuilder.Append("errorcheck: false, ");
+
+            if (!string.IsNullOrEmpty(searchActionOptions.SearchText))
+                javaScriptBuilder.AppendFormat("Find: '{0}', ", searchActionOptions.SearchText);
+
+            if (searchActionOptions.AdvancedSearching)
+                javaScriptBuilder.Append("multipleSearch: true, ");
+
+            if (searchActionOptions.AdvancedSearchingWithGroups)
+                javaScriptBuilder.Append("multipleGroup: true, ");
+
+            if (!searchActionOptions.CloneSearchRowOnAdd)
+                javaScriptBuilder.Append("cloneSearchRowOnAdd: false, ");
+
+            if (!string.IsNullOrWhiteSpace(searchActionOptions.OnInitializeSearch))
+                javaScriptBuilder.AppendFormat("onInitializeSearch: {0}, ", searchActionOptions.OnInitializeSearch);
+
+            if (!string.IsNullOrWhiteSpace(searchActionOptions.OnReset))
+                javaScriptBuilder.AppendFormat("onReset: {0}, ", searchActionOptions.OnReset);
+
+            if (!string.IsNullOrWhiteSpace(searchActionOptions.OnSearch))
+                javaScriptBuilder.AppendFormat("onSearch: {0}, ", searchActionOptions.OnSearch);
+
+            if (searchActionOptions.RecreateFilter)
+                javaScriptBuilder.Append("recreateFilter: true, ");
+
+            if (!string.IsNullOrEmpty(searchActionOptions.ResetText))
+                javaScriptBuilder.AppendFormat("Reset: '{0}', ", searchActionOptions.ResetText);
+
+            AppendSearchOperators(searchActionOptions.SearchOperators, javaScriptBuilder);
+
+            if (searchActionOptions.ShowOnLoad)
+                javaScriptBuilder.Append("showOnLoad: true, ");
+
+            if (searchActionOptions.ShowQuery)
+                javaScriptBuilder.Append("showQuery: true, ");
+
+            if (!string.IsNullOrEmpty(searchActionOptions.Layer))
+                javaScriptBuilder.AppendFormat("layer: '{0}', ", searchActionOptions.Layer);
+
+            if (searchActionOptions.Templates != null && searchActionOptions.Templates.Count > 0)
+            {
+                JavaScriptSerializer serializer = new JavaScriptSerializer();
+                serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
+
+                javaScriptBuilder.Append("tmplNames: [],");
+                int templateNameIndex = javaScriptBuilder.Length - 2;
+                javaScriptBuilder.Append("tmplFilters: [");
+                foreach (KeyValuePair<string, JqGridRequestSearchingFilters> template in searchActionOptions.Templates)
+                {
+                    javaScriptBuilder.Insert(templateNameIndex, "'" + template.Key + "', ");
+                    templateNameIndex += template.Key.Length + 4;
+                    javaScriptBuilder.Append(serializer.Serialize(template.Value) + ", ");
+                }
+                javaScriptBuilder.Remove(templateNameIndex - 2, 2);
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append("],");
+            }
+        }
+
+        private void AppendNavigatorButton(string navigatorPagerSelector, JqGridNavigatorButtonOptions buttonOptions, StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.AppendFormat(".jqGrid('navButtonAdd', {0}, {{ ", navigatorPagerSelector);
+            if (buttonOptions.Caption != JqGridNavigatorDefaults.ButtonCaption)
+                javaScriptBuilder.AppendFormat("caption: '{0}', ", buttonOptions.Caption);
+
+            if (buttonOptions.Icon != JqGridNavigatorDefaults.ButtonIcon)
+                javaScriptBuilder.AppendFormat("buttonicon: '{0}', ", buttonOptions.Icon);
+
+            if (!string.IsNullOrWhiteSpace(buttonOptions.OnClick))
+                javaScriptBuilder.AppendFormat("onClickButton: {0}, ", buttonOptions.OnClick);
+
+            if (buttonOptions.Position != JqGridNavigatorButtonPositions.Last)
+                javaScriptBuilder.Append("position: 'first', ");
+
+            if (!string.IsNullOrEmpty(buttonOptions.ToolTip))
+                javaScriptBuilder.AppendFormat("title: '{0}', ", buttonOptions.ToolTip);
+
+            if (buttonOptions.Cursor != JqGridNavigatorDefaults.ButtonCursor)
+                javaScriptBuilder.AppendFormat("cursor: '{0}', ", buttonOptions.Cursor);
+
+            if (!string.IsNullOrWhiteSpace(buttonOptions.Id))
+                javaScriptBuilder.AppendFormat("id: '{0}', ", buttonOptions.Id);
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" })");
+            }
+            else
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 4, 4);
+                javaScriptBuilder.Append(")");
+            }
+        }
+
+        private void AppendNavigatorSeparator(string navigatorPagerSelector, JqGridNavigatorSeparatorOptions separatorOptions, StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.AppendFormat(".jqGrid('navSeparatorAdd', {0}, {{ ", navigatorPagerSelector);
+
+            if (separatorOptions.Class != JqGridNavigatorDefaults.SeparatorClass)
+                javaScriptBuilder.AppendFormat("sepclass: '{0}', ", separatorOptions.Class);
+
+            if (!string.IsNullOrEmpty(separatorOptions.Content))
+                javaScriptBuilder.AppendFormat("sepcontent: '{0}', ", separatorOptions.Content);
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" })");
+            }
+            else
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 4, 4);
+                javaScriptBuilder.Append(")");
+            }
+        }
+
+        private void AppendInlineNavigator(StringBuilder javaScriptBuilder)
+        {
+            string navigatorPagerSelector = _navigatorOptions.Pager == JqGridNavigatorPagers.Top ? TopPagerSelector : PagerSelector;
+
+            javaScriptBuilder.AppendFormat(".jqGrid('inlineNav', {0}, ", navigatorPagerSelector).AppendLine();
+
+            AppendInlineNavigatorOptions(javaScriptBuilder);
+
+            javaScriptBuilder.Append(")");
+        }
+
+        private void AppendInlineNavigatorOptions(StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.Append("{ ");
+
+            AppendBaseNavigatorOptions(_inlineNavigatorOptions, javaScriptBuilder);
+
+            if (!_inlineNavigatorOptions.Save)
+                javaScriptBuilder.Append("save: false, ");
+
+            if (_inlineNavigatorOptions.SaveIcon != JqGridNavigatorDefaults.SaveIcon)
+                javaScriptBuilder.AppendFormat("saveicon: '{0}', ", _inlineNavigatorOptions.SaveIcon);
+
+            if (!string.IsNullOrEmpty(_inlineNavigatorOptions.SaveText))
+                javaScriptBuilder.AppendFormat("savetext: '{0}', ", _inlineNavigatorOptions.SaveText);
+
+            if (_inlineNavigatorOptions.SaveToolTip != JqGridNavigatorDefaults.SaveToolTip)
+                javaScriptBuilder.AppendFormat("savetitle: '{0}', ", _inlineNavigatorOptions.SaveToolTip);
+
+            if (!_inlineNavigatorOptions.Cancel)
+                javaScriptBuilder.Append("cancel: false, ");
+
+            if (_inlineNavigatorOptions.CancelIcon != JqGridNavigatorDefaults.CancelIcon)
+                javaScriptBuilder.AppendFormat("cancelicon: '{0}', ", _inlineNavigatorOptions.CancelIcon);
+
+            if (!string.IsNullOrEmpty(_inlineNavigatorOptions.CancelText))
+                javaScriptBuilder.AppendFormat("canceltext: '{0}', ", _inlineNavigatorOptions.CancelText);
+
+            if (_inlineNavigatorOptions.CancelToolTip != JqGridNavigatorDefaults.CancelToolTip)
+                javaScriptBuilder.AppendFormat("canceltitle: '{0}', ", _inlineNavigatorOptions.CancelToolTip);
+
+            AppendInlineNavigatorAddActionOptions(_inlineNavigatorOptions.AddActionOptions, javaScriptBuilder);
+            AppendInlineNavigatorActionOptions("editParams", _inlineNavigatorOptions.ActionOptions, javaScriptBuilder);
+
+            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+            {
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                javaScriptBuilder.Append(" }");
+            }
+            else
+                javaScriptBuilder.Append("}");
+        }
+
+        private static void AppendInlineNavigatorActionOptions(string actionName, JqGridInlineNavigatorActionOptions actionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (actionOptions != null)
+            {
+                javaScriptBuilder.AppendFormat("{0}: {{ ", actionName);
+
+                if (actionOptions.Keys)
+                    javaScriptBuilder.Append("keys: true, ");
+
+                if (!string.IsNullOrWhiteSpace(actionOptions.OnEditFunction))
+                    javaScriptBuilder.AppendFormat("oneditfunc: {0}, ", actionOptions.OnEditFunction);
+
+                if (!string.IsNullOrWhiteSpace(actionOptions.SuccessFunction))
+                    javaScriptBuilder.AppendFormat("successfunc: {0}, ", actionOptions.SuccessFunction);
+
+                if (!string.IsNullOrWhiteSpace(actionOptions.Url))
+                    javaScriptBuilder.AppendFormat("url: '{0}', ", actionOptions.Url);
+
+                if (!string.IsNullOrWhiteSpace(actionOptions.ExtraParamScript))
+                    javaScriptBuilder.AppendFormat("extraparam: {0}, ", actionOptions.ExtraParamScript);
+                else if (actionOptions.ExtraParam != null)
+                {
+                    JavaScriptSerializer serializer = new JavaScriptSerializer();
+                    javaScriptBuilder.AppendFormat("extraparam: {0}, ", serializer.Serialize(actionOptions.ExtraParam));
+                }
+
+                if (!string.IsNullOrWhiteSpace(actionOptions.AfterSaveFunction))
+                    javaScriptBuilder.AppendFormat("aftersavefunc: {0}, ", actionOptions.AfterSaveFunction);
+
+                if (!string.IsNullOrWhiteSpace(actionOptions.ErrorFunction))
+                    javaScriptBuilder.AppendFormat("errorfunc: {0}, ", actionOptions.ErrorFunction);
+
+                if (!string.IsNullOrWhiteSpace(actionOptions.AfterRestoreFunction))
+                    javaScriptBuilder.AppendFormat("afterrestorefunc: {0}, ", actionOptions.AfterRestoreFunction);
+
+                if (!actionOptions.RestoreAfterError)
+                    javaScriptBuilder.Append("restoreAfterError: false, ");
+
+                if (actionOptions.MethodType != JqGridMethodTypes.Post)
+                    javaScriptBuilder.Append("mtype: 'GET', ");
+
+                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+                {
+                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                    javaScriptBuilder.Append(" }, ");
+                }
+                else
+                {
+                    int actionNameLength = actionName.Length + 4;
+                    javaScriptBuilder.Remove(javaScriptBuilder.Length - actionNameLength, actionNameLength);
+                }
+            }
+        }
+
+        private static void AppendInlineNavigatorAddActionOptions(JqGridInlineNavigatorAddActionOptions actionOptions, StringBuilder javaScriptBuilder)
+        {
+            if (actionOptions != null)
+            {
+                javaScriptBuilder.Append("addParams: { ");
+
+                if (actionOptions.RowId != JqGridNavigatorDefaults.NewRowId)
+                    javaScriptBuilder.AppendFormat("rowID: '{0}', ", actionOptions.RowId);
+
+                if (actionOptions.InitData != null)
+                {
+                    JavaScriptSerializer serializer = new JavaScriptSerializer();
+                    javaScriptBuilder.AppendFormat("initdata: {0}, ", serializer.Serialize(actionOptions.InitData));
+                }
+
+                if (actionOptions.Position != JqGridNewRowPositions.First)
+                    javaScriptBuilder.AppendFormat("position: 'last', ");
+
+                if (actionOptions.UseDefaultValues)
+                    javaScriptBuilder.Append("useDefValues: true, ");
+
+                if (actionOptions.UseFormatter)
+                    javaScriptBuilder.Append("useFormatter: true, ");
+
+                AppendInlineNavigatorActionOptions("addRowParams", actionOptions.Options, javaScriptBuilder);
+
+                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+                {
+                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+                    javaScriptBuilder.Append(" }, ");
+                }
+                else
+                {
+                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 13, 13);
+                }
+            }
+        }
+
+        private void AppendFilterToolbar(StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.Append(".jqGrid('filterToolbar'");
+
+            if (_filterToolbarOptions != null)
+            {
+                javaScriptBuilder.Append(", { ");
+
+                AppendFilterOptions(_filterToolbarOptions, javaScriptBuilder);
+
+                if (_filterToolbarOptions.DefaultSearchOperator != JqGridSearchOperators.Bw)
+                    javaScriptBuilder.AppendFormat("defaultSearch: '{0}',", _filterToolbarOptions.DefaultSearchOperator.ToString().ToLower());
+
+                if (_filterToolbarOptions.GroupingOperator != JqGridSearchGroupingOperators.And)
+                    javaScriptBuilder.Append("groupOp: 'OR',");
+
+                if (!_filterToolbarOptions.SearchOnEnter)
+                    javaScriptBuilder.Append("searchOnEnter: false,");
+
+                if (_filterToolbarOptions.SearchOperators)
+                    javaScriptBuilder.Append("searchOperators: true,");
+
+                if (_filterToolbarOptions.OperandToolTip != JqGridFilterToolbarDefaults.OperandToolTip)
+                    javaScriptBuilder.AppendFormat("operandTitle: '{0}',", _filterToolbarOptions.OperandToolTip);
+
+                if (_filterToolbarOptions.Operands != null && _filterToolbarOptions.Operands.Count > 0 && _filterToolbarOptions.Operands != JqGridFilterToolbarDefaults.Operands)
+                {
+                    int javaScriptBuilderPosition = javaScriptBuilder.Length;
+
+                    foreach (KeyValuePair<JqGridSearchOperators, string> operand in _filterToolbarOptions.Operands)
+                    {
+                        string defaultShortText;
+                        if (JqGridFilterToolbarDefaults.Operands.TryGetValue(operand.Key, out defaultShortText) && operand.Value != defaultShortText)
+                            javaScriptBuilder.AppendFormat("'{0}':'{1}',", operand.Key.ToString().ToLower(), operand.Value);
+                    }
+
+                    if (javaScriptBuilderPosition != javaScriptBuilder.Length)
+                    {
+                        javaScriptBuilder.Insert(javaScriptBuilderPosition, "operands: {");
+                        javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+                        javaScriptBuilder.Append("},");
+                    }
+                }
+
+                if (_filterToolbarOptions.StringResult)
+                    javaScriptBuilder.Append("stringResult: true,");
+
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+                javaScriptBuilder.Append(" }");
+            }
+
+            javaScriptBuilder.Append(")");
+        }
+
+        private void AppendFilterGrid(StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.AppendFormat("$({0}).jqGrid('filterGrid', {1}, {{", FilterGridSelector, GridSelector).AppendLine();
+            javaScriptBuilder.AppendLine("gridModel: false, gridNames: false,");
+
+            javaScriptBuilder.AppendLine("filterModel: [");
+
+            int lastGridModelIndex = _filterGridModel.Count - 1;
+            for (int gridModelIndex = 0; gridModelIndex < _filterGridModel.Count; gridModelIndex++)
+            {
+                JqGridFilterGridRowModel gridRowModel = _filterGridModel[gridModelIndex];
+                javaScriptBuilder.AppendFormat("{{ label: '{0}', name: '{1}', ", gridRowModel.Label, gridRowModel.ColumnName);
+
+                if (!string.IsNullOrWhiteSpace(gridRowModel.DefaultValue))
+                    javaScriptBuilder.AppendFormat("defval: '{0}', ", gridRowModel.DefaultValue);
+
+                if (!string.IsNullOrWhiteSpace(gridRowModel.SelectUrl))
+                    javaScriptBuilder.AppendFormat("surl: '{0}', ", gridRowModel.SelectUrl);
+
+                javaScriptBuilder.AppendFormat("stype: '{0}' }}", gridRowModel.SearchType.ToString().ToLower());
+
+                if (lastGridModelIndex == gridModelIndex)
+                    javaScriptBuilder.AppendLine();
+                else
+                    javaScriptBuilder.AppendLine(",");
+            }
+
+            javaScriptBuilder.Append("]");
+
+            if (_filterGridOptions != null)
+            {
+                javaScriptBuilder.AppendLine(",");
+                AppendFilterOptions(_filterGridOptions, javaScriptBuilder);
+
+                if (!string.IsNullOrWhiteSpace(_filterGridOptions.ButtonsClass))
+                    javaScriptBuilder.AppendFormat("buttonclass: '{0}',", _filterGridOptions.ButtonsClass);
+
+                if (_filterGridOptions.ClearEnabled.HasValue)
+                    javaScriptBuilder.AppendFormat("enableClear: {0},", _filterGridOptions.ClearEnabled.Value.ToString().ToLower());
+
+                if (!string.IsNullOrWhiteSpace(_filterGridOptions.ClearText))
+                    javaScriptBuilder.AppendFormat("clearButton: '{0}',", _filterGridOptions.ClearText);
+
+                if (!string.IsNullOrWhiteSpace(_filterGridOptions.FormClass))
+                    javaScriptBuilder.AppendFormat("formclass: '{0}',", _filterGridOptions.FormClass);
+
+                if (_filterGridOptions.MarkSearched.HasValue)
+                    javaScriptBuilder.AppendFormat("marksearched: {0},", _filterGridOptions.MarkSearched.Value.ToString().ToLower());
+
+                if (_filterGridOptions.SearchEnabled.HasValue)
+                    javaScriptBuilder.AppendFormat("enableSearch: {0},", _filterGridOptions.SearchEnabled.Value.ToString().ToLower());
+
+                if (!string.IsNullOrWhiteSpace(_filterGridOptions.SearchText))
+                    javaScriptBuilder.AppendFormat("searchButton: '{0}',", _filterGridOptions.SearchText);
+
+                if (!string.IsNullOrWhiteSpace(_filterGridOptions.TableClass))
+                    javaScriptBuilder.AppendFormat("tableclass: '{0}',", _filterGridOptions.TableClass);
+
+                if (_filterGridOptions.Type.HasValue)
+                    javaScriptBuilder.AppendFormat("formtype: '{0}',", _filterGridOptions.Type.Value.ToString().ToLower());
+
+                if (!string.IsNullOrWhiteSpace(_filterGridOptions.Url))
+                    javaScriptBuilder.AppendFormat("url: '{0}',", _filterGridOptions.Url);
+
+                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+            }
+
+            javaScriptBuilder.AppendLine("});");
+        }
+
+        private static void AppendFilterOptions(JqGridFilterOptions options, StringBuilder javaScriptBuilder)
+        {
+            if (options != null)
+            {
+                if (!string.IsNullOrWhiteSpace(options.AfterClear))
+                    javaScriptBuilder.AppendFormat("afterClear: {0},", options.AfterClear);
+
+                if (!string.IsNullOrWhiteSpace(options.AfterSearch))
+                    javaScriptBuilder.AppendFormat("afterSearch: {0},", options.AfterSearch);
+
+                if (options.AutoSearch.HasValue)
+                    javaScriptBuilder.AppendFormat("autosearch: {0},", options.AutoSearch.Value.ToString().ToLower());
+
+                if (!string.IsNullOrWhiteSpace(options.BeforeClear))
+                    javaScriptBuilder.AppendFormat("beforeClear: {0},", options.BeforeClear);
+
+                if (!string.IsNullOrWhiteSpace(options.BeforeSearch))
+                    javaScriptBuilder.AppendFormat("beforeSearch: {0},", options.BeforeSearch);
+            }
+        }
+
+        private void AppendFooterData(StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.Append(".jqGrid('footerData', 'set', { ");
+
+            foreach (KeyValuePair<string, object> footerValue in _footerData)
+                javaScriptBuilder.AppendFormat(" {0}: '{1}', ", footerValue.Key, Convert.ToString(footerValue.Value));
+
+            javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+            javaScriptBuilder.AppendFormat(" }}, {0})", _footerDataUseFormatters.ToString().ToLower());
+        }
+
+        private void AppendGroupHeaders(StringBuilder javaScriptBuilder)
+        {
+            javaScriptBuilder.Append(".jqGrid('setGroupHeaders', { ");
+
+            if (_groupHeadersUseColSpanStyle)
+                javaScriptBuilder.Append("useColSpanStyle: true, ");
+
+            javaScriptBuilder.Append("groupHeaders: [ ");
+            foreach (JqGridGroupHeader groupHeader in _groupHeaders)
+                javaScriptBuilder.AppendFormat("{{ startColumnName: '{0}', numberOfColumns: {1}, titleText: '{2}' }}, ", groupHeader.StartColumn, groupHeader.NumberOfColumns, groupHeader.Title);
+            javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2).Append(" ]");
+
+            javaScriptBuilder.Append("})");
+        }
+
+        private static void AppendColumnLabelOptions(string columnName, JqGridColumnLabelOptions options, StringBuilder javaScriptBuilder)
+        {
+            if (options == null) return;
+            JavaScriptSerializer serializer = new JavaScriptSerializer();
+            javaScriptBuilder.AppendFormat(".jqGrid('setLabel', '{0}', ", columnName);
+            javaScriptBuilder.AppendFormat("'{0}', ", string.IsNullOrWhiteSpace(options.Label) ? string.Empty : options.Label);
+
+            if (string.IsNullOrWhiteSpace(options.Class))
+            {
+                if (options.CssStyles != null)
+                    javaScriptBuilder.AppendFormat("{0}, ", serializer.Serialize(options.CssStyles));
+                else if (options.HtmlAttributes != null)
+                    javaScriptBuilder.Append("null, ");
+            }
+            else
+                javaScriptBuilder.AppendFormat("'{0}', ", options.Class);
+
+            if (options.HtmlAttributes != null)
+                javaScriptBuilder.AppendFormat("{0}, ", serializer.Serialize(options.HtmlAttributes));
+
+            javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+            javaScriptBuilder.Append(" )");
+        }
+
+        private static IDictionary<string, object> AnonymousObjectToDictionary(object anonymousObject)
+        {
+            Dictionary<string, object> dictionary = new Dictionary<string, object>();
+
+            if (anonymousObject != null)
+            {
+                foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(anonymousObject))
+                    dictionary.Add(property.Name, property.GetValue(anonymousObject));
+            }
+
+            return dictionary;
+        }
+        #endregion
+
+        #region Fluent API
+        /// <summary>
+        /// Adds column with actions predefined formatter.
+        /// </summary>
+        /// <param name="name">Name for the column.</param>
+        /// <param name="position">Position of the column.</param>
+        /// <param name="width">Width of the column.</param>
+        /// <param name="editButton">Value indicating if edit button is enabled.</param>
+        /// <param name="deleteButton">Value indicating if delete button is enabled.</param>
+        /// <param name="useFormEditing">Value indicating if form editing should be used instead of inline editing.</param>
+        /// <param name="inlineEditingOptions">Options for inline editing (RestoreAfterError and MethodType options are ignored in this context).</param>
+        /// <param name="formEditingOptions">Options for form editing.</param>
+        /// <param name="deleteOptions">Options for deleting.</param>
+        /// <returns>JqGridHelper instance.</returns>
+        /// <remarks>It is adviced to set JqGridResponse.JsonReader.RepeatItems to false if you want to use this method, otherwise jqGrid will not skip this column while mapping data.</remarks>
+        public JqGridHelper<TModel> AddActionsColumn(string name, int position = 0, int width = 60, bool editButton = true, bool deleteButton = true, bool useFormEditing = false, JqGridInlineNavigatorActionOptions inlineEditingOptions = null, JqGridNavigatorEditActionOptions formEditingOptions = null, JqGridNavigatorDeleteActionOptions deleteOptions = null)
+        {
+            JqGridColumnModel actionsColumnModel = new JqGridColumnModel(name);
+            actionsColumnModel.Width = width;
+            actionsColumnModel.Resizable = false;
+            actionsColumnModel.Searchable = false;
+            actionsColumnModel.Sortable = false;
+            actionsColumnModel.Viewable = false;
+            actionsColumnModel.Formatter = new SettedString(true, JqGridColumnPredefinedFormatters.Actions);
+            actionsColumnModel.FormatterOptions = new JqGridColumnFormatterOptions()
+            {
+                EditButton = editButton,
+                DeleteButton = deleteButton,
+                UseFormEditing = useFormEditing,
+                InlineEditingOptions = inlineEditingOptions,
+                FormEditingOptions = formEditingOptions,
+                DeleteOptions = deleteOptions
+            };
+
+            if (position <= 0)
+            {
+                _options.ColumnsNames.Insert(0, string.Empty);
+                _options.ColumnsModels.Insert(0, actionsColumnModel);
+            }
+            else if (position >= _options.ColumnsModels.Count)
+            {
+                _options.ColumnsNames.Add(string.Empty);
+                _options.ColumnsModels.Add(actionsColumnModel);
+            }
+            else
+            {
+                _options.ColumnsNames.Insert(position, string.Empty);
+                _options.ColumnsModels.Insert(position, actionsColumnModel);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Enables Navigator for this JqGridHelper instance.
+        /// </summary>
+        /// <param name="options">The options for the Navigator.</param>
+        /// <param name="editActionOptions">The options for the edit action.</param>
+        /// <param name="addActionOptions">The options for the add action.</param>
+        /// <param name="deleteActionOptions">The options for the delete action.</param>
+        /// <param name="searchActionOptions">The options for the search action.</param>
+        /// <param name="viewActionOptions">The options for the view action.</param>
+        /// <returns>JqGridHelper instance with enabled Navigator.</returns>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
+        public JqGridHelper<TModel> Navigator(JqGridNavigatorOptions options, JqGridNavigatorEditActionOptions editActionOptions = null, JqGridNavigatorEditActionOptions addActionOptions = null, JqGridNavigatorDeleteActionOptions deleteActionOptions = null, JqGridNavigatorSearchActionOptions searchActionOptions = null, JqGridNavigatorViewActionOptions viewActionOptions = null)
+        {
+            _navigatorOptions = options ?? throw new ArgumentNullException(nameof(options));
+            _navigatorEditActionOptions = editActionOptions;
+            _navigatorAddActionOptions = addActionOptions;
+            _navigatorDeleteActionOptions = deleteActionOptions;
+            _navigatorSearchActionOptions = searchActionOptions;
+            _navigatorViewActionOptions = viewActionOptions;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Enables Inline Navigator for this JqGridHelper instance.
+        /// </summary>
+        /// <param name="options">The options for the Inline Navigator.</param>
+        /// <returns>JqGridHelper instance with enabled Inline Navigator.</returns>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
+        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+        public JqGridHelper<TModel> InlineNavigator(JqGridInlineNavigatorOptions options)
+        {
+            if (_navigatorOptions == null)
+                throw new InvalidOperationException("In order to call InlineNavigator method you must call Navigator method first.");
+            _inlineNavigatorOptions = options ?? throw new ArgumentNullException(nameof(options));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds button to this JqGridHelper instance Navigator.
+        /// </summary>
+        /// <param name="caption">The caption for the button.</param>
+        /// <param name="icon">The icon (form UI theme images) for the button. If this is set to "none" only text will appear.</param>
+        /// <param name="onClick">The function for button click action.</param>
+        /// <param name="position">The position where the button will be added.</param>
+        /// <param name="toolTip">The tooltip for the button.</param>
+        /// <param name="cursor">The value which determines the cursor when user mouseover the button.</param>
+        /// <param name="cloneToTop">The value which defines if the button added to the bottom pager should be coppied to the top pager.</param>
+        /// <returns>JqGridHelper instance.</returns>
+        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+        public JqGridHelper<TModel> AddNavigatorButton(string caption = JqGridNavigatorDefaults.ButtonCaption, string icon = JqGridNavigatorDefaults.ButtonIcon, string onClick = null, JqGridNavigatorButtonPositions position = JqGridNavigatorButtonPositions.Last, string toolTip = "", string cursor = JqGridNavigatorDefaults.ButtonCursor, bool cloneToTop = false)
+        {
+            if (_navigatorOptions == null)
+                throw new InvalidOperationException("In order to call AddNavigatorButton method you must call Navigator method first.");
+
+            _navigatorControlsOptions.Add(new JqGridNavigatorButtonOptions()
+            {
+                CloneToTop = cloneToTop,
+                Caption = caption,
+                Icon = icon,
+                OnClick = onClick,
+                Position = position,
+                ToolTip = toolTip,
+                Cursor = cursor
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds button to this JqGridHelper instance Navigator.
+        /// </summary>
+        /// <param name="options">The options for the button.</param>
+        /// <returns>JqGridHelper instance.</returns>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
+        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+        public JqGridHelper<TModel> AddNavigatorButton(JqGridNavigatorButtonOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            if (_navigatorOptions == null)
+                throw new InvalidOperationException("In order to call AddNavigatorButton method you must call Navigator method first.");
+
+            _navigatorControlsOptions.Add(options);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds separator to this JqGridHelper instance Navigator.
+        /// </summary>
+        /// <param name="class">The class for the separator.</param>
+        /// <param name="content">The content for the separator.</param>
+        /// <param name="cloneToTop">The value which defines if the separator added to the bottom pager should be coppied to the top pager.</param>
+        /// <returns>JqGridHelper instance.</returns>
+        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+        public JqGridHelper<TModel> AddNavigatorSeparator(string @class = JqGridNavigatorDefaults.SeparatorClass, string content = "", bool cloneToTop = false)
+        {
+            if (_navigatorOptions == null)
+                throw new InvalidOperationException("In order to call AddNavigatorSeparator method you must call Navigator method first.");
+
+            _navigatorControlsOptions.Add(new JqGridNavigatorSeparatorOptions()
+            {
+                CloneToTop = cloneToTop,
+                Class = @class,
+                Content = content
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds separator to this JqGridHelper instance Navigator.
+        /// </summary>
+        /// <param name="options">The options for the separator.</param>
+        /// <returns>JqGridHelper instance.</returns>
+        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+        public JqGridHelper<TModel> AddNavigatorSeparator(JqGridNavigatorSeparatorOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            if (_navigatorOptions == null)
+                throw new InvalidOperationException("In order to call AddNavigatorSeparator method you must call Navigator method first.");
+
+            _navigatorControlsOptions.Add(options);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Enables filter toolbar for this JqGridHelper instance.
+        /// </summary>
+        /// <param name="options">The options for the filter toolbar.</param>
+        /// <returns>JqGridHelper instance with enabled filter toolbar.</returns>
+        public JqGridHelper<TModel> FilterToolbar(JqGridFilterToolbarOptions options = null)
+        {
+            _filterToolbar = true;
+            _filterToolbarOptions = options;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Enables filter grid for this JqGridHelper instance.
+        /// </summary>
+        /// <param name="model">The model for the filter grid (if null, the model will be build based on ColumnsModels and ColumnsNames).</param>
+        /// <param name="options">The options for the filter grid.</param>
+        /// <returns>JqGridHelper instance with enabled filter grid.</returns>
+        /// <exception cref="System.InvalidOperationException">The filter grid model has not been provided and the automatic generation is not possible because the count of items in ColumnsModel  is different from ColumnsNames.</exception>
+        public JqGridHelper<TModel> FilterGrid(List<JqGridFilterGridRowModel> model = null, JqGridFilterGridOptions options = null)
+        {
+            if (model == null)
+            {
+                if (_options.ColumnsModels.Count != _options.ColumnsNames.Count)
+                    throw new InvalidOperationException("Can't build filter grid model because ColumnsModels.Count is not equal to ColumnsNames.Count");
+
+                _filterGridModel = new List<JqGridFilterGridRowModel>();
+                for (int i = 0; i < _options.ColumnsModels.Count; i++)
+                {
+                    if (_options.ColumnsModels[i].Searchable.GetValueOrDefault())
+                    {
+                        _filterGridModel.Add(new JqGridFilterGridRowModel(_options.ColumnsModels[i].Name, _options.ColumnsNames[i])
+                        {
+                            DefaultValue = _options.ColumnsModels[i].SearchOptions != null ? _options.ColumnsModels[i].SearchOptions.DefaultValue : string.Empty,
+                            SearchType = _options.ColumnsModels[i].SearchType,
+                            SelectUrl = _options.ColumnsModels[i].SearchOptions != null ? _options.ColumnsModels[i].SearchOptions.DataUrl : string.Empty
+                        });
+                    }
+                }
+            }
+            else
+                _filterGridModel = model;
+            _filterGridOptions = options;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets data on footer of this JqGridHelper instance (requires footerEnabled = true).
+        /// </summary>
+        /// <param name="data">The object with values for the footer. Should have names which are the same as names from ColumnsModels.</param>
+        /// <param name="useFormatters">The value indicating if the formatters from columns should be used for footer.</param>
+        /// <returns>JqGridHelper instance with footer data.</returns>
+        public JqGridHelper<TModel> SetFooterData(object data, bool useFormatters = true)
+        {
+            return SetFooterData(AnonymousObjectToDictionary(data), useFormatters);
+        }
+
+        /// <summary>
+        /// Sets data on footer of this JqGridHelper instance (requires footerEnabled = true).
+        /// </summary>
+        /// <param name="data">The dictionary with values for the footer. Should have keys which are the same as names from ColumnsModels.</param>
+        /// <param name="useFormatters">The value indicating if the formatters from columns should be used for footer.</param>
+        /// <returns>JqGridHelper instance with footer data.</returns>
+        public JqGridHelper<TModel> SetFooterData(IDictionary<string, object> data, bool useFormatters = true)
+        {
+            _footerData = data;
+            _footerDataUseFormatters = useFormatters;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets grouping headers for this JqGridHelper instance.
+        /// </summary>
+        /// <param name="groupHeaders">Settings for grouping headers.</param>
+        /// <param name="useColSpanStyle">The value which determines if the non grouping header cell should have cell above it (false), or the column should be treated as one combining boot (true).</param>
+        /// <returns>JqGridHelper instance with grouping header.</returns>
+        /// <exception cref="System.InvalidOperationException">Columns sorting (reordering) is enabled. </exception>
+        public JqGridHelper<TModel> SetGroupHeaders(IEnumerable<JqGridGroupHeader> groupHeaders, bool useColSpanStyle = false)
+        {
+            if (_options.Sortable.GetValueOrDefault())
+                throw new InvalidOperationException("Header grouping can not be set-up when columns sorting (reordering) is enabled.");
+
+            _groupHeaders = groupHeaders;
+            _groupHeadersUseColSpanStyle = useColSpanStyle;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets frozen columns for this JqGridHelper instance.
+        /// </summary>
+        /// <returns>JqGridHelper instance with frozen columns.</returns>
+        /// <exception cref="System.InvalidOperationException">
+        /// <list type="bullet">
+        /// <item><description>TreeGrid is enabled.</description></item>
+        /// <item><description>SubGrid is enabled.</description></item>
+        /// <item><description>Columns sorting (reordering) is enabled.</description></item>
+        /// <item><description>Dynamic scrolling is enabled.</description></item>
+        /// <item><description>Data grouping is enabled.</description></item>
+        /// </list> 
+        /// </exception>
+        public JqGridHelper<TModel> SetFrozenColumns()
+        {
+            if (_options.TreeGridEnabled.GetValueOrDefault())
+                throw new InvalidOperationException("Frozen columns can not be set-up when TreeGrid is enabled.");
+
+            if (_options.SubgridEnabled.GetValueOrDefault())
+                throw new InvalidOperationException("Frozen columns can not be set-up when SubGrid is enabled.");
+
+            if (_options.Sortable.GetValueOrDefault())
+                throw new InvalidOperationException("Frozen columns can not be set-up when columns sorting (reordering) is enabled.");
+
+            if (_options.DynamicScrollingMode != JqGridDynamicScrollingModes.Disabled)
+                throw new InvalidOperationException("Frozen columns can not be set-up when dynamic scrolling is enabled.");
+
+            if (_options.GroupingEnabled.GetValueOrDefault())
+                throw new InvalidOperationException("Frozen columns can not be set-up when data grouping is enabled.");
+
+            _setFrozenColumns = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets some column options with dynamic data, that we can't set in attributes
+        /// </summary>
+        /// <param name="column">Name of column</param>
+        /// <param name="model">Model with data to set</param>
+        /// <returns>This JqGridHelper</returns>
+        /// <exception cref="ArgumentNullException">If column and/or model not defined</exception>
+        /// <exception cref="KeyNotFoundException">If column doesn't exist in model</exception>
+        public JqGridHelper<TModel> ExtendColumnOptions(string column, JqGridExtendColumnModel model)
+        {
+            if (string.IsNullOrWhiteSpace(column))
+                throw new ArgumentNullException(nameof(column));
+            if (_options.ColumnsModels.All(m => m.Name != column))
+                throw new KeyNotFoundException("This column doesn't exist in model.");
+            if (model == null)
+                throw new ArgumentNullException(nameof(model));
+
+            JqGridColumnModel columnModel = _options.ColumnsModels.Single(c => c.Name == column);
+
+            if (model.IsEditOptionsPostDataSetted)
+                columnModel.EditOptions.PostData = model.EditOptionsPostData;
+
+            if (model.IsEditOptionsHtmlAttributesSetted)
+                columnModel.EditOptions.HtmlAttributes = model.EditOptionsHtmlAttributes;
+
+            if (model.IsEditOptionsValueDictionarySetted)
+                columnModel.EditOptions.ValueDictionary = model.EditOptionsValueDictionary;
+
+            if (model.IsLabelOptionsHtmlAttributesSetted)
+                columnModel.LabelOptions.HtmlAttributes = model.LabelOptionsHtmlAttributes;
+
+            if (model.IsLabelOptionsCssStylesSetted)
+                columnModel.LabelOptions.CssStyles = model.LabelOptionsCssStyles;
+
+            if (model.IsSearchOptionsHtmlAttributesSetted)
+                columnModel.SearchOptions.HtmlAttributes = model.SearchOptionsHtmlAttributes;
+
+            if (model.IsSearchOptionsValueDictionarySetted)
+                columnModel.SearchOptions.ValueDictionary = model.SearchOptionsValueDictionary;
+
+            return this;
+        }
+        #endregion
+    }
 }
 

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridHelper.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridHelper.cs
@@ -9,2573 +9,2617 @@ using System.Web.Script.Serialization;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Helper class for generating jqGrid HMTL and JavaScript
-    /// </summary>
-    /// <typeparam name="TModel">Type of model for this grid</typeparam>
-    public class JqGridHelper<TModel> : IJqGridHelper
-    {
-        #region Fields
-        private JqGridOptions<TModel> _options;
-        private JqGridInlineNavigatorOptions _inlineNavigatorOptions;
-        private JqGridNavigatorOptions _navigatorOptions;
-        private JqGridNavigatorActionOptions _navigatorEditActionOptions;
-        private JqGridNavigatorActionOptions _navigatorAddActionOptions;
-        private JqGridNavigatorActionOptions _navigatorDeleteActionOptions;
-        private JqGridNavigatorActionOptions _navigatorSearchActionOptions;
-        private JqGridNavigatorActionOptions _navigatorViewActionOptions;
-        private List<JqGridNavigatorControlOptions> _navigatorControlsOptions = new List<JqGridNavigatorControlOptions>();
-        private bool _filterToolbar = false;
-        private JqGridFilterToolbarOptions _filterToolbarOptions;
-        private List<JqGridFilterGridRowModel> _filterGridModel;
-        private JqGridFilterGridOptions _filterGridOptions;
-        private IDictionary<string, object> _footerData = null;
-        private bool _footerDataUseFormatters = true;
-        private bool _groupHeadersUseColSpanStyle = false;
-        private IEnumerable<JqGridGroupHeader> _groupHeaders = null;
-        private bool _setFrozenColumns = false;
-        private bool _asSubgrid = false;
-        private object _subgridHelper = null;
-        #endregion
-
-        #region Properties
-        /// <summary>
-        /// Gets the grid identifier.
-        /// </summary>
-        public string Id { get { return _options.Id; } }
-
-        private string GridSelector { get { return _asSubgrid ? "'#' + subgridTableId" : String.Format("'#{0}'", Id); } }
-
-        /// <summary>
-        /// Gets the grid pager identifier.
-        /// </summary>
-        public string PagerId { get { return _options.Id + "Pager"; } }
-
-        private string TopPagerSelector { get { return _asSubgrid ? "'#' + subgridTableId + '_toppager'" : String.Format("'#{0}_toppager'", Id); } }
-
-        private string PagerSelector { get { return _asSubgrid ? "'#' + subgridPagerId" : String.Format("'#{0}'", PagerId); } }
-
-        /// <summary>
-        /// Gets the filter grid (div) placeholder identifier.
-        /// </summary>
-        public string FilterGridId { get { return _options.Id + "Search"; } }
-
-        private string FilterGridSelector { get { return _asSubgrid ? "'#' + subgridFilterGridId" : String.Format("'#{0}'", FilterGridId); } }
-        #endregion
-
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridHelper class.
-        /// </summary>
-        /// <param name="id">Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div (id='{0}Search') and in JavaScript.</param>
-        /// <param name="afterInsertRow">The function for event which is raised after every inserted row.</param>
-        /// <param name="afterEditCell">The function for event which is raised after the edited cell is edited.</param>
-        /// <param name="afterRestoreCell">The function for event which is raised after calling the method restoreCell or the user press ESC leaving the changes.</param>
-        /// <param name="afterSaveCell">The function for event which is raised after the cell has been successfully saved.</param>
-        /// <param name="afterSubmitCell">The function for event which is raised after the cell and other data is posted to the server.</param>
-        /// <param name="altClass">The class that is used for alternate rows.</param>
-        /// <param name="altRows">The value indicating if the grid should be "zebra-striped".</param>
-        /// <param name="autoEncode">The value indicating if the grid should auto encode/decode the data.</param>
-        /// <param name="autoWidth">The value indicating if the grid width will be recalculated automatically to the width of the parent element.</param>
-        /// <param name="beforeRequest">The function for event which is raised before requesting any data.</param>
-        /// <param name="beforeSelectRow">The function for event which is raised when the user click on the row, but before selecting it.</param>
-        /// <param name="beforeEditCell">The function for event which is raised before editing the cell.</param>
-        /// <param name="beforeSaveCell">The function for event which is raised before validation of values if any.</param>
-        /// <param name="beforeSubmitCell">The function for event which is raised before submit the cell content to the server.</param>
-        /// <param name="beforeProcessing">This function for event which is raised before proccesing the data returned from the server.</param>
-        /// <param name="caption">The caption for the grid.</param>
-        /// <param name="cellLayout">The padding plus border width of the cell.</param>
-        /// <param name="cellEditingEnabled">The value indicating if cell editing is enabled.</param>
-        /// <param name="cellEditingSubmitMode">The cell editing submit mode.</param>
-        /// <param name="cellEditingUrl">The URL for cell editing submit.</param>
-        /// <param name="dataString">The string of data which will be used when DataType is set to JqGridDataTypes.XmlString or JqGridDataTypes.JsonString.</param>
-        /// <param name="dataType">The type of information to expect to represent data in the grid.</param>
-        /// <param name="deepEmpty">The value indicating if jqGrid should be using jQuery.empty for the the row and all its children elements.</param>
-        /// <param name="direction">The language direction in grid.</param>
-        /// <param name="dynamicScrollingMode">The value which defines if dynamic scrolling is enabled.</param>
-        /// <param name="dynamicScrollingTimeout">The timeout (in miliseconds) if DynamicScrollingMode is set to JqGridDynamicScrollingModes.HoldVisibleRows.</param>
-        /// <param name="editingUrl">The url for inline and form editing</param>
-        /// <param name="emptyRecords">The information to be displayed when the returned (or the current) number of records is zero.</param>
-        /// <param name="expandColumnClick">The value which defines whether the tree is expanded and/or collapsed when user clicks on the text of the expanded column, not only on the image.</param>
-        /// <param name="expandColumn">The name of column which should be used to expand the tree grid.</param>
-        /// <param name="errorCell">The function for event which is raised when there is a server error while saving cell.</param>
-        /// <param name="formatCell">The function for event which allows formatting the cell content before editing.</param>
-        /// <param name="footerEnabled">The value indicating if the footer table (with one row) will be placed below the grid records and above the pager.</param>
-        /// <param name="gridView">The value indicating if all the data should be inserted into DOM with one jQuery call.</param>
-        /// <param name="groupingEnabled">The value indicating if the grouping is enabled.</param>
-        /// <param name="groupingView">The grouping view options.</param>
-        /// <param name="height">The height of the grid in pixels (default 'auto').</param>
-        /// <param name="headerTitles">The value which defines whether the title attribute is added to the column headers.</param>
-        /// <param name="hidden">The value which defines whether the grid is initialy hidden (no data loaded, only caption layer is shown). Takes effect only if the caption is not empty string and hiddenEnabled is true.</param>
-        /// <param name="hoverRows">The value which defines whether the mouse hovering over the grid data rows is enabled</param>
-        /// <param name="ignoreCase">The value which defines whether the local searching is case-sensitive.</param>
-        /// <param name="hiddenEnabled">The value which defines whether the show/hide grid button is enabled. Takes effect only if the caption is not empty string.</param>
-        /// <param name="jsonReader">The JSON reader for the grid.</param>
-        /// <param name="loadBeforeSend">The function for pre-callback to modify the XMLHttpRequest object before it is sent.</param>
-        /// <param name="loadError">The function for event which is raised after the request fails.</param>
-        /// <param name="loadComplete">The function for event which is raised immediately after every server request.</param>
-        /// <param name="loadOnce">The value which defines whether the grid should load the data only once and all further manipulationsshould be done on the client side.</param>
-        /// <param name="methodType">The type of request to make.</param>
-        /// <param name="multiKey">The key which should be pressed when the user makes multiselection.</param>
-        /// <param name="multiBoxOnly">The value which defines whether the multiselection is done only when the checkbox is clicked.</param>
-        /// <param name="multiSelect">The value which defines whether the multiselection is enabled.</param>
-        /// <param name="multiSelectWidth">The width of the multiselect colum.</param>
-        /// <param name="multiSort">The value which defines whether the sorting by multiple columns is enabled.</param>
-        /// <param name="gridComplete">The function for event which is raised after all the data is loaded into the grid and all other processes are complete.</param>
-        /// <param name="onCellSelect">The function for event which is raised when user clicks on particular cell in the grid.</param>
-        /// <param name="onDoubleClickRow">The function for event which is raised immediately after row was double clicked.</param>
-        /// <param name="onHeaderClick">The function for event which is raised after clicking to hide or show grid.</param>
-        /// <param name="onInitGrid">The function for event which is raised only once before populating the data.</param>
-        /// <param name="onPaging">The function for event which is raised before populating the data after page index/size change.</param>
-        /// <param name="onRightClickRow">The function for event which is raised immediately after row was right clicked.</param>
-        /// <param name="onSelectAll">The function for event which is raised when MultipleSelect option is true and user clicks on the header checkbox.</param>
-        /// <param name="onSelectCell">The function for event which is raised after the cell is selected for editing.</param>
-        /// <param name="onSelectRow">The function for event which is raised immediately after row was clicked.</param>
-        /// <param name="onSortCol">The function for event which is raised immediately after sortable column was clicked and before sorting the data.</param>
-        /// <param name="pager">If grid should use a pager bar to navigate through the records.</param>
-        /// <param name="parametersNames">The customized names for jqGrid request parameters.</param>
-        /// <param name="postData">The additional data which will be added to the request.</param>
-        /// <param name="postDataScript">The JavaScript which will dynamically generate the additional data which will be added to the request (this property takes precedence over postData).</param>
-        /// <param name="resizeStart">The function for event which is raised when user starts resizing a column.</param>
-        /// <param name="resizeStop">The function for event which is raised after the column is resized.</param>
-        /// <param name="rowAttributes">The function which can add attributes to the row during the creation of the data (dynamically).</param>
-        /// <param name="rowsList">The array to construct a select box element in the pager in which user can change the number of the visible rows.</param>
-        /// <param name="rowsNumber">How many records should be displayed in the grid.</param>
-        /// <param name="rowsNumbers">The value which defines whether a new column, which purpose is to count the number of available rows, should be added at left of the grid.</param>
-        /// <param name="rowsNumbersWidth">The width of the row number column.</param>
-        /// <param name="shrinkToFit">The value which defines whether the columns width should be recalculated to fit the width of the grid.</param>
-        /// <param name="scrollOffset">The width of vertical scrollbar.</param>
-        /// <param name="serializeCellData">The function for event which can serialize the data passed to the ajax request when the cell is being saved.</param>
-        /// <param name="serializeGridData">The function for event which can serialize the data passed to the ajax request.</param>
-        /// <param name="serializeSubGridData">The function for event which can serialize the data passed to the subgrid ajax request.</param>
-        /// <param name="sortable">The value which defines whether the columns can be reordered by dragging and dropping them with the mouse.</param>
-        /// <param name="sortingName">The initial sorting column index, when  using data returned from server.</param>
-        /// <param name="sortingOrder">The initial sorting order, when  using data returned from server.</param>
-        /// <param name="styleUI">The CSS framework.</param>
-        /// <param name="subgridEnabled">The value which defines if subgrid is enabled.</param>
-        /// <param name="subgridModel">The subgrid model.</param>
-        /// <param name="subgridHelper">The subgrid helper for "Subgrid as Grid" scenario. If this option has value, the SugridModel, SubgridUrl and SubGridRowExpanded options are ignored. It will also add additional parameter 'id' to the request.</param>
-        /// <param name="subgridUrl">The url for subgrid data requests.</param>
-        /// <param name="subgridColumnWidth">The width of subgrid expand/colapse column.</param>
-        /// <param name="subGridBeforeExpand">The function for event which is raised just before expanding the subgrid.</param>
-        /// <param name="subGridRowColapsed">The function for event which is raised when the user clicks on the plus icon of the grid.</param>
-        /// <param name="subGridRowExpanded">The function for event which is raised when the user clicks on the minus icon of the grid.</param>
-        /// <param name="topPager">The value indicating if jqGrid should place a pager element at top of the grid below the caption (if available).</param>
-        /// <param name="treeGridEnabled">The value which defines if TreeGrid is enabled.</param>
-        /// <param name="treeGridModel">The model for TreeGrid.</param>
-        /// <param name="url">The url for data requests.</param>
-        /// <param name="userDataOnFooter">The value indicating if the values from user data should be placed on footer.</param>
-        /// <param name="viewRecords">If grid should display the beginning and ending record number out of the total number of records in the query.</param>
-        /// <param name="width">The width of the grid in pixels.</param>
-        /// <param name="compatibilityMode">The compatibility mode.</param>
-        public JqGridHelper(string id, string afterInsertRow = null, string afterEditCell = null, string afterRestoreCell = null, string afterSaveCell = null, string afterSubmitCell = null, string altClass = JqGridOptionsDefaults.AltClass, bool altRows = false, bool autoEncode = false, bool autoWidth = false, string beforeRequest = null, string beforeSelectRow = null, string beforeEditCell = null, string beforeSaveCell = null, string beforeSubmitCell = null, string beforeProcessing = null, string caption = null, int cellLayout = JqGridOptionsDefaults.CellLayout, bool cellEditingEnabled = false, JqGridCellEditingSubmitModes cellEditingSubmitMode = JqGridCellEditingSubmitModes.Remote, string cellEditingUrl = null, string dataString = null, JqGridDataTypes dataType = JqGridDataTypes.Xml, bool deepEmpty = false, JqGridLanguageDirections direction = JqGridLanguageDirections.Ltr, JqGridDynamicScrollingModes dynamicScrollingMode = JqGridDynamicScrollingModes.Disabled, int dynamicScrollingTimeout = 200, string editingUrl = null, string emptyRecords = JqGridOptionsDefaults.EmptyRecords, bool expandColumnClick = true, string expandColumn = null, int? height = null, string errorCell = null, string formatCell = null, bool footerEnabled = false, bool gridView = false, bool groupingEnabled = false, JqGridGroupingView groupingView = null, bool headerTitles = false, bool hidden = false, bool hiddenEnabled = true, bool hoverRows = true, bool ignoreCase = false, JqGridJsonReader jsonReader = null, string loadBeforeSend = null, string loadError = null, string loadComplete = null, bool loadOnce = false, JqGridMethodTypes methodType = JqGridMethodTypes.Get, JqGridMultiKeys? multiKey = null, bool multiBoxOnly = false, bool multiSelect = false, int multiSelectWidth = 20, bool multiSort = false, string gridComplete = null, string onCellSelect = null, string onDoubleClickRow = null, string onHeaderClick = null, string onInitGrid = null, string onPaging = null, string onRightClickRow = null, string onSelectAll = null, string onSelectCell = null, string onSelectRow = null, string onSortCol = null, bool pager = false, JqGridParametersNames parametersNames = null, object postData = null, string postDataScript = null, string resizeStart = null, string resizeStop = null, string rowAttributes = null, List<int> rowsList = null, int rowsNumber = 20, bool rowsNumbers = false, int rowsNumbersWidth = 25, bool shrinkToFit = true, int scrollOffset = 18, string serializeCellData = null, string serializeGridData = null, string serializeSubGridData = null, bool sortable = false, string sortingName = "", JqGridSortingOrders sortingOrder = JqGridSortingOrders.Asc, JqGridStyleUIOptions styleUI = JqGridStyleUIOptions.jQueryUI, bool subgridEnabled = false, JqGridSubgridModel subgridModel = null, object subgridHelper = null, string subgridUrl = null, int subgridColumnWidth = 20, string subGridBeforeExpand = null, string subGridRowColapsed = null, string subGridRowExpanded = null, bool topPager = false, bool treeGridEnabled = false, JqGridTreeGridModels treeGridModel = JqGridTreeGridModels.Nested, string url = null, bool userDataOnFooter = false, bool viewRecords = false, int? width = null, JqGridCompatibilityModes compatibilityMode = JqGridCompatibilityModes.JqGrid)
-            : this(new JqGridOptions<TModel>(id) { CompatibilityMode = compatibilityMode, AfterInsertRow = afterInsertRow, AfterEditCell = afterEditCell, AfterRestoreCell = afterRestoreCell, AfterSaveCell = afterSaveCell, AfterSubmitCell = afterSubmitCell, AltClass = altClass, AltRows = altRows, AutoEncode = autoEncode, AutoWidth = autoWidth, BeforeRequest = beforeRequest, BeforeSelectRow = beforeSelectRow, BeforeEditCell = beforeEditCell, BeforeSaveCell = beforeSaveCell, BeforeSubmitCell = beforeSubmitCell, BeforeProcessing = beforeProcessing, Caption = caption, CellLayout = cellLayout, CellEditingEnabled = cellEditingEnabled, CellEditingSubmitMode = cellEditingSubmitMode, CellEditingUrl = cellEditingUrl, DataString = dataString, DataType = dataType, DeepEmpty = deepEmpty, Direction = direction, DynamicScrollingMode = dynamicScrollingMode, DynamicScrollingTimeout = dynamicScrollingTimeout, EditingUrl = editingUrl, EmptyRecords = emptyRecords, ExpandColumnClick = expandColumnClick, ExpandColumn = expandColumn, ErrorCell = errorCell, FormatCell = formatCell, FooterEnabled = footerEnabled, GridView = gridView, GroupingEnabled = groupingEnabled, GroupingView = groupingView, Height = height, HeaderTitles = headerTitles, Hidden = hidden, HiddenEnabled = hiddenEnabled, HoverRows = hoverRows, IgnoreCase = ignoreCase, JsonReader = jsonReader, LoadBeforeSend = loadBeforeSend, LoadError = loadError, LoadComplete = loadComplete, LoadOnce = loadOnce, MethodType = methodType, MultiBoxOnly = multiBoxOnly, MultiKey = multiKey, MultiSelect = multiSelect, MultiSelectWidth = multiSelectWidth, MultiSort = multiSort, GridComplete = gridComplete, OnCellSelect = onCellSelect, OnDoubleClickRow = onDoubleClickRow, OnHeaderClick = onHeaderClick, OnInitGrid = onInitGrid, OnPaging = onPaging, OnRightClickRow = onRightClickRow, OnSelectAll = onSelectAll, OnSelectRow = onSelectRow, OnSelectCell = onSelectCell, OnSortCol = onSortCol, Pager = pager, ParametersNames = parametersNames, PostData = postData, PostDataScript = postDataScript, RowAttributes = rowAttributes, RowsList = rowsList, RowsNumber = rowsNumber, RowsNumbers = rowsNumbers, RowsNumbersWidth = rowsNumbersWidth, ShrinkToFit = shrinkToFit, ScrollOffset = scrollOffset, SerializeCellData = serializeCellData, SerializeGridData = serializeGridData, SerializeSubGridData = serializeSubGridData, Sortable = sortable, SortingName = sortingName, SortingOrder = sortingOrder, StyleUI = styleUI, SubgridEnabled = subgridEnabled, SubgridModel = subgridModel, SubgridUrl = subgridUrl, SubgridColumnWidth = subgridColumnWidth, SubGridBeforeExpand = subGridBeforeExpand, SubGridRowColapsed = subGridRowColapsed, SubGridRowExpanded = subGridRowExpanded, TopPager = topPager, TreeGridEnabled = treeGridEnabled, TreeGridModel = treeGridModel, Url = url, UserDataOnFooter = userDataOnFooter, ViewRecords = viewRecords, Width = width }, subgridHelper)
-        {
-            _options.JsonReader = _options.JsonReader ?? JqGridResponse.JsonReader;
-            _options.ParametersNames = _options.ParametersNames ?? JqGridRequest.ParameterNames;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the JqGridHelper class.
-        /// </summary>
-        /// <param name="options">Options for the grid</param>
-        /// <param name="subgridHelper">The subgrid helper for "Subgrid as Grid" scenario. If this option has value, the SugridModel, SubgridUrl and SubGridRowExpanded options are ignored. It will also add additional parameter 'id' to the request.</param>
-        public JqGridHelper(JqGridOptions<TModel> options, object subgridHelper = null)
-        {
-            _options = options;
-
-            if (subgridHelper != null)
-            {
-                Type subgridHelperType = subgridHelper.GetType();
-                if (!subgridHelperType.IsGenericType || subgridHelperType.GetGenericTypeDefinition() != typeof(JqGridHelper<>))
-                    throw new ArgumentException("The object must be of type JqGridHelper<T>.", "subgridHelper");
-                _subgridHelper = subgridHelper;
-            }
-        }
-        #endregion
-
-        #region Methods
-        /// <summary>
-        /// Returns the HTML that is used to render the table placeholder for the grid. 
-        /// </summary>
-        /// <returns>The HTML that represents the table placeholder for jqGrid</returns>
-        public MvcHtmlString GetTableHtml()
-        {
-            return MvcHtmlString.Create(String.Format("<table id='{0}'></table>", Id));
-        }
-
-        /// <summary>
-        /// Returns the HTML that is used to render the pager (div) placeholder for the grid. 
-        /// </summary>
-        /// <returns>The HTML that represents the pager (div) placeholder for jqGrid</returns>
-        public MvcHtmlString GetPagerHtml()
-        {
-            return MvcHtmlString.Create(String.Format("<div id='{0}'></div>", PagerId));
-        }
-
-        /// <summary>
-        /// Returns the HTML that is used to render the filter grid (div) placeholder for the grid. 
-        /// </summary>
-        /// <returns>The HTML that represents the filter grid (div) placeholder for jqGrid</returns>
-        public MvcHtmlString GetFilterGridHtml()
-        {
-            return MvcHtmlString.Create(String.Format("<div id='{0}'></div>", FilterGridId));
-        }
-
-        /// <summary>
-        /// Returns the HTML that is used to render the table placeholder for the grid with pager placeholder below it and filter grid (if enabled) placeholder above it.
-        /// </summary>
-        /// <returns>The HTML that represents the table placeholder for jqGrid with pager placeholder below i</returns>
-        public MvcHtmlString GetHtml()
-        {
-            if (_filterGridModel != null && _options.Pager)
-                return MvcHtmlString.Create(GetFilterGridHtml().ToHtmlString() + GetTableHtml().ToHtmlString() + GetPagerHtml().ToHtmlString());
-            else if (_filterGridModel != null)
-                return MvcHtmlString.Create(GetFilterGridHtml().ToHtmlString() + GetTableHtml().ToHtmlString());
-            else if (_options.Pager)
-                return MvcHtmlString.Create(GetTableHtml().ToHtmlString() + GetPagerHtml().ToHtmlString());
-            else
-                return MvcHtmlString.Create(GetTableHtml().ToHtmlString());
-        }
-
-        /// <summary>
-        /// Return the JavaScript that is used to initialize jqGrid with given options.
-        /// </summary>
-        /// <returns>The JavaScript that initializes jqGrid with give options</returns>
-        /// <exception cref="System.InvalidOperationException">
-        /// <list type="bullet">
-        /// <item><description>TreeGrid and data grouping are both enabled.</description></item>
-        /// <item><description>Rows numbers and data grouping are both enabled.</description></item>
-        /// <item><description>Dynamic scrolling and data grouping are both enabled.</description></item>
-        /// <item><description>TreeGrid and GridView are both enabled.</description></item>
-        /// <item><description>SubGrid and GridView are both enabled.</description></item>
-        /// <item><description>AfterInsertRow event and GridView are both enabled.</description></item>
-        /// </list> 
-        /// </exception>
-        public MvcHtmlString GetJavaScript()
-        {
-            ValidateLimitations();
-
-            StringBuilder javaScriptBuilder = new StringBuilder();
-
-            javaScriptBuilder.AppendFormat("$({0}).jqGrid({{", GridSelector).AppendLine();
-            AppendColumnsNames(javaScriptBuilder);
-            AppendColumnsModels(javaScriptBuilder);
-            AppendOptions(javaScriptBuilder);
-            javaScriptBuilder.Append("})");
-
-            foreach (JqGridColumnModel columnModel in _options.ColumnsModels)
-            {
-                if (columnModel.LabelOptions != null)
-                    AppendColumnLabelOptions(columnModel.Name, columnModel.LabelOptions, javaScriptBuilder);
-            }
-
-            if (_options.FooterEnabled && _footerData != null && _footerData.Count > 0)
-                AppendFooterData(javaScriptBuilder);
-
-            if (_navigatorOptions != null)
-                AppendNavigator(javaScriptBuilder);
-
-            if (_inlineNavigatorOptions != null)
-                AppendInlineNavigator(javaScriptBuilder);
-
-            if (_filterToolbar)
-                AppendFilterToolbar(javaScriptBuilder);
-
-            if (_groupHeaders != null && _groupHeaders.Count() > 0)
-                AppendGroupHeaders(javaScriptBuilder);
-
-            if (_setFrozenColumns)
-                javaScriptBuilder.Append(".jqGrid('setFrozenColumns')");
-
-            javaScriptBuilder.AppendLine(";");
-
-            if (_filterGridModel != null)
-                AppendFilterGrid(javaScriptBuilder);
-
-            return MvcHtmlString.Create(javaScriptBuilder.ToString());
-        }
-
-        internal string GetSubGridRowExpanded()
-        {
-            _asSubgrid = true;
-
-            StringBuilder subGridRowExpandedBuilder = new StringBuilder();
-            subGridRowExpandedBuilder.AppendLine("function(subgridId, rowId) {");
-
-            if (_filterGridModel != null)
-            {
-                subGridRowExpandedBuilder.AppendLine("var subgridFilterGridId = subgridId + '_s';");
-                subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<div id=\"' + subgridFilterGridId + '\"></div>');");
-            }
-
-            subGridRowExpandedBuilder.AppendLine("var subgridTableId = subgridId + '_t';");
-            subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<table id=\"' + subgridTableId + '\"></table>');");
-
-            if (_options.Pager)
-            {
-                subGridRowExpandedBuilder.AppendLine("var subgridPagerId = subgridId + '_p';");
-                subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<div id=\"' + subgridPagerId + '\"></div>');");
-            }
-
-            subGridRowExpandedBuilder.AppendLine(GetJavaScript().ToString());
-
-            subGridRowExpandedBuilder.Append("}");
-            return subGridRowExpandedBuilder.ToString();
-        }
-
-        private void ValidateLimitations()
-        {
-            if (_options.TreeGridEnabled && _options.GroupingEnabled)
-                throw new InvalidOperationException("TreeGrid and data grouping can not be enabled at the same time.");
-
-            if (_options.RowsNumbers && _options.GroupingEnabled)
-                throw new InvalidOperationException("Rows numbers and data grouping can not be enabled at the same time.");
-
-            if (_options.DynamicScrollingMode != JqGridDynamicScrollingModes.Disabled && _options.GroupingEnabled)
-                throw new InvalidOperationException("Dynamic scrolling and data grouping can not be enabled at the same time.");
-
-            if (_options.TreeGridEnabled && _options.GridView)
-                throw new InvalidOperationException("TreeGrid and GridView can not be enabled at the same time.");
-
-            if (_options.SubgridEnabled && _options.GridView)
-                throw new InvalidOperationException("SubGrid and GridView can not be enabled at the same time.");
-
-            if (!String.IsNullOrWhiteSpace(_options.AfterInsertRow) && _options.GridView)
-                throw new InvalidOperationException("AfterInsertRow event and GridView can not be enabled at the same time.");
-        }
-
-        private void AppendColumnsNames(StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.Append("colNames: [");
-
-            foreach(string columnName in _options.ColumnsNames)
-                javaScriptBuilder.AppendFormat("'{0}',", columnName);
-
-            if (javaScriptBuilder[javaScriptBuilder.Length - 1] == ',')
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-
-            javaScriptBuilder.AppendLine("],");
-        }
-
-        private void AppendColumnsModels(StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.AppendLine("colModel: [");
-
-            int lastColumnModelIndex = _options.ColumnsModels.Count - 1;
-            for (int columnModelIndex = 0; columnModelIndex < _options.ColumnsModels.Count; columnModelIndex++)
-            {
-                JqGridColumnModel columnModel = _options.ColumnsModels[columnModelIndex];
-                javaScriptBuilder.Append("{ ");
-
-                if (columnModel.Alignment != JqGridAlignments.Left)
-                    javaScriptBuilder.AppendFormat("align: '{0}', ", columnModel.Alignment.ToString().ToLower());
-
-                if (!String.IsNullOrWhiteSpace(columnModel.Index))
-                    javaScriptBuilder.AppendFormat("index: '{0}', ", columnModel.Index);
-
-                if (!String.IsNullOrWhiteSpace(columnModel.CellAttributes))
-                    javaScriptBuilder.AppendFormat("cellattr: {0}, ", columnModel.CellAttributes);
-
-                if (!String.IsNullOrWhiteSpace(columnModel.Classes))
-                    javaScriptBuilder.AppendFormat("classes: '{0}', ", columnModel.Classes);
-
-                if (columnModel.DateFormat != JqGridOptionsDefaults.DateFormat)
-                    javaScriptBuilder.AppendFormat("datefmt: '{0}', ", columnModel.DateFormat);
-
-                if (columnModel.Editable)
-                {
-                    javaScriptBuilder.Append("editable: true, ");
-                    if (columnModel.EditType != JqGridColumnEditTypes.Text)
-                        javaScriptBuilder.AppendFormat("edittype: '{0}', ", columnModel.EditType.ToString().ToLower());
-                    AppendEditOptions(columnModel.EditOptions, javaScriptBuilder);
-                    AppendColumnRules("editrules", columnModel.EditRules, javaScriptBuilder);
-                    AppendFormOptions(columnModel.FormOptions, javaScriptBuilder);
-                }
-
-                if (columnModel.Fixed)
-                    javaScriptBuilder.Append("fixed: true, ");
-
-                if (columnModel.Frozen)
-                    javaScriptBuilder.Append("frozen: true, ");
-
-                if (!String.IsNullOrWhiteSpace(columnModel.Formatter))
-                {
-                    javaScriptBuilder.AppendFormat("formatter: {0}, ", columnModel.Formatter);
-                    AppendFormatterOptions(columnModel.Formatter, columnModel.FormatterOptions, javaScriptBuilder);
-                    if (!String.IsNullOrWhiteSpace(columnModel.UnFormatter))
-                        javaScriptBuilder.AppendFormat("unformat: {0}, ", columnModel.UnFormatter);
-                }
-
-                if (columnModel.InitialSortingOrder != JqGridSortingOrders.Asc)
-                    javaScriptBuilder.Append("firstsortorder: 'desc', ");
-
-                if (columnModel.Hidden)
-                    javaScriptBuilder.Append("hidden: true, ");
-
-                if (columnModel.HideInDialog)
-                    javaScriptBuilder.Append("hidedlg: true, ");
-
-                if (!String.IsNullOrWhiteSpace(columnModel.JsonMapping))
-                    javaScriptBuilder.AppendFormat("jsonmap: '{0}', ", columnModel.JsonMapping);
-
-                if (columnModel.Key)
-                    javaScriptBuilder.Append("key: true, ");
-
-                if (!columnModel.Resizable)
-                    javaScriptBuilder.Append("resizable: false, ");
-
-                if (columnModel.Searchable)
-                {
-                    if (columnModel.SearchType != JqGridColumnSearchTypes.Text)
-                        javaScriptBuilder.AppendFormat("stype: '{0}', ", columnModel.SearchType.ToString().ToLower());
-                    AppendSearchOptions(columnModel.SearchOptions, javaScriptBuilder);
-                    AppendColumnRules("searchrules", columnModel.SearchRules, javaScriptBuilder);
-                }
-                else
-                    javaScriptBuilder.AppendFormat("search: false, ");
-
-                if (_options.GroupingEnabled)
-                {
-                    if (columnModel.SummaryType.HasValue)
-                    {
-                        if (columnModel.SummaryType.Value != JqGridColumnSummaryTypes.Custom)
-                            javaScriptBuilder.AppendFormat("summaryType: '{0}', ", columnModel.SummaryType.Value.ToString().ToLower());
-                        else
-                            javaScriptBuilder.AppendFormat("summaryType: {0}, ", columnModel.SummaryFunction);
-                    }
-
-                    if (columnModel.SummaryTemplate != "{0}")
-                        javaScriptBuilder.AppendFormat("summaryTpl: '{0}', ", columnModel.SummaryTemplate);
-                }
-
-                if (!columnModel.Sortable)
-                {
-                    javaScriptBuilder.AppendFormat("sortable: false, ");
-                }
-                else if (columnModel.SortType != JqGridColumnSortTypes.Text)
-                {
-                    if (columnModel.SortType == JqGridColumnSortTypes.Function && !String.IsNullOrEmpty(columnModel.SortFunction))
-                        javaScriptBuilder.AppendFormat("sorttype: {0}, ", columnModel.SortFunction);
-                    else if (columnModel.SortType != JqGridColumnSortTypes.Function)
-                        javaScriptBuilder.AppendFormat("sorttype: '{0}', ", columnModel.SortType.ToString().ToLower());
-                }
-
-                if (!columnModel.Title)
-                    javaScriptBuilder.AppendFormat("title: false, ");
-
-                if (columnModel.Width != 150)
-                    javaScriptBuilder.AppendFormat("width: {0}, ", columnModel.Width);
-
-                if (!columnModel.Viewable)
-                    javaScriptBuilder.AppendFormat("viewable: false, ");
-
-                if (!String.IsNullOrWhiteSpace(columnModel.XmlMapping))
-                    javaScriptBuilder.AppendFormat("xmlmap: '{0}', ", columnModel.XmlMapping);
-
-                javaScriptBuilder.AppendFormat("name: '{0}' }}", columnModel.Name);
-
-                if (lastColumnModelIndex == columnModelIndex)
-                    javaScriptBuilder.AppendLine();
-                else
-                    javaScriptBuilder.AppendLine(",");
-            }
-
-            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 1);
-
-            javaScriptBuilder.AppendLine("],");
-        }
-
-        private void AppendEditOptions(JqGridColumnEditOptions editOptions, StringBuilder javaScriptBuilder)
-        {
-            if (editOptions != null)
-            {
-                JavaScriptSerializer serializer = new JavaScriptSerializer();
-                javaScriptBuilder.Append("editoptions: { ");
-
-                if (!String.IsNullOrWhiteSpace(editOptions.CustomElementFunction))
-                    javaScriptBuilder.AppendFormat("custom_element: {0}, ", editOptions.CustomElementFunction);
-
-                if (!String.IsNullOrWhiteSpace(editOptions.CustomValueFunction))
-                    javaScriptBuilder.AppendFormat("custom_value: {0}, ", editOptions.CustomValueFunction);
-
-                if (editOptions.InternalDataEvents != null)
-                {
-                    if (editOptions.DataEvents == null)
-                        editOptions.DataEvents = new List<JqGridColumnDataEvent>();
-
-                    foreach (JqGridColumnDataEvent dataEvent in editOptions.InternalDataEvents)
-                        editOptions.DataEvents.Add(new JqGridColumnDataEvent(dataEvent.Type, String.Format(dataEvent.Function, _options.Id)));
-                }
-                AppendElementOptions(editOptions, serializer, javaScriptBuilder);
-
-                if (editOptions.NullIfEmpty)
-                    javaScriptBuilder.AppendFormat("NullIfEmpty: true, ", editOptions.CustomValueFunction);
-
-                if (editOptions.HtmlAttributes != null && editOptions.HtmlAttributes.Count > 0)
-                {
-                    string htmlAttributesSerialized = serializer.Serialize(editOptions.HtmlAttributes);
-                    javaScriptBuilder.AppendFormat("{0}, ", htmlAttributesSerialized.Substring(1, htmlAttributesSerialized.Length - 2));
-                }
-
-                if (!String.IsNullOrWhiteSpace(editOptions.PostDataScript))
-                    javaScriptBuilder.AppendFormat("postData: {0}, ", editOptions.PostDataScript);
-                else if (editOptions.PostData != null)
-                {
-                    serializer = new JavaScriptSerializer();
-                    javaScriptBuilder.AppendFormat("postData: {0}, ", serializer.Serialize(editOptions.PostData));
-                }
-
-                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                    javaScriptBuilder.Append(" }, ");
-                }
-                else
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 15, 15);
-            }
-        }
-
-        private void AppendElementOptions(JqGridColumnElementOptions elementOptions, JavaScriptSerializer serializer, StringBuilder javaScriptBuilder)
-        {
-            if (!String.IsNullOrWhiteSpace(elementOptions.BuildSelect))
-                javaScriptBuilder.AppendFormat("buildSelect: {0}, ", elementOptions.BuildSelect);
-
-            if (elementOptions.DataEvents != null && elementOptions.DataEvents.Count() > 0)
-            {
-                javaScriptBuilder.Append("dataEvents: [ ");
-                foreach (JqGridColumnDataEvent dataEvent in elementOptions.DataEvents)
-                {
-                    if (dataEvent.Data == null)
-                        javaScriptBuilder.AppendFormat("{{ type: '{0}', fn: {1} }}, ", dataEvent.Type, dataEvent.Function);
-                    else
-                        javaScriptBuilder.AppendFormat("{{ type: '{0}', data: {1}, fn: {2} }}, ", dataEvent.Type, serializer.Serialize(dataEvent.Data), dataEvent.Function);
-                }
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append(" ], ");
-            }
-
-            if (elementOptions.JQueryUIWidgetDataInitRenderer != null)
-                javaScriptBuilder.AppendFormat("dataInit: {0}, ", elementOptions.JQueryUIWidgetDataInitRenderer(_options.CompatibilityMode, GridSelector));
-            else if (!String.IsNullOrWhiteSpace(elementOptions.DataInit))
-                javaScriptBuilder.AppendFormat("dataInit: {0}, ", elementOptions.DataInit);
-
-            if (!String.IsNullOrWhiteSpace(elementOptions.DataUrl))
-                javaScriptBuilder.AppendFormat("dataUrl: '{0}', ", elementOptions.DataUrl);
-
-            if (!String.IsNullOrWhiteSpace(elementOptions.DefaultValue))
-                javaScriptBuilder.AppendFormat("defaultValue: '{0}', ", elementOptions.DefaultValue);
-
-            if (!String.IsNullOrWhiteSpace(elementOptions.Value))
-                javaScriptBuilder.AppendFormat("value: '{0}', ", elementOptions.Value);
-            else if (elementOptions.ValueDictionary != null)
-                javaScriptBuilder.AppendFormat("value: {0}, ", serializer.Serialize(elementOptions.ValueDictionary));
-        }
-
-        private static void AppendColumnRules(string rulesName, JqGridColumnRules rules, StringBuilder javaScriptBuilder)
-        {
-            if (rules != null)
-            {
-                javaScriptBuilder.AppendFormat("{0}: {{ ", rulesName);
-
-                if (rules.Custom)
-                {
-                    javaScriptBuilder.Append("custom: true, ");
-
-                    if (!String.IsNullOrWhiteSpace(rules.CustomFunction))
-                        javaScriptBuilder.AppendFormat("custom_func: {0}, ", rules.CustomFunction);
-                }
-
-                if (rules.Date)
-                    javaScriptBuilder.Append("date: true, ");
-
-                if (rules.EditHidden)
-                    javaScriptBuilder.Append("edithidden: true, ");
-
-                if (rules.Email)
-                    javaScriptBuilder.Append("email: true, ");
-
-                if (rules.Integer)
-                    javaScriptBuilder.Append("integer: true, ");
-
-                if (rules.MaxValue.HasValue)
-                    javaScriptBuilder.AppendFormat("maxValue: {0}, ", rules.MaxValue.Value);
-
-                if (rules.MinValue.HasValue)
-                    javaScriptBuilder.AppendFormat("minValue: {0}, ", rules.MinValue.Value);
-
-                if (rules.Number)
-                    javaScriptBuilder.Append("number: true, ");
-
-                if (rules.Required)
-                    javaScriptBuilder.Append("required: true, ");
-
-                if (rules.Time)
-                    javaScriptBuilder.Append("time: true, ");
-
-                if (rules.Url)
-                    javaScriptBuilder.Append("url: true, ");
-
-                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                    javaScriptBuilder.Append(" }, ");
-                }
-                else
-                {
-                    int rulesNameLength = rulesName.Length + 4;
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - rulesNameLength, rulesNameLength);
-                }
-            }
-        }
-
-        private static void AppendFormOptions(JqGridColumnFormOptions formOptions, StringBuilder javaScriptBuilder)
-        {
-            if (formOptions != null)
-            {
-                javaScriptBuilder.Append("formoptions: { ");
-
-                if (formOptions.ColumnPosition.HasValue)
-                    javaScriptBuilder.AppendFormat("colpos: {0},", formOptions.ColumnPosition.Value);
-
-                if (!String.IsNullOrWhiteSpace(formOptions.ElementPrefix))
-                    javaScriptBuilder.AppendFormat("elmprefix: '{0}',", formOptions.ElementPrefix);
-
-                if (!String.IsNullOrWhiteSpace(formOptions.ElementSuffix))
-                    javaScriptBuilder.AppendFormat("elmsuffix: '{0}',", formOptions.ElementSuffix);
-
-                if (!String.IsNullOrWhiteSpace(formOptions.Label))
-                    javaScriptBuilder.AppendFormat("label: '{0}',", formOptions.Label);
-
-                if (formOptions.RowPosition.HasValue)
-                    javaScriptBuilder.AppendFormat("rowpos: {0},", formOptions.RowPosition.Value);
-
-                if (javaScriptBuilder[javaScriptBuilder.Length - 1] == ',')
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-                    javaScriptBuilder.Append(" }, ");
-                }
-                else
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 15, 15);
-            }
-        }
-
-        private static void AppendFormatterOptions(string formatter, JqGridColumnFormatterOptions formatterOptions, StringBuilder javaScriptBuilder)
-        {
-            if (formatterOptions != null && !formatterOptions.IsDefault(formatter))
-            {
-                javaScriptBuilder.Append("formatoptions: { ");
-
-                switch (formatter)
-                {
-                    case JqGridColumnPredefinedFormatters.Integer:
-                        javaScriptBuilder.AppendFormat("{0}{1}", (formatterOptions.DefaultValue == JqGridOptionsDefaults.IntegerFormatterDefaultValue) ? String.Empty : String.Format("defaultValue: '{0}', ", formatterOptions.DefaultValue), (formatterOptions.ThousandsSeparator == JqGridOptionsDefaults.FormatterThousandsSeparator) ? String.Empty : String.Format("thousandsSeparator: '{0}', ", formatterOptions.ThousandsSeparator));
-                        break;
-                    case JqGridColumnPredefinedFormatters.Number:
-                        javaScriptBuilder.AppendFormat("{0}{1}{2}{3}", (formatterOptions.DecimalPlaces == JqGridOptionsDefaults.FormatterDecimalPlaces) ? String.Empty : String.Format("decimalPlaces: {0}, ", formatterOptions.DecimalPlaces), (formatterOptions.DecimalSeparator == JqGridOptionsDefaults.FormatterDecimalSeparator) ? String.Empty : String.Format("decimalSeparator: '{0}', ", formatterOptions.DecimalSeparator), (formatterOptions.DefaultValue == JqGridOptionsDefaults.NumberFormatterDefaultValue) ? String.Empty : String.Format("defaultValue: '{0}', ", formatterOptions.DefaultValue), (formatterOptions.ThousandsSeparator == JqGridOptionsDefaults.FormatterThousandsSeparator) ? String.Empty : String.Format("thousandsSeparator: '{0}', ", formatterOptions.ThousandsSeparator));
-                        break;
-                    case JqGridColumnPredefinedFormatters.Currency:
-                        javaScriptBuilder.AppendFormat("{0}{1}{2}{3}{4}{5}", (formatterOptions.DecimalPlaces == JqGridOptionsDefaults.FormatterDecimalPlaces) ? String.Empty : String.Format("decimalPlaces: {0}, ", formatterOptions.DecimalPlaces), (formatterOptions.DecimalSeparator == JqGridOptionsDefaults.FormatterDecimalSeparator) ? String.Empty : String.Format("decimalSeparator: '{0}', ", formatterOptions.DecimalSeparator), (formatterOptions.DefaultValue == JqGridOptionsDefaults.NumberFormatterDefaultValue) ? String.Empty : String.Format("defaultValue: '{0}', ", formatterOptions.DefaultValue), String.IsNullOrWhiteSpace(formatterOptions.Prefix) ? String.Empty : String.Format("prefix: '{0}', ", formatterOptions.Prefix), String.IsNullOrWhiteSpace(formatterOptions.Suffix) ? String.Empty : String.Format("suffix: '{0}', ", formatterOptions.Suffix), (formatterOptions.ThousandsSeparator == JqGridOptionsDefaults.FormatterThousandsSeparator) ? String.Empty : String.Format("thousandsSeparator: '{0}', ", formatterOptions.ThousandsSeparator));
-                        break;
-                    case JqGridColumnPredefinedFormatters.Date:
-                        javaScriptBuilder.AppendFormat("{0}{1}", (formatterOptions.SourceFormat == JqGridOptionsDefaults.FormatterSourceFormat) ? String.Empty : String.Format("srcformat: '{0}', ", formatterOptions.SourceFormat), (formatterOptions.OutputFormat == JqGridOptionsDefaults.FormatterOutputFormat) ? String.Empty : String.Format("newformat: '{0}', ", formatterOptions.OutputFormat));
-                        break;
-                    case JqGridColumnPredefinedFormatters.Link:
-                        javaScriptBuilder.AppendFormat("target: '{0}', ", formatterOptions.Target);
-                        break;
-                    case JqGridColumnPredefinedFormatters.ShowLink:
-                        javaScriptBuilder.AppendFormat("{0}{1}{2}{3}{4}", String.IsNullOrWhiteSpace(formatterOptions.BaseLinkUrl) ? String.Empty : String.Format("baseLinkUrl: '{0}', ", formatterOptions.BaseLinkUrl), String.IsNullOrWhiteSpace(formatterOptions.ShowAction) ? String.Empty : String.Format("showAction: '{0}', ", formatterOptions.ShowAction), String.IsNullOrWhiteSpace(formatterOptions.AddParam) ? String.Empty : String.Format("addParam: '{0}', ", formatterOptions.AddParam), String.IsNullOrWhiteSpace(formatterOptions.Target) ? String.Empty : String.Format("target: '{0}', ", formatterOptions.Target), (formatterOptions.IdName == JqGridOptionsDefaults.FormatterIdName) ? String.Empty : String.Format("idName: '{0}', ", formatterOptions.IdName));
-                        break;
-                    case JqGridColumnPredefinedFormatters.CheckBox:
-                        javaScriptBuilder.Append("disabled: false, ");
-                        break;
-                    case JqGridColumnPredefinedFormatters.Actions:
-                        javaScriptBuilder.AppendFormat("{0}{1}{2}", formatterOptions.EditButton ? String.Empty : "editbutton: false, ", formatterOptions.DeleteButton ? String.Empty : "delbutton: false, ", !formatterOptions.UseFormEditing ? String.Empty : "editformbutton: true, ");
-
-                        if (formatterOptions.EditButton)
-                        {
-                            if (!formatterOptions.UseFormEditing && formatterOptions.InlineEditingOptions != null)
-                            {
-                                if (formatterOptions.InlineEditingOptions.Keys)
-                                    javaScriptBuilder.Append("keys: true, ");
-
-                                if (!String.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.OnEditFunction))
-                                    javaScriptBuilder.AppendFormat("onEdit: {0}, ", formatterOptions.InlineEditingOptions.OnEditFunction);
-
-                                if (!String.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.SuccessFunction))
-                                    javaScriptBuilder.AppendFormat("onSuccess: {0}, ", formatterOptions.InlineEditingOptions.SuccessFunction);
-
-                                if (!String.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.Url))
-                                    javaScriptBuilder.AppendFormat("url: '{0}', ", formatterOptions.InlineEditingOptions.Url);
-
-                                if (!String.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.ExtraParamScript))
-                                    javaScriptBuilder.AppendFormat("extraparam: {0}, ", formatterOptions.InlineEditingOptions.ExtraParamScript);
-                                else if (formatterOptions.InlineEditingOptions.ExtraParam != null)
-                                {
-                                    JavaScriptSerializer serializer = new JavaScriptSerializer();
-                                    javaScriptBuilder.AppendFormat("extraparam: {0}, ", serializer.Serialize(formatterOptions.InlineEditingOptions.ExtraParam));
-                                }
-
-                                if (!String.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.AfterSaveFunction))
-                                    javaScriptBuilder.AppendFormat("afterSave: {0}, ", formatterOptions.InlineEditingOptions.AfterSaveFunction);
-
-                                if (!String.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.ErrorFunction))
-                                    javaScriptBuilder.AppendFormat("onError: {0}, ", formatterOptions.InlineEditingOptions.ErrorFunction);
-
-                                if (!String.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.AfterRestoreFunction))
-                                    javaScriptBuilder.AppendFormat("afterRestore: {0}, ", formatterOptions.InlineEditingOptions.AfterRestoreFunction);
-
-                                if (!formatterOptions.InlineEditingOptions.RestoreAfterError)
-                                    javaScriptBuilder.Append("restoreAfterError: false, ");
-
-                                if (formatterOptions.InlineEditingOptions.MethodType != JqGridMethodTypes.Post)
-                                    javaScriptBuilder.Append("mtype: 'GET', ");
-                            }
-                            else if (formatterOptions.UseFormEditing && formatterOptions.FormEditingOptions != null)
-                                AppendNavigatorActionOptions("editOptions: ", formatterOptions.FormEditingOptions, javaScriptBuilder);
-                        }
-
-                        if (formatterOptions.DeleteButton && formatterOptions.DeleteOptions != null)
-                            AppendNavigatorActionOptions("delOptions: ", formatterOptions.DeleteOptions, javaScriptBuilder);
-                        break;
-                }
-
-                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                    javaScriptBuilder.Append(" }, ");
-                }
-                else
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 17, 17);
-            }
-        }
-
-        private void AppendSearchOptions(JqGridColumnSearchOptions searchOptions, StringBuilder javaScriptBuilder)
-        {
-            if (searchOptions != null)
-            {
-                JavaScriptSerializer serializer = new JavaScriptSerializer();
-                javaScriptBuilder.Append("searchoptions: { ");
-
-                AppendElementOptions(searchOptions, serializer, javaScriptBuilder);
-
-                if (searchOptions.HtmlAttributes != null && searchOptions.HtmlAttributes.Count > 0)
-                    javaScriptBuilder.AppendFormat("attr: {0}, ", serializer.Serialize(searchOptions.HtmlAttributes));
-
-                if (!searchOptions.ClearSearch)
-                    javaScriptBuilder.AppendFormat("clearSearch: false, ");
-
-                if (searchOptions.SearchHidden)
-                    javaScriptBuilder.AppendFormat("searchhidden: true, ");
-
-                AppendSearchOperators(searchOptions.SearchOperators, javaScriptBuilder);
-
-                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                    javaScriptBuilder.Append(" }, ");
-                }
-                else
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 17, 17);
-            }
-        }
-
-        private static void AppendSearchOperators(JqGridSearchOperators? searchOperators, StringBuilder javaScriptBuilder)
-        {
-            if (searchOperators.HasValue && searchOperators.Value != (JqGridSearchOperators)32768)
-            {
-                javaScriptBuilder.Append("sopt: [ ");
-                foreach (JqGridSearchOperators searchOperator in Enum.GetValues(typeof(JqGridSearchOperators)))
-                {
-                    if (searchOperator != JqGridSearchOperators.EqualOrNotEqual && searchOperator != JqGridSearchOperators.NoTextOperators && searchOperator != JqGridSearchOperators.TextOperators && (searchOperators.Value & searchOperator) == searchOperator)
-                        javaScriptBuilder.AppendFormat("'{0}',", Enum.GetName(typeof(JqGridSearchOperators), searchOperator).ToLower());
-                }
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-                javaScriptBuilder.Append("], ");
-            }
-        }
-
-        private void AppendOptions(StringBuilder javaScriptBuilder)
-        {
-            if (!String.IsNullOrWhiteSpace(_options.AfterInsertRow))
-                javaScriptBuilder.AppendFormat("afterInsertRow: {0},", _options.AfterInsertRow).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.AfterEditCell))
-                javaScriptBuilder.AppendFormat("afterEditCell: {0},", _options.AfterEditCell).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.AfterRestoreCell))
-                javaScriptBuilder.AppendFormat("afterRestoreCell: {0},", _options.AfterRestoreCell).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.AfterSaveCell))
-                javaScriptBuilder.AppendFormat("afterSaveCell: {0},", _options.AfterSaveCell).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.AfterSubmitCell))
-                javaScriptBuilder.AppendFormat("afterSubmitCell: {0},", _options.AfterSubmitCell).AppendLine();
-
-            if (_options.AltClass != JqGridOptionsDefaults.AltClass)
-                javaScriptBuilder.AppendFormat("altclass: '{0}',", _options.AltClass).AppendLine();
-
-            if (_options.AltRows)
-                javaScriptBuilder.Append("altRows: true,").AppendLine();
-
-            if (_options.AutoEncode)
-                javaScriptBuilder.Append("autoencode: true,").AppendLine();
-
-            if (_options.AutoWidth)
-                javaScriptBuilder.Append("autowidth: true,").AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.BeforeRequest))
-                javaScriptBuilder.AppendFormat("beforeRequest: {0},", _options.BeforeRequest).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.BeforeSelectRow))
-                javaScriptBuilder.AppendFormat("beforeSelectRow: {0},", _options.BeforeSelectRow).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.BeforeEditCell))
-                javaScriptBuilder.AppendFormat("beforeEditCell: {0},", _options.BeforeEditCell).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.BeforeSaveCell))
-                javaScriptBuilder.AppendFormat("beforeSaveCell: {0},", _options.BeforeSaveCell).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.BeforeSubmitCell))
-                javaScriptBuilder.AppendFormat("beforeSubmitCell: {0},", _options.BeforeSubmitCell).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.BeforeProcessing))
-                javaScriptBuilder.AppendFormat("beforeProcessing: {0},", _options.BeforeProcessing).AppendLine();
-
-            if (_options.CellLayout != JqGridOptionsDefaults.CellLayout)
-                javaScriptBuilder.AppendFormat("cellLayout: {0},", _options.CellLayout).AppendLine();
-
-            if (_options.CellEditingEnabled)
-            {
-                javaScriptBuilder.Append("cellEdit: true,").AppendLine();
-                if (_options.CellEditingSubmitMode != JqGridCellEditingSubmitModes.Remote)
-                    javaScriptBuilder.Append("cellsubmit: 'clientArray',").AppendLine();
-
-                if (!String.IsNullOrWhiteSpace(_options.CellEditingUrl))
-                    javaScriptBuilder.AppendFormat("cellurl: '{0}',", _options.CellEditingUrl).AppendLine();
-            }
-
-            if (!String.IsNullOrEmpty(_options.Caption))
-            {
-                javaScriptBuilder.AppendFormat("caption: '{0}',", _options.Caption).AppendLine();
-
-                if (!_options.HiddenEnabled)
-                    javaScriptBuilder.Append("hidegrid: false,").AppendLine();
-                else if (_options.Hidden)
-                    javaScriptBuilder.Append("hiddengrid: true,").AppendLine();
-            }
-
-            if (_options.UseDataString())
-                javaScriptBuilder.AppendFormat("datastr: '{0}',", _options.DataString).AppendLine();
-            else if (_asSubgrid)
-            {
-                if (_options.Url.Contains("?"))
-                    javaScriptBuilder.AppendFormat("url: '{0}&id=' + encodeURIComponent(rowId),", _options.Url).AppendLine();
-                else
-                    javaScriptBuilder.AppendFormat("url: '{0}?id=' + encodeURIComponent(rowId),", _options.Url).AppendLine();
-            }
-            else
-                javaScriptBuilder.AppendFormat("url: '{0}',", _options.Url).AppendLine();
-
-            if (_options.DataType != JqGridDataTypes.Xml)
-                javaScriptBuilder.AppendFormat("datatype: '{0}',", _options.DataType.ToString().ToLower()).AppendLine();
-
-            if (_options.DeepEmpty)
-                javaScriptBuilder.Append("deepempty: true,").AppendLine();
-
-            if (_options.Direction != JqGridLanguageDirections.Ltr)
-                javaScriptBuilder.Append("direction: 'rtl',").AppendLine();
-
-            if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldAllRows)
-                javaScriptBuilder.Append("scroll: true,").AppendLine();
-            else if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldVisibleRows)
-            {
-                javaScriptBuilder.Append("scroll: 10,").AppendLine();
-                if (_options.DynamicScrollingTimeout != 200)
-                    javaScriptBuilder.AppendFormat("scrollTimeout: {0},", _options.DynamicScrollingTimeout).AppendLine();
-            }
-
-            if (_options.EmptyRecords != JqGridOptionsDefaults.EmptyRecords)
-                javaScriptBuilder.AppendFormat("emptyrecords: '{0}',", _options.EmptyRecords).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.EditingUrl))
-                javaScriptBuilder.AppendFormat("editurl: '{0}',", _options.EditingUrl).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.ErrorCell))
-                javaScriptBuilder.AppendFormat("errorCell: {0},", _options.ErrorCell).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.FormatCell))
-                javaScriptBuilder.AppendFormat("formatCell: {0},", _options.FormatCell).AppendLine();
-
-            if (_options.FooterEnabled)
-            {
-                javaScriptBuilder.Append("footerrow: true,").AppendLine();
-                if (_options.UserDataOnFooter)
-                    javaScriptBuilder.Append("userDataOnFooter: true,").AppendLine();
-            }
-
-            if (_options.GridView)
-                javaScriptBuilder.Append("gridview: true,").AppendLine();
-
-            if (_options.GroupingEnabled)
-            {
-                javaScriptBuilder.Append("grouping: true,").AppendLine();
-                AppendGroupingView(javaScriptBuilder);
-            }
-
-            if (_options.HeaderTitles)
-                javaScriptBuilder.Append("headertitles: true,").AppendLine();
-
-            if (!_options.HoverRows)
-                javaScriptBuilder.Append("hoverrows: false").AppendLine();
-
-            if (_options.IgnoreCase)
-                javaScriptBuilder.Append("ignoreCase: true,").AppendLine();
-
-            AppendJsonReader(javaScriptBuilder);
-
-            if (!String.IsNullOrWhiteSpace(_options.LoadBeforeSend))
-                javaScriptBuilder.AppendFormat("loadBeforeSend: {0},", _options.LoadBeforeSend).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.LoadComplete))
-                javaScriptBuilder.AppendFormat("loadComplete: {0},", _options.LoadComplete).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.LoadError))
-                javaScriptBuilder.AppendFormat("loadError: {0},", _options.LoadError).AppendLine();
-
-            if (_options.LoadOnce)
-                javaScriptBuilder.Append("loadonce: true,").AppendLine();
-
-            if (_options.MethodType != JqGridMethodTypes.Get)
-                javaScriptBuilder.AppendFormat("mtype: 'POST',").AppendLine();
-
-            if (_options.MultiKey.HasValue)
-                javaScriptBuilder.AppendFormat("multikey: '{0}Key',", _options.MultiKey.Value.ToString().ToLower()).AppendLine();
-
-            if (_options.MultiBoxOnly)
-                javaScriptBuilder.Append("multiboxonly: true,").AppendLine();
-
-            if (_options.MultiSelect)
-                javaScriptBuilder.Append("multiselect: true,").AppendLine();
-
-            if (_options.MultiSelectWidth != 20)
-                javaScriptBuilder.AppendFormat("multiselectWidth: {0},", _options.MultiSelectWidth).AppendLine();
-
-            if (_options.MultiSort)
-                javaScriptBuilder.Append("multiSort: true,").AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.GridComplete))
-                javaScriptBuilder.AppendFormat("gridComplete: {0},", _options.GridComplete).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnCellSelect))
-                javaScriptBuilder.AppendFormat("onCellSelect: {0},", _options.OnCellSelect).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnDoubleClickRow))
-                javaScriptBuilder.AppendFormat("ondblClickRow: {0},", _options.OnDoubleClickRow).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnHeaderClick))
-                javaScriptBuilder.AppendFormat("onHeaderClick: {0},", _options.OnHeaderClick).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnInitGrid))
-                javaScriptBuilder.AppendFormat("onInitGrid: {0},", _options.OnInitGrid).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnPaging))
-                javaScriptBuilder.AppendFormat("onPaging: {0},", _options.OnPaging).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnRightClickRow))
-                javaScriptBuilder.AppendFormat("onRightClickRow: {0},", _options.OnRightClickRow).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnSelectAll))
-                javaScriptBuilder.AppendFormat("onSelectAll: {0},", _options.OnSelectAll).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnSelectCell))
-                javaScriptBuilder.AppendFormat("onSelectCell: {0},", _options.OnSelectCell).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnSelectRow))
-                javaScriptBuilder.AppendFormat("onSelectRow: {0},", _options.OnSelectRow).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.OnSortCol))
-                javaScriptBuilder.AppendFormat("onSortCol: {0},", _options.OnSortCol).AppendLine();
-
-            if (_options.Pager)
-                javaScriptBuilder.AppendFormat("pager: {0},", PagerSelector).AppendLine();
-
-            AppendParametersNames(javaScriptBuilder);
-
-            if (!String.IsNullOrWhiteSpace(_options.PostDataScript))
-                javaScriptBuilder.AppendFormat("postData: {0},", _options.PostDataScript).AppendLine();
-            else if (_options.PostData != null)
-            {
-                JavaScriptSerializer serializer = new JavaScriptSerializer();
-                javaScriptBuilder.AppendFormat("postData: {0},", serializer.Serialize(_options.PostData));
-            }
-
-            if (!String.IsNullOrWhiteSpace(_options.ResizeStart))
-                javaScriptBuilder.AppendFormat("resizeStart: {0},", _options.ResizeStart).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.ResizeStop))
-                javaScriptBuilder.AppendFormat("resizeStop: {0},", _options.ResizeStop).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.RowAttributes))
-                javaScriptBuilder.AppendFormat("rowattr: {0},", _options.RowAttributes).AppendLine();
-
-            if (_options.RowsList != null && _options.RowsList.Count > 0)
-            {
-                javaScriptBuilder.Append("rowList: [");
-                javaScriptBuilder.Append(String.Join(",", _options.RowsList));
-                javaScriptBuilder.Append("],").AppendLine();
-            }
-
-            if (_options.RowsNumber != 20)
-                javaScriptBuilder.AppendFormat("rowNum: {0},", _options.RowsNumber).AppendLine();
-
-            if (_options.RowsNumbers)
-                javaScriptBuilder.Append("rownumbers: true,").AppendLine();
-
-            if (_options.RowsNumbersWidth != 25)
-                javaScriptBuilder.AppendFormat("rownumWidth: {0},", _options.RowsNumbersWidth).AppendLine();
-
-            if (_options.ColumnsRemaping != null && _options.ColumnsRemaping.Count > 0)
-            {
-                javaScriptBuilder.Append("remapColumns: [");
-                javaScriptBuilder.Append(String.Join(",", _options.ColumnsRemaping));
-                javaScriptBuilder.Append("],").AppendLine();
-            }
-
-            if (!_options.ShrinkToFit)
-                javaScriptBuilder.Append("shrinkToFit: false,").AppendLine();
-
-            if (_options.ScrollOffset != 18)
-                javaScriptBuilder.AppendFormat("scrollOffset: {0},", _options.ScrollOffset).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.SerializeCellData))
-                javaScriptBuilder.AppendFormat("serializeCellData: {0},", _options.SerializeCellData).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.SerializeGridData))
-                javaScriptBuilder.AppendFormat("serializeGridData: {0},", _options.SerializeGridData).AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.SerializeSubGridData))
-                javaScriptBuilder.AppendFormat("serializeSubGridData: {0},", _options.SerializeSubGridData).AppendLine();
-
-            if (_options.Sortable)
-                javaScriptBuilder.Append("sortable: true,").AppendLine();
-
-            if (!String.IsNullOrWhiteSpace(_options.SortingName))
-                javaScriptBuilder.AppendFormat("sortname: '{0}',", _options.SortingName).AppendLine();
-
-            if (_options.SortingOrder != JqGridSortingOrders.Asc)
-                javaScriptBuilder.Append("sortorder: 'desc',").AppendLine();
-
-            if (_options.StyleUI != JqGridStyleUIOptions.jQueryUI)
-                javaScriptBuilder.AppendFormat("styleUI: '{0}',", _options.StyleUI.ToString()).AppendLine();
-
-            if (_options.SubgridEnabled)
-            {
-                javaScriptBuilder.Append("subGrid: true,").AppendLine();
-
-                if (_options.SubgridColumnWidth != 20)
-                    javaScriptBuilder.AppendFormat("subGridWidth: {0},", _options.SubgridColumnWidth).AppendLine();
-
-                if (!String.IsNullOrWhiteSpace(_options.SubGridBeforeExpand))
-                    javaScriptBuilder.AppendFormat("subGridBeforeExpand: {0},", _options.SubGridBeforeExpand).AppendLine();
-
-                if (_subgridHelper != null)
-                {
-                    Type subgridHelperType = _subgridHelper.GetType();
-                    javaScriptBuilder.AppendFormat("subGridRowExpanded: {0},", subgridHelperType.GetMethod("GetSubGridRowExpanded", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).Invoke(_subgridHelper, null)).AppendLine();
-                }
-                else
-                {
-                    AppendSubgridModel(javaScriptBuilder);
-
-                    if (!String.IsNullOrWhiteSpace(_options.SubgridUrl))
-                        javaScriptBuilder.AppendFormat("subGridUrl: '{0}',", _options.SubgridUrl).AppendLine();
-
-
-                    if (!String.IsNullOrWhiteSpace(_options.SubGridRowExpanded))
-                        javaScriptBuilder.AppendFormat("subGridRowExpanded: {0},", _options.SubGridRowExpanded).AppendLine();
-                }
-
-                if (!String.IsNullOrWhiteSpace(_options.SubGridRowColapsed))
-                    javaScriptBuilder.AppendFormat("subGridRowColapsed: {0},", _options.SubGridRowColapsed).AppendLine();
-            }
-
-            if (_options.TopPager)
-                javaScriptBuilder.AppendFormat("toppager: true,").AppendLine();
-
-            if (_options.TreeGridEnabled)
-            {
-                if (!_options.ExpandColumnClick)
-                    javaScriptBuilder.AppendFormat("ExpandColClick: false,").AppendLine();
-
-                if (!String.IsNullOrWhiteSpace(_options.ExpandColumn))
-                    javaScriptBuilder.AppendFormat("ExpandColumn: '{0}',", _options.ExpandColumn).AppendLine();
-
-                javaScriptBuilder.AppendFormat("treeGrid: true,").AppendLine();
-
-                if (_options.TreeGridModel != JqGridTreeGridModels.Nested)
-                    javaScriptBuilder.AppendFormat("treeGridModel: 'adjacency',").AppendLine();
-            }
-
-            if (_options.ViewRecords)
-                javaScriptBuilder.AppendFormat("viewrecords: true,").AppendLine();
-
-            if (_options.Width.HasValue)
-                javaScriptBuilder.AppendFormat("width: {0},", _options.Width.Value).AppendLine();
-
-            if (_options.Height.HasValue)
-                javaScriptBuilder.AppendFormat("height: {0}", _options.Height.Value).AppendLine();
-            else
-                javaScriptBuilder.AppendLine("height: '100%'");
-        }
-
-        private void AppendJsonReader(StringBuilder javaScriptBuilder)
-        {
-            if (!_options.JsonReader.IsDefault())
-            {
-                javaScriptBuilder.Append("jsonReader: { ");
-
-                if (_options.JsonReader.Records != JqGridOptionsDefaults.ResponseRecords)
-                    javaScriptBuilder.AppendFormat("root: '{0}', ", _options.JsonReader.Records);
-
-                if (_options.JsonReader.PageIndex != JqGridOptionsDefaults.ResponsePageIndex)
-                    javaScriptBuilder.AppendFormat("page: '{0}', ", _options.JsonReader.PageIndex);
-
-                if (_options.JsonReader.TotalPagesCount != JqGridOptionsDefaults.ResponseTotalPagesCount)
-                    javaScriptBuilder.AppendFormat("total: '{0}', ", _options.JsonReader.TotalPagesCount);
-
-                if (_options.JsonReader.TotalRecordsCount != JqGridOptionsDefaults.ResponseTotalRecordsCount)
-                    javaScriptBuilder.AppendFormat("records: '{0}', ", _options.JsonReader.TotalRecordsCount);
-
-                if (!_options.JsonReader.RepeatItems)
-                    javaScriptBuilder.Append("repeatitems: false, ");
-
-                if (_options.JsonReader.RecordValues != JqGridOptionsDefaults.ResponseRecordValues)
-                    javaScriptBuilder.AppendFormat("cell: '{0}', ", _options.JsonReader.RecordValues);
-
-                if (_options.JsonReader.RecordId != JqGridOptionsDefaults.ResponseRecordId)
-                    javaScriptBuilder.AppendFormat("id: '{0}', ", _options.JsonReader.RecordId);
-
-                if (_options.JsonReader.UserData != JqGridOptionsDefaults.ResponseUserData)
-                    javaScriptBuilder.AppendFormat("userdata: '{0}', ", _options.JsonReader.UserData);
-
-                if (!_options.JsonReader.SubgridReader.IsDefault())
-                {
-                    javaScriptBuilder.Append("subgrid: { ");
-
-                    if (_options.JsonReader.SubgridReader.Records != JqGridOptionsDefaults.ResponseRecords)
-                        javaScriptBuilder.AppendFormat("root: '{0}', ", _options.JsonReader.SubgridReader.Records);
-
-                    if (!_options.JsonReader.SubgridReader.RepeatItems)
-                        javaScriptBuilder.Append("repeatitems: false, ");
-
-                    if (_options.JsonReader.SubgridReader.RecordValues != JqGridOptionsDefaults.ResponseRecordValues)
-                        javaScriptBuilder.AppendFormat("cell: '{0}', ", _options.JsonReader.SubgridReader.RecordValues);
-
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                    javaScriptBuilder.Append(" }, ");
-                }
-
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append(" }, ").AppendLine();
-            }
-        }
-
-        private void AppendParametersNames(StringBuilder javaScriptBuilder)
-        {
-            if (!_options.ParametersNames.IsDefault())
-            {
-                javaScriptBuilder.Append("prmNames: { ");
-
-                if (_options.ParametersNames.PageIndex != JqGridOptionsDefaults.RequestPageIndex)
-                    javaScriptBuilder.AppendFormat("page: '{0}', ", _options.ParametersNames.PageIndex);
-
-                if (_options.ParametersNames.RecordsCount != JqGridOptionsDefaults.RequestRecordsCount)
-                    javaScriptBuilder.AppendFormat("rows: '{0}', ", _options.ParametersNames.RecordsCount);
-
-                if (_options.ParametersNames.SortingName != JqGridOptionsDefaults.RequestSortingName)
-                    javaScriptBuilder.AppendFormat("sort: '{0}', ", _options.ParametersNames.SortingName);
-
-                if (_options.ParametersNames.SortingOrder != JqGridOptionsDefaults.RequestSortingOrder)
-                    javaScriptBuilder.AppendFormat("order: '{0}', ", _options.ParametersNames.SortingOrder);
-
-                if (_options.ParametersNames.Searching != JqGridOptionsDefaults.RequestSearching)
-                    javaScriptBuilder.AppendFormat("search: '{0}', ", _options.ParametersNames.Searching);
-
-                if (_options.ParametersNames.Id != JqGridOptionsDefaults.RequestId)
-                    javaScriptBuilder.AppendFormat("id: '{0}', ", _options.ParametersNames.Id);
-
-                if (_options.ParametersNames.Operator != JqGridOptionsDefaults.RequestOperator)
-                    javaScriptBuilder.AppendFormat("oper: '{0}', ", _options.ParametersNames.Operator);
-
-                if (_options.ParametersNames.EditOperator != JqGridOptionsDefaults.RequestEditOperator)
-                    javaScriptBuilder.AppendFormat("editoper: '{0}', ", _options.ParametersNames.EditOperator);
-
-                if (_options.ParametersNames.AddOperator != JqGridOptionsDefaults.RequestAddOperator)
-                    javaScriptBuilder.AppendFormat("addoper: '{0}', ", _options.ParametersNames.AddOperator);
-
-                if (_options.ParametersNames.DeleteOperator != JqGridOptionsDefaults.RequestDeleteOperator)
-                    javaScriptBuilder.AppendFormat("deloper: '{0}', ", _options.ParametersNames.DeleteOperator);
-
-                if (_options.ParametersNames.SubgridId != JqGridOptionsDefaults.RequestSubgridId)
-                    javaScriptBuilder.AppendFormat("subgridid: '{0}', ", _options.ParametersNames.SubgridId);
-
-                if (!String.IsNullOrWhiteSpace(_options.ParametersNames.PagesCount))
-                    javaScriptBuilder.AppendFormat("npage: '{0}', ", _options.ParametersNames.PagesCount);
-
-                if (_options.ParametersNames.TotalRows != JqGridOptionsDefaults.RequestTotalRows)
-                    javaScriptBuilder.AppendFormat("totalrows: '{0}', ", _options.ParametersNames.TotalRows);
-
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append(" }, ").AppendLine();
-            }
-        }
-
-        private void AppendGroupingView(StringBuilder javaScriptBuilder)
-        {
-            if (_options.GroupingView != null)
-            {
-                javaScriptBuilder.Append("groupingView: { ");
-
-                if (_options.GroupingView.Fields != null && _options.GroupingView.Fields.Length > 0)
-                {
-                    javaScriptBuilder.Append("groupField: [");
-                    foreach(string field in _options.GroupingView.Fields)
-                        javaScriptBuilder.AppendFormat("'{0}', ", field);
-                    javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-                }
-
-                if (_options.GroupingView.Orders != null && _options.GroupingView.Orders.Length > 0 && _options.GroupingView.Orders.Contains(JqGridSortingOrders.Desc))
-                {
-                    javaScriptBuilder.Append("groupOrder: [");
-                    foreach (JqGridSortingOrders order in _options.GroupingView.Orders)
-                        javaScriptBuilder.AppendFormat("'{0}', ", order.ToString().ToLower());
-                    javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-                }
-
-                if (_options.GroupingView.Texts != null && _options.GroupingView.Texts.Length > 0)
-                {
-                    javaScriptBuilder.Append("groupText: [");
-                    foreach (string text in _options.GroupingView.Texts)
-                        javaScriptBuilder.AppendFormat("'{0}', ", text);
-                    javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-                }
-
-                if (_options.GroupingView.Summary != null && _options.GroupingView.Summary.Length > 0 && _options.GroupingView.Summary.Contains(true))
-                {
-                    javaScriptBuilder.Append("groupSummary: [");
-                    foreach (bool summary in _options.GroupingView.Summary)
-                        javaScriptBuilder.AppendFormat("{0}, ", summary.ToString().ToLower());
-                    javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-                }
-
-                if (_options.GroupingView.ColumnShow != null && _options.GroupingView.ColumnShow.Length > 0 && _options.GroupingView.ColumnShow.Contains(false))
-                {
-                    javaScriptBuilder.Append("groupColumnShow: [");
-                    foreach (bool columnShow in _options.GroupingView.ColumnShow)
-                        javaScriptBuilder.AppendFormat("{0}, ", columnShow.ToString().ToLower());
-                    javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-                }
-
-                if (_options.GroupingView.IsInTheSameGroupCallbacks != null && _options.GroupingView.IsInTheSameGroupCallbacks.Length > 0)
-                {
-                    javaScriptBuilder.Append("isInTheSameGroup: [");
-                    foreach (string isInTheSameGroupCallback in _options.GroupingView.IsInTheSameGroupCallbacks)
-                        javaScriptBuilder.AppendFormat("{0}, ", isInTheSameGroupCallback);
-                    javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-                }
-
-                if (_options.GroupingView.FormatDisplayFieldCallbacks != null && _options.GroupingView.FormatDisplayFieldCallbacks.Length > 0)
-                {
-                    javaScriptBuilder.Append("formatDisplayField: [");
-                    foreach (string formatDisplayFieldCallback in _options.GroupingView.FormatDisplayFieldCallbacks)
-                        javaScriptBuilder.AppendFormat("{0}, ", formatDisplayFieldCallback);
-                    javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
-                }
-
-                if (_options.GroupingView.SummaryOnHide)
-                    javaScriptBuilder.Append("showSummaryOnHide: true, ");
-
-                if (_options.GroupingView.DataSorted)
-                    javaScriptBuilder.Append("groupDataSorted: true, ");
-
-                if (_options.GroupingView.Collapse)
-                    javaScriptBuilder.Append("groupCollapse: true, ");
-
-                if (_options.GroupingView.PlusIcon != JqGridOptionsDefaults.GroupingPlusIcon)
-                    javaScriptBuilder.AppendFormat("plusicon: '{0}', ", _options.GroupingView.PlusIcon);
-
-                if (_options.GroupingView.MinusIcon != JqGridOptionsDefaults.GroupingMinusIcon)
-                    javaScriptBuilder.AppendFormat("minusicon: '{0}', ", _options.GroupingView.MinusIcon);
-
-                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                    javaScriptBuilder.Append(" }, ").AppendLine();
-                }
-                else
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 16, 16);
-            }
-        }
-
-        private void AppendSubgridModel(StringBuilder javaScriptBuilder)
-        {
-            if (_options.SubgridModel != null)
-            {
-                javaScriptBuilder.AppendLine("subGridModel: [{ ");
-
-                javaScriptBuilder.Append("name: [");
-                foreach (string columnName in _options.SubgridModel.ColumnsNames)
-                    javaScriptBuilder.AppendFormat("'{0}',", columnName);
-                if (_options.SubgridModel.ColumnsNames.Count > 0)
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-                javaScriptBuilder.AppendLine("],");
-
-                javaScriptBuilder.Append("align: [");
-                foreach (JqGridAlignments alignments in _options.SubgridModel.ColumnsAlignments)
-                    javaScriptBuilder.AppendFormat("'{0}',", alignments.ToString().ToLower());
-                if (_options.SubgridModel.ColumnsAlignments.Count > 0)
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-                javaScriptBuilder.AppendLine("],");
-
-                javaScriptBuilder.Append("width: [");
-                foreach (int width in _options.SubgridModel.ColumnsWidths)
-                    javaScriptBuilder.AppendFormat("{0},", width);
-                if (_options.SubgridModel.ColumnsWidths.Count > 0)
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-                javaScriptBuilder.AppendLine("]");
-
-                javaScriptBuilder.AppendLine(" }],");
-            }
-        }
-
-        private void AppendNavigator(StringBuilder javaScriptBuilder)
-        {
-            string navigatorPagerSelector = _navigatorOptions.Pager == JqGridNavigatorPagers.Top ? TopPagerSelector : PagerSelector;
-            javaScriptBuilder.AppendFormat(".jqGrid('navGrid', {0},", navigatorPagerSelector).AppendLine();
-            AppendNavigatorOptions(javaScriptBuilder);
-
-            if (_navigatorEditActionOptions != null || _navigatorAddActionOptions != null || _navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
-            {
-                javaScriptBuilder.AppendLine(",");
-                AppendNavigatorActionOptions(String.Empty, _navigatorEditActionOptions, javaScriptBuilder);
-                if (_navigatorAddActionOptions != null || _navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
-                {
-                    javaScriptBuilder.AppendLine(",");
-                    AppendNavigatorActionOptions(String.Empty, _navigatorAddActionOptions, javaScriptBuilder);
-                    if (_navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
-                    {
-                        javaScriptBuilder.AppendLine(",");
-                        AppendNavigatorActionOptions(String.Empty, _navigatorDeleteActionOptions, javaScriptBuilder);
-                        if (_navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
-                        {
-                            javaScriptBuilder.AppendLine(",");
-                            AppendNavigatorActionOptions(String.Empty, _navigatorSearchActionOptions, javaScriptBuilder);
-                            if (_navigatorViewActionOptions != null)
-                            {
-                                javaScriptBuilder.AppendLine(",");
-                                AppendNavigatorActionOptions(String.Empty, _navigatorViewActionOptions, javaScriptBuilder);
-                            }
-                        }
-                    }
-                }
-            }
-
-            javaScriptBuilder.Append(")");
-
-            foreach (JqGridNavigatorControlOptions controlOptions in _navigatorControlsOptions)
-            {
-                if (controlOptions is JqGridNavigatorButtonOptions)
-                {
-                    JqGridNavigatorButtonOptions buttonOptions = (JqGridNavigatorButtonOptions)controlOptions;
-                    AppendNavigatorButton(navigatorPagerSelector, buttonOptions, javaScriptBuilder);
-                    if (_navigatorOptions.Pager == JqGridNavigatorPagers.Standard && controlOptions.CloneToTop)
-                        AppendNavigatorButton(TopPagerSelector, buttonOptions, javaScriptBuilder);
-                }
-                else if (controlOptions is JqGridNavigatorSeparatorOptions)
-                {
-                    JqGridNavigatorSeparatorOptions separatorOptions = (JqGridNavigatorSeparatorOptions)controlOptions;
-                    AppendNavigatorSeparator(navigatorPagerSelector, separatorOptions, javaScriptBuilder);
-                    if (_navigatorOptions.Pager == JqGridNavigatorPagers.Standard && controlOptions.CloneToTop)
-                        AppendNavigatorSeparator(TopPagerSelector, separatorOptions, javaScriptBuilder);
-                }
-            }
-        }
-
-        private static void AppendBaseNavigatorOptions(JqGridNavigatorOptionsBase baseNavigatorOptions, StringBuilder javaScriptBuilder)
-        {
-            if (!baseNavigatorOptions.Add)
-                javaScriptBuilder.Append("add: false, ");
-
-            if (baseNavigatorOptions.AddIcon != JqGridNavigatorDefaults.AddIcon)
-                javaScriptBuilder.AppendFormat("addicon: '{0}', ", baseNavigatorOptions.AddIcon);
-
-            if (!String.IsNullOrEmpty(baseNavigatorOptions.AddText))
-                javaScriptBuilder.AppendFormat("addtext: '{0}', ", baseNavigatorOptions.AddText);
-
-            if (baseNavigatorOptions.AddToolTip != JqGridNavigatorDefaults.AddToolTip)
-                javaScriptBuilder.AppendFormat("addtitle: '{0}', ", baseNavigatorOptions.AddToolTip);
-
-            if (!baseNavigatorOptions.Edit)
-                javaScriptBuilder.Append("edit: false, ");
-
-            if (baseNavigatorOptions.EditIcon != JqGridNavigatorDefaults.EditIcon)
-                javaScriptBuilder.AppendFormat("editicon: '{0}', ", baseNavigatorOptions.EditIcon);
-
-            if (!String.IsNullOrEmpty(baseNavigatorOptions.EditText))
-                javaScriptBuilder.AppendFormat("edittext: '{0}', ", baseNavigatorOptions.EditText);
-
-            if (baseNavigatorOptions.EditToolTip != JqGridNavigatorDefaults.EditToolTip)
-                javaScriptBuilder.AppendFormat("edittitle: '{0}', ", baseNavigatorOptions.EditToolTip);
-
-            if (baseNavigatorOptions.Position != JqGridAlignments.Left)
-                javaScriptBuilder.AppendFormat("position: '{0}', ", baseNavigatorOptions.Position.ToString().ToLower());
-        }
-
-        private void AppendNavigatorOptions(StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.Append("{ ");
-
-            AppendBaseNavigatorOptions(_navigatorOptions, javaScriptBuilder);
-
-            if (_navigatorOptions.AlertCaption != JqGridNavigatorDefaults.AlertCaption)
-                javaScriptBuilder.AppendFormat("alertcap: '{0}', ", _navigatorOptions.AlertCaption);
-
-            if (_navigatorOptions.AlertText != JqGridNavigatorDefaults.AlertText)
-                javaScriptBuilder.AppendFormat("alerttext: '{0}', ", _navigatorOptions.AlertText);
-
-            if (_navigatorOptions.CloneToTop)
-                javaScriptBuilder.Append("cloneToTop: true, ");
-
-            if (!_navigatorOptions.CloseOnEscape)
-                javaScriptBuilder.Append("closeOnEscape: false, ");
-
-            if (!_navigatorOptions.Delete)
-                javaScriptBuilder.Append("del: false, ");
-
-            if (_navigatorOptions.DeleteIcon != JqGridNavigatorDefaults.DeleteIcon)
-                javaScriptBuilder.AppendFormat("delicon: '{0}', ", _navigatorOptions.DeleteIcon);
-
-            if (!String.IsNullOrEmpty(_navigatorOptions.DeleteText))
-                javaScriptBuilder.AppendFormat("deltext: '{0}', ", _navigatorOptions.DeleteText);
-
-            if (_navigatorOptions.DeleteToolTip != JqGridNavigatorDefaults.DeleteToolTip)
-                javaScriptBuilder.AppendFormat("deltitle: '{0}', ", _navigatorOptions.DeleteToolTip);
-
-            if (!_navigatorOptions.Refresh)
-                javaScriptBuilder.Append("refresh: false, ");
-
-            if (_navigatorOptions.RefreshIcon != JqGridNavigatorDefaults.RefreshIcon)
-                javaScriptBuilder.AppendFormat("refreshicon: '{0}', ", _navigatorOptions.RefreshIcon);
-
-            if (!String.IsNullOrEmpty(_navigatorOptions.RefreshText))
-                javaScriptBuilder.AppendFormat("refreshtext: '{0}', ", _navigatorOptions.RefreshText);
-
-            if (_navigatorOptions.RefreshToolTip != JqGridNavigatorDefaults.RefreshToolTip)
-                javaScriptBuilder.AppendFormat("refreshtitle: '{0}', ", _navigatorOptions.RefreshToolTip);
-
-            if (_navigatorOptions.RefreshMode != JqGridRefreshModes.FirstPage)
-                javaScriptBuilder.Append("refreshstate: 'current', ");
-
-            if (!String.IsNullOrWhiteSpace(_navigatorOptions.AfterRefresh))
-                javaScriptBuilder.AppendFormat("afterRefresh: {0}, ", _navigatorOptions.AfterRefresh);
-
-            if (!String.IsNullOrWhiteSpace(_navigatorOptions.BeforeRefresh))
-                javaScriptBuilder.AppendFormat("beforeRefresh: {0}, ", _navigatorOptions.BeforeRefresh);
-
-            if (!_navigatorOptions.Search)
-                javaScriptBuilder.Append("search: false, ");
-
-            if (_navigatorOptions.SearchIcon != JqGridNavigatorDefaults.SearchIcon)
-                javaScriptBuilder.AppendFormat("searchicon: '{0}', ", _navigatorOptions.SearchIcon);
-
-            if (!String.IsNullOrEmpty(_navigatorOptions.SearchText))
-                javaScriptBuilder.AppendFormat("searchtext: '{0}', ", _navigatorOptions.SearchText);
-
-            if (_navigatorOptions.SearchToolTip != JqGridNavigatorDefaults.SearchToolTip)
-                javaScriptBuilder.AppendFormat("searchtitle: '{0}', ", _navigatorOptions.SearchToolTip);
-
-            if (_navigatorOptions.View)
-                javaScriptBuilder.Append("view: true, ");
-
-            if (_navigatorOptions.ViewIcon != JqGridNavigatorDefaults.ViewIcon)
-                javaScriptBuilder.AppendFormat("viewicon: '{0}', ", _navigatorOptions.ViewIcon);
-
-            if (!String.IsNullOrEmpty(_navigatorOptions.ViewText))
-                javaScriptBuilder.AppendFormat("viewtext: '{0}', ", _navigatorOptions.ViewText);
-
-            if (_navigatorOptions.ViewToolTip != JqGridNavigatorDefaults.ViewToolTip)
-                javaScriptBuilder.AppendFormat("viewtitle: '{0}', ", _navigatorOptions.ViewToolTip);
-
-            if (!String.IsNullOrWhiteSpace(_navigatorOptions.AddFunction))
-                javaScriptBuilder.AppendFormat("addfunc: {0}, ", _navigatorOptions.AddFunction);
-
-            if (!String.IsNullOrWhiteSpace(_navigatorOptions.EditFunction))
-                javaScriptBuilder.AppendFormat("editfunc: {0}, ", _navigatorOptions.EditFunction);
-
-            if (!String.IsNullOrWhiteSpace(_navigatorOptions.DeleteFunction))
-                javaScriptBuilder.AppendFormat("delfunc: {0}, ", _navigatorOptions.DeleteFunction);
-
-            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-            {
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append(" }");
-            }
-            else
-                javaScriptBuilder.Append("}");
-        }
-
-        private static void AppendNavigatorActionOptions(string optionsName, JqGridNavigatorActionOptions actionOptions, StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.AppendFormat("{0}{{ ", optionsName);
-
-            if (actionOptions != null)
-            {
-                if (actionOptions.Left != 0)
-                    javaScriptBuilder.AppendFormat("left: {0}, ", actionOptions.Left);
-
-                if (actionOptions.Top != 0)
-                    javaScriptBuilder.AppendFormat("top: {0}, ", actionOptions.Top);
-
-                if (actionOptions.DataWidth.HasValue)
-                    javaScriptBuilder.AppendFormat("datawidth: {0}, ", actionOptions.DataWidth.Value);
-
-                if (actionOptions.Height.HasValue)
-                    javaScriptBuilder.AppendFormat("height: {0}, ", actionOptions.Height.Value);
-
-                if (actionOptions.DataHeight.HasValue)
-                    javaScriptBuilder.AppendFormat("dataheight: {0}, ", actionOptions.DataHeight.Value);
-
-                if (actionOptions.Modal)
-                    javaScriptBuilder.Append("modal: true, ");
-
-                if (!actionOptions.Dragable)
-                    javaScriptBuilder.Append("drag: false, ");
-
-                if (!actionOptions.Resizable)
-                    javaScriptBuilder.Append("resize: false, ");
-
-                if (!actionOptions.UseJqModal)
-                    javaScriptBuilder.Append("jqModal: false, ");
-
-                if (actionOptions.CloseOnEscape)
-                    javaScriptBuilder.Append("closeOnEscape: true, ");
-
-                if (actionOptions.Overlay != 30)
-                    javaScriptBuilder.AppendFormat("overlay: {0}, ", actionOptions.Overlay);
-
-                if (!String.IsNullOrWhiteSpace(actionOptions.OnClose))
-                    javaScriptBuilder.AppendFormat("onClose: {0}, ", actionOptions.OnClose);
-
-                JqGridNavigatorFormActionOptions formActionOptions = actionOptions as JqGridNavigatorFormActionOptions;
-                if (formActionOptions != null)
-                {
-                    AppendNavigatorFormActionOptions(formActionOptions, javaScriptBuilder);
-
-                    IJqGridNavigatorPageableFormActionOptions pageableFormActionOptions = formActionOptions as IJqGridNavigatorPageableFormActionOptions;
-                    if (pageableFormActionOptions != null)
-                        AppendNavigatorPageableFormActionOptions(pageableFormActionOptions, javaScriptBuilder);
-
-                    JqGridNavigatorModifyActionOptions modifyActionOptions = formActionOptions as JqGridNavigatorModifyActionOptions;
-                    if (modifyActionOptions != null)
-                    {
-                        AppendNavigatorModifyActionOptions(modifyActionOptions, javaScriptBuilder);
-                        JqGridNavigatorEditActionOptions editActionOptions = modifyActionOptions as JqGridNavigatorEditActionOptions;
-                        if (editActionOptions != null)
-                            AppendNavigatorEditActionOptions(editActionOptions, javaScriptBuilder);
-                        else
-                            AppendNavigatorDeleteActionOptions(modifyActionOptions as JqGridNavigatorDeleteActionOptions, javaScriptBuilder);
-                    }
-                    else
-                        AppendNavigatorViewActionOptions(formActionOptions as JqGridNavigatorViewActionOptions, javaScriptBuilder);
-                }
-                else
-                    AppendNavigatorSearchActionOptions(actionOptions as JqGridNavigatorSearchActionOptions, javaScriptBuilder);
-
-            }
-
-            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-            {
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                if (!String.IsNullOrEmpty(optionsName))
-                    javaScriptBuilder.Append(" }, ");
-                else
-                    javaScriptBuilder.Append(" }");
-            }
-            else if (!String.IsNullOrEmpty(optionsName))
-            {
-                int optionsNameLength = optionsName.Length + 2;
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - optionsNameLength, optionsNameLength);
-            }
-            else
-                javaScriptBuilder.Append("}");
-        }
-
-        private static void AppendNavigatorFormActionOptions(JqGridNavigatorFormActionOptions formActionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (!String.IsNullOrWhiteSpace(formActionOptions.BeforeInitData))
-                javaScriptBuilder.AppendFormat("beforeInitData: {0}, ", formActionOptions.BeforeInitData);
-
-            if (!String.IsNullOrWhiteSpace(formActionOptions.BeforeShowForm))
-                javaScriptBuilder.AppendFormat("beforeShowForm: {0}, ", formActionOptions.BeforeShowForm);
-        }
-
-        private static void AppendNavigatorPageableFormActionOptions(IJqGridNavigatorPageableFormActionOptions pageableFormActionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (!pageableFormActionOptions.NavigationKeys.IsDefault())
-                javaScriptBuilder.AppendFormat("navkeys: [{0}, {1}, {2}], ", pageableFormActionOptions.NavigationKeys.Enabled.ToString().ToLower(), (int)pageableFormActionOptions.NavigationKeys.RecordUp, (int)pageableFormActionOptions.NavigationKeys.RecordDown);
-
-            if (!pageableFormActionOptions.ViewPagerButtons)
-                javaScriptBuilder.Append("viewPagerButtons: false, ");
-
-            if (pageableFormActionOptions.RecreateForm)
-                javaScriptBuilder.Append("recreateForm: true, ");
-        }
-
-        private static void AppendNavigatorModifyActionOptions(JqGridNavigatorModifyActionOptions modifyActionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (!String.IsNullOrWhiteSpace(modifyActionOptions.Url))
-                javaScriptBuilder.AppendFormat("url: '{0}', ", modifyActionOptions.Url);
-
-            if (modifyActionOptions.MethodType != JqGridMethodTypes.Post)
-                javaScriptBuilder.Append("mtype: 'GET', ");
-
-            if (!modifyActionOptions.ReloadAfterSubmit)
-                javaScriptBuilder.Append("reloadAfterSubmit: false, ");
-
-            if (!String.IsNullOrWhiteSpace(modifyActionOptions.AfterShowForm))
-                javaScriptBuilder.AppendFormat("afterShowForm: {0}, ", modifyActionOptions.AfterShowForm);
-
-            if (!String.IsNullOrWhiteSpace(modifyActionOptions.AfterSubmit))
-                javaScriptBuilder.AppendFormat("afterSubmit: {0}, ", modifyActionOptions.AfterSubmit);
-
-            if (!String.IsNullOrWhiteSpace(modifyActionOptions.BeforeSubmit))
-                javaScriptBuilder.AppendFormat("beforeSubmit: {0}, ", modifyActionOptions.BeforeSubmit);
-
-            if (!String.IsNullOrWhiteSpace(modifyActionOptions.OnClickSubmit))
-                javaScriptBuilder.AppendFormat("onclickSubmit: {0}, ", modifyActionOptions.OnClickSubmit);
-
-            if (!String.IsNullOrWhiteSpace(modifyActionOptions.ErrorTextFormat))
-                javaScriptBuilder.AppendFormat("errorTextFormat: {0}, ", modifyActionOptions.ErrorTextFormat);
-        }
-
-        private static void AppendNavigatorEditActionOptions(JqGridNavigatorEditActionOptions editActionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (editActionOptions.Width != 300)
-                javaScriptBuilder.AppendFormat("width: {0}, ", editActionOptions.Width);
-
-            JavaScriptSerializer serializer = new JavaScriptSerializer();
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.ExtraDataScript))
-                javaScriptBuilder.AppendFormat("editData: {0},", editActionOptions.ExtraDataScript).AppendLine();
-            else if (editActionOptions.ExtraData != null)
-                javaScriptBuilder.AppendFormat("editData: {0}, ", serializer.Serialize(editActionOptions.ExtraData));
-
-            if (editActionOptions.AjaxOptions != null)
-                javaScriptBuilder.AppendFormat("ajaxEditOptions: {0}, ", serializer.Serialize(editActionOptions.AjaxOptions));
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.SerializeData))
-                javaScriptBuilder.AppendFormat("serializeEditData: {0}, ", editActionOptions.SerializeData);
-
-            if (editActionOptions.AddedRowPosition != JqGridNewRowPositions.First)
-                javaScriptBuilder.Append("addedrow: 'last', ");
-
-            if (!editActionOptions.ClearAfterAdd)
-                javaScriptBuilder.Append("clearAfterAdd: false, ");
-
-            if (editActionOptions.CloseAfterAdd)
-                javaScriptBuilder.Append("closeAfterAdd: true, ");
-
-            if (editActionOptions.CloseAfterEdit)
-                javaScriptBuilder.Append("closeAfterEdit: true, ");
-
-            if (editActionOptions.CheckOnSubmit)
-                javaScriptBuilder.Append("checkOnSubmit: true, ");
-
-            if (editActionOptions.CheckOnUpdate)
-                javaScriptBuilder.Append("checkOnUpdate: true, ");
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.TopInfo))
-                javaScriptBuilder.AppendFormat("topinfo: '{0}', ", editActionOptions.TopInfo);
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.BottomInfo))
-                javaScriptBuilder.AppendFormat("bottominfo: '{0}', ", editActionOptions.BottomInfo);
-
-            if (editActionOptions.SaveKeyEnabled || (editActionOptions.SaveKey != (char)13))
-                javaScriptBuilder.AppendFormat("savekey: [{0}, {1}], ", editActionOptions.SaveKeyEnabled.ToString().ToLower(), (int)editActionOptions.SaveKey);
-
-            if (!editActionOptions.SaveButtonIcon.Equals(JqGridFormButtonIcon.SaveIcon))
-                javaScriptBuilder.AppendFormat("saveicon: [{0}, '{1}', '{2}'], ", editActionOptions.SaveButtonIcon.Enabled.ToString().ToLower(), editActionOptions.SaveButtonIcon.Position.ToString().ToLower(), editActionOptions.SaveButtonIcon.Class);
-
-            if (!editActionOptions.CloseButtonIcon.Equals(JqGridFormButtonIcon.CloseIcon))
-                javaScriptBuilder.AppendFormat("closeicon: [{0}, '{1}', '{2}'], ", editActionOptions.CloseButtonIcon.Enabled.ToString().ToLower(), editActionOptions.CloseButtonIcon.Position.ToString().ToLower(), editActionOptions.CloseButtonIcon.Class);
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.AfterClickPgButtons))
-                javaScriptBuilder.AppendFormat("afterclickPgButtons: {0}, ", editActionOptions.AfterClickPgButtons);
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.AfterComplete))
-                javaScriptBuilder.AppendFormat("afterComplete: {0}, ", editActionOptions.AfterComplete);
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.BeforeCheckValues))
-                javaScriptBuilder.AppendFormat("beforeCheckValues: {0}, ", editActionOptions.BeforeCheckValues);
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.OnClickPgButtons))
-                javaScriptBuilder.AppendFormat("onclickPgButtons: {0}, ", editActionOptions.OnClickPgButtons);
-
-            if (!String.IsNullOrWhiteSpace(editActionOptions.OnInitializeForm))
-                javaScriptBuilder.AppendFormat("onInitializeForm: {0}, ", editActionOptions.OnInitializeForm);
-        }
-
-        private static void AppendNavigatorDeleteActionOptions(JqGridNavigatorDeleteActionOptions deleteActionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (deleteActionOptions.Width != 240)
-                javaScriptBuilder.AppendFormat("width: {0}, ", deleteActionOptions.Width);
-
-            JavaScriptSerializer serializer = new JavaScriptSerializer();
-
-            if (!String.IsNullOrWhiteSpace(deleteActionOptions.ExtraDataScript))
-                javaScriptBuilder.AppendFormat("delData: {0},", deleteActionOptions.ExtraDataScript).AppendLine();
-            else if (deleteActionOptions.ExtraData != null)
-                javaScriptBuilder.AppendFormat("delData: {0}, ", serializer.Serialize(deleteActionOptions.ExtraData));
-
-            if (deleteActionOptions.AjaxOptions != null)
-                javaScriptBuilder.AppendFormat("ajaxDelOptions: {0}, ", serializer.Serialize(deleteActionOptions.AjaxOptions));
-
-            if (!String.IsNullOrWhiteSpace(deleteActionOptions.SerializeData))
-                javaScriptBuilder.AppendFormat("serializeDelData: {0}, ", deleteActionOptions.SerializeData);
-
-            if (!deleteActionOptions.DeleteButtonIcon.Equals(JqGridFormButtonIcon.DeleteIcon))
-                javaScriptBuilder.AppendFormat("delicon: [{0}, '{1}', '{2}'], ", deleteActionOptions.DeleteButtonIcon.Enabled.ToString().ToLower(), deleteActionOptions.DeleteButtonIcon.Position.ToString().ToLower(), deleteActionOptions.DeleteButtonIcon.Class);
-
-            if (!deleteActionOptions.CancelButtonIcon.Equals(JqGridFormButtonIcon.CancelIcon))
-                javaScriptBuilder.AppendFormat("cancelicon: [{0}, '{1}', '{2}'], ", deleteActionOptions.CancelButtonIcon.Enabled.ToString().ToLower(), deleteActionOptions.CancelButtonIcon.Position.ToString().ToLower(), deleteActionOptions.CancelButtonIcon.Class);
-        }
-
-        private static void AppendNavigatorViewActionOptions(JqGridNavigatorViewActionOptions viewActionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (viewActionOptions.Width != 0)
-                javaScriptBuilder.AppendFormat("width: {0}, ", viewActionOptions.Width);
-
-            if (viewActionOptions.LabelsWidth != "30%")
-                javaScriptBuilder.AppendFormat("labelswidth: '{0}', ", viewActionOptions.LabelsWidth);
-
-            if (!viewActionOptions.CloseButtonIcon.Equals(JqGridFormButtonIcon.CloseIcon))
-                javaScriptBuilder.AppendFormat("closeicon: [{0}, '{1}', '{2}'], ", viewActionOptions.CloseButtonIcon.Enabled.ToString().ToLower(), viewActionOptions.CloseButtonIcon.Position.ToString().ToLower(), viewActionOptions.CloseButtonIcon.Class);
-        }
-
-        private static void AppendNavigatorSearchActionOptions(JqGridNavigatorSearchActionOptions searchActionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (searchActionOptions.Width != 450)
-                javaScriptBuilder.AppendFormat("width: {0}, ", searchActionOptions.Width);
-
-            if (!String.IsNullOrWhiteSpace(searchActionOptions.AfterRedraw))
-                javaScriptBuilder.AppendFormat("afterRedraw: {0}, ", searchActionOptions.AfterRedraw);
-
-            if (!String.IsNullOrWhiteSpace(searchActionOptions.AfterShowSearch))
-                javaScriptBuilder.AppendFormat("afterShowSearch: {0}, ", searchActionOptions.AfterShowSearch);
-
-            if (!String.IsNullOrWhiteSpace(searchActionOptions.BeforeShowSearch))
-                javaScriptBuilder.AppendFormat("beforeShowSearch: {0}, ", searchActionOptions.BeforeShowSearch);
-
-            if (!String.IsNullOrEmpty(searchActionOptions.Caption))
-                javaScriptBuilder.AppendFormat("caption: '{0}', ", searchActionOptions.Caption);
-
-            if (searchActionOptions.CloseAfterSearch)
-                javaScriptBuilder.Append("closeAfterSearch: true, ");
-
-            if (searchActionOptions.CloseAfterReset)
-                javaScriptBuilder.Append("closeAfterReset: true, ");
-
-            if (!searchActionOptions.ErrorCheck)
-                javaScriptBuilder.Append("errorcheck: false, ");
-
-            if (!String.IsNullOrEmpty(searchActionOptions.SearchText))
-                javaScriptBuilder.AppendFormat("Find: '{0}', ", searchActionOptions.SearchText);
-
-            if (searchActionOptions.AdvancedSearching)
-                javaScriptBuilder.Append("multipleSearch: true, ");
-
-            if (searchActionOptions.AdvancedSearchingWithGroups)
-                javaScriptBuilder.Append("multipleGroup: true, ");
-
-            if (!searchActionOptions.CloneSearchRowOnAdd)
-                javaScriptBuilder.Append("cloneSearchRowOnAdd: false, ");
-
-            if (!String.IsNullOrWhiteSpace(searchActionOptions.OnInitializeSearch))
-                javaScriptBuilder.AppendFormat("onInitializeSearch: {0}, ", searchActionOptions.OnInitializeSearch);
-
-            if (!String.IsNullOrWhiteSpace(searchActionOptions.OnReset))
-                javaScriptBuilder.AppendFormat("onReset: {0}, ", searchActionOptions.OnReset);
-
-            if (!String.IsNullOrWhiteSpace(searchActionOptions.OnSearch))
-                javaScriptBuilder.AppendFormat("onSearch: {0}, ", searchActionOptions.OnSearch);
-
-            if (searchActionOptions.RecreateFilter)
-                javaScriptBuilder.Append("recreateFilter: true, ");
-
-            if (!String.IsNullOrEmpty(searchActionOptions.ResetText))
-                javaScriptBuilder.AppendFormat("Reset: '{0}', ", searchActionOptions.ResetText);
-
-            AppendSearchOperators(searchActionOptions.SearchOperators, javaScriptBuilder);
-
-            if (searchActionOptions.ShowOnLoad)
-                javaScriptBuilder.Append("showOnLoad: true, ");
-
-            if (searchActionOptions.ShowQuery)
-                javaScriptBuilder.Append("showQuery: true, ");
-
-            if (!String.IsNullOrEmpty(searchActionOptions.Layer))
-                javaScriptBuilder.AppendFormat("layer: '{0}', ", searchActionOptions.Layer);
-
-            if (searchActionOptions.Templates != null && searchActionOptions.Templates.Count > 0)
-            {
-                JavaScriptSerializer serializer = new JavaScriptSerializer();
-                serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
-
-                javaScriptBuilder.Append("tmplNames: [],");
-                int templateNameIndex = javaScriptBuilder.Length - 2;
-                javaScriptBuilder.Append("tmplFilters: [");
-                foreach (KeyValuePair<string, JqGridRequestSearchingFilters> template in searchActionOptions.Templates)
-                {
-                    javaScriptBuilder.Insert(templateNameIndex, "'" + template.Key + "', ");
-                    templateNameIndex += template.Key.Length + 4;
-                    javaScriptBuilder.Append(serializer.Serialize(template.Value) + ", ");
-                }
-                javaScriptBuilder.Remove(templateNameIndex - 2, 2);
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append("],");
-            }
-        }
-
-        private void AppendNavigatorButton(string navigatorPagerSelector, JqGridNavigatorButtonOptions buttonOptions, StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.AppendFormat(".jqGrid('navButtonAdd', {0}, {{ ", navigatorPagerSelector);
-            if (buttonOptions.Caption != JqGridNavigatorDefaults.ButtonCaption)
-                javaScriptBuilder.AppendFormat("caption: '{0}', ", buttonOptions.Caption);
-
-            if (buttonOptions.Icon != JqGridNavigatorDefaults.ButtonIcon)
-                javaScriptBuilder.AppendFormat("buttonicon: '{0}', ", buttonOptions.Icon);
-
-            if (!String.IsNullOrWhiteSpace(buttonOptions.OnClick))
-                javaScriptBuilder.AppendFormat("onClickButton: {0}, ", buttonOptions.OnClick);
-
-            if (buttonOptions.Position != JqGridNavigatorButtonPositions.Last)
-                javaScriptBuilder.Append("position: 'first', ");
-
-            if (!String.IsNullOrEmpty(buttonOptions.ToolTip))
-                javaScriptBuilder.AppendFormat("title: '{0}', ", buttonOptions.ToolTip);
-
-            if (buttonOptions.Cursor != JqGridNavigatorDefaults.ButtonCursor)
-                javaScriptBuilder.AppendFormat("cursor: '{0}', ", buttonOptions.Cursor);
-
-            if (!String.IsNullOrWhiteSpace(buttonOptions.Id))
-                javaScriptBuilder.AppendFormat("id: '{0}', ", buttonOptions.Id);
-
-            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-            {
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append(" })");
-            }
-            else
-            {
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 4, 4);
-                javaScriptBuilder.Append(")");
-            }
-        }
-
-        private void AppendNavigatorSeparator(string navigatorPagerSelector, JqGridNavigatorSeparatorOptions separatorOptions, StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.AppendFormat(".jqGrid('navSeparatorAdd', {0}, {{ ", navigatorPagerSelector);
-
-            if (separatorOptions.Class != JqGridNavigatorDefaults.SeparatorClass)
-                javaScriptBuilder.AppendFormat("sepclass: '{0}', ", separatorOptions.Class);
-
-            if (!String.IsNullOrEmpty(separatorOptions.Content))
-                javaScriptBuilder.AppendFormat("sepcontent: '{0}', ", separatorOptions.Content);
-
-            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-            {
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append(" })");
-            }
-            else
-            {
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 4, 4);
-                javaScriptBuilder.Append(")");
-            }
-        }
-
-        private void AppendInlineNavigator(StringBuilder javaScriptBuilder)
-        {
-            string navigatorPagerSelector = _navigatorOptions.Pager == JqGridNavigatorPagers.Top ? TopPagerSelector : PagerSelector;
-
-            javaScriptBuilder.AppendFormat(".jqGrid('inlineNav', {0}, ", navigatorPagerSelector).AppendLine();
-
-            AppendInlineNavigatorOptions(javaScriptBuilder);
-
-            javaScriptBuilder.Append(")");
-        }
-
-        private void AppendInlineNavigatorOptions(StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.Append("{ ");
-
-            AppendBaseNavigatorOptions(_inlineNavigatorOptions, javaScriptBuilder);
-
-            if (!_inlineNavigatorOptions.Save)
-                javaScriptBuilder.Append("save: false, ");
-
-            if (_inlineNavigatorOptions.SaveIcon != JqGridNavigatorDefaults.SaveIcon)
-                javaScriptBuilder.AppendFormat("saveicon: '{0}', ", _inlineNavigatorOptions.SaveIcon);
-
-            if (!String.IsNullOrEmpty(_inlineNavigatorOptions.SaveText))
-                javaScriptBuilder.AppendFormat("savetext: '{0}', ", _inlineNavigatorOptions.SaveText);
-
-            if (_inlineNavigatorOptions.SaveToolTip != JqGridNavigatorDefaults.SaveToolTip)
-                javaScriptBuilder.AppendFormat("savetitle: '{0}', ", _inlineNavigatorOptions.SaveToolTip);
-
-            if (!_inlineNavigatorOptions.Cancel)
-                javaScriptBuilder.Append("cancel: false, ");
-
-            if (_inlineNavigatorOptions.CancelIcon != JqGridNavigatorDefaults.CancelIcon)
-                javaScriptBuilder.AppendFormat("cancelicon: '{0}', ", _inlineNavigatorOptions.CancelIcon);
-
-            if (!String.IsNullOrEmpty(_inlineNavigatorOptions.CancelText))
-                javaScriptBuilder.AppendFormat("canceltext: '{0}', ", _inlineNavigatorOptions.CancelText);
-
-            if (_inlineNavigatorOptions.CancelToolTip != JqGridNavigatorDefaults.CancelToolTip)
-                javaScriptBuilder.AppendFormat("canceltitle: '{0}', ", _inlineNavigatorOptions.CancelToolTip);
-
-            AppendInlineNavigatorAddActionOptions(_inlineNavigatorOptions.AddActionOptions, javaScriptBuilder);
-            AppendInlineNavigatorActionOptions("editParams", _inlineNavigatorOptions.ActionOptions, javaScriptBuilder);
-
-            if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-            {
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append(" }");
-            }
-            else
-                javaScriptBuilder.Append("}");
-        }
-
-        private static void AppendInlineNavigatorActionOptions(string actionName, JqGridInlineNavigatorActionOptions actionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (actionOptions != null)
-            {
-                javaScriptBuilder.AppendFormat("{0}: {{ ", actionName);
-
-                if (actionOptions.Keys)
-                    javaScriptBuilder.Append("keys: true, ");
-
-                if (!String.IsNullOrWhiteSpace(actionOptions.OnEditFunction))
-                    javaScriptBuilder.AppendFormat("oneditfunc: {0}, ", actionOptions.OnEditFunction);
-
-                if (!String.IsNullOrWhiteSpace(actionOptions.SuccessFunction))
-                    javaScriptBuilder.AppendFormat("successfunc: {0}, ", actionOptions.SuccessFunction);
-
-                if (!String.IsNullOrWhiteSpace(actionOptions.Url))
-                    javaScriptBuilder.AppendFormat("url: '{0}', ", actionOptions.Url);
-
-                if (!String.IsNullOrWhiteSpace(actionOptions.ExtraParamScript))
-                    javaScriptBuilder.AppendFormat("extraparam: {0}, ", actionOptions.ExtraParamScript);
-                else if (actionOptions.ExtraParam != null)
-                {
-                    JavaScriptSerializer serializer = new JavaScriptSerializer();
-                    javaScriptBuilder.AppendFormat("extraparam: {0}, ", serializer.Serialize(actionOptions.ExtraParam));
-                }
-
-                if (!String.IsNullOrWhiteSpace(actionOptions.AfterSaveFunction))
-                    javaScriptBuilder.AppendFormat("aftersavefunc: {0}, ", actionOptions.AfterSaveFunction);
-
-                if (!String.IsNullOrWhiteSpace(actionOptions.ErrorFunction))
-                    javaScriptBuilder.AppendFormat("errorfunc: {0}, ", actionOptions.ErrorFunction);
-
-                if (!String.IsNullOrWhiteSpace(actionOptions.AfterRestoreFunction))
-                    javaScriptBuilder.AppendFormat("afterrestorefunc: {0}, ", actionOptions.AfterRestoreFunction);
-
-                if (!actionOptions.RestoreAfterError)
-                    javaScriptBuilder.Append("restoreAfterError: false, ");
-
-                if (actionOptions.MethodType != JqGridMethodTypes.Post)
-                    javaScriptBuilder.Append("mtype: 'GET', ");
-
-                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                    javaScriptBuilder.Append(" }, ");
-                }
-                else
-                {
-                    int actionNameLength = actionName.Length + 4;
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - actionNameLength, actionNameLength);
-                }
-            }
-        }
-
-        private static void AppendInlineNavigatorAddActionOptions(JqGridInlineNavigatorAddActionOptions actionOptions, StringBuilder javaScriptBuilder)
-        {
-            if (actionOptions != null)
-            {
-                javaScriptBuilder.Append("addParams: { ");
-
-                if (actionOptions.RowId != JqGridNavigatorDefaults.NewRowId)
-                    javaScriptBuilder.AppendFormat("rowID: '{0}', ", actionOptions.RowId);
-
-                if (actionOptions.InitData != null)
-                {
-                    JavaScriptSerializer serializer = new JavaScriptSerializer();
-                    javaScriptBuilder.AppendFormat("initdata: {0}, ", serializer.Serialize(actionOptions.InitData));
-                }
-
-                if (actionOptions.Position != JqGridNewRowPositions.First)
-                    javaScriptBuilder.AppendFormat("position: 'last', ");
-
-                if (actionOptions.UseDefaultValues)
-                    javaScriptBuilder.Append("useDefValues: true, ");
-
-                if (actionOptions.UseFormatter)
-                    javaScriptBuilder.Append("useFormatter: true, ");
-
-                AppendInlineNavigatorActionOptions("addRowParams", actionOptions.Options, javaScriptBuilder);
-
-                if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                    javaScriptBuilder.Append(" }, ");
-                }
-                else
-                {
-                    javaScriptBuilder.Remove(javaScriptBuilder.Length - 13, 13);
-                }
-            }
-        }
-
-        private void AppendFilterToolbar(StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.Append(".jqGrid('filterToolbar'");
-
-            if (_filterToolbarOptions != null)
-            {
-                javaScriptBuilder.Append(", { ");
-
-                AppendFilterOptions(_filterToolbarOptions, javaScriptBuilder);
-
-                if (_filterToolbarOptions.DefaultSearchOperator != JqGridSearchOperators.Bw)
-                    javaScriptBuilder.AppendFormat("defaultSearch: '{0}',", _filterToolbarOptions.DefaultSearchOperator.ToString().ToLower());
-
-                if (_filterToolbarOptions.GroupingOperator != JqGridSearchGroupingOperators.And)
-                    javaScriptBuilder.Append("groupOp: 'OR',");
-
-                if (!_filterToolbarOptions.SearchOnEnter)
-                    javaScriptBuilder.Append("searchOnEnter: false,");
-
-                if (_filterToolbarOptions.SearchOperators)
-                    javaScriptBuilder.Append("searchOperators: true,");
-
-                if (_filterToolbarOptions.OperandToolTip != JqGridFilterToolbarDefaults.OperandToolTip)
-                    javaScriptBuilder.AppendFormat("operandTitle: '{0}',", _filterToolbarOptions.OperandToolTip );
-
-                if (_filterToolbarOptions.Operands != null && _filterToolbarOptions.Operands.Count > 0 && _filterToolbarOptions.Operands != JqGridFilterToolbarDefaults.Operands)
-                {
-                    int javaScriptBuilderPosition = javaScriptBuilder.Length;
-
-                    foreach (KeyValuePair<JqGridSearchOperators, string> operand in _filterToolbarOptions.Operands)
-                    {
-                        string defaultShortText;
-                        if (JqGridFilterToolbarDefaults.Operands.TryGetValue(operand.Key, out defaultShortText) && operand.Value != defaultShortText)
-                            javaScriptBuilder.AppendFormat("'{0}':'{1}',", operand.Key.ToString().ToLower(), operand.Value);
-                    }
-
-                    if (javaScriptBuilderPosition != javaScriptBuilder.Length)
-                    {
-                        javaScriptBuilder.Insert(javaScriptBuilderPosition, "operands: {");
-                        javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-                        javaScriptBuilder.Append("},");
-                    }
-                }
-
-                if (_filterToolbarOptions.StringResult)
-                    javaScriptBuilder.Append("stringResult: true,");
-
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-                javaScriptBuilder.Append(" }");
-            }
-
-            javaScriptBuilder.Append(")");
-        }
-
-        private void AppendFilterGrid(StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.AppendFormat("$({0}).jqGrid('filterGrid', {1}, {{", FilterGridSelector, GridSelector).AppendLine();
-            javaScriptBuilder.AppendLine("gridModel: false, gridNames: false,");
-
-            javaScriptBuilder.AppendLine("filterModel: [");
-
-            int lastGridModelIndex = _filterGridModel.Count - 1;
-            for (int gridModelIndex = 0; gridModelIndex < _filterGridModel.Count; gridModelIndex++)
-            {
-                JqGridFilterGridRowModel gridRowModel = _filterGridModel[gridModelIndex];
-                javaScriptBuilder.AppendFormat("{{ label: '{0}', name: '{1}', ", gridRowModel.Label, gridRowModel.ColumnName);
-
-                if (!String.IsNullOrWhiteSpace(gridRowModel.DefaultValue))
-                    javaScriptBuilder.AppendFormat("defval: '{0}', ", gridRowModel.DefaultValue);
-
-                if (!String.IsNullOrWhiteSpace(gridRowModel.SelectUrl))
-                    javaScriptBuilder.AppendFormat("surl: '{0}', ", gridRowModel.SelectUrl);
-
-                javaScriptBuilder.AppendFormat("stype: '{0}' }}", gridRowModel.SearchType.ToString().ToLower());
-
-                if (lastGridModelIndex == gridModelIndex)
-                    javaScriptBuilder.AppendLine();
-                else
-                    javaScriptBuilder.AppendLine(",");
-            }
-
-            javaScriptBuilder.Append("]");
-
-            if (_filterGridOptions != null)
-            {
-                javaScriptBuilder.AppendLine(",");
-                AppendFilterOptions(_filterGridOptions, javaScriptBuilder);
-
-                if (!String.IsNullOrWhiteSpace(_filterGridOptions.ButtonsClass))
-                    javaScriptBuilder.AppendFormat("buttonclass: '{0}',", _filterGridOptions.ButtonsClass);
-
-                if (_filterGridOptions.ClearEnabled.HasValue)
-                    javaScriptBuilder.AppendFormat("enableClear: {0},", _filterGridOptions.ClearEnabled.Value.ToString().ToLower());
-
-                if (!String.IsNullOrWhiteSpace(_filterGridOptions.ClearText))
-                    javaScriptBuilder.AppendFormat("clearButton: '{0}',", _filterGridOptions.ClearText);
-
-                if (!String.IsNullOrWhiteSpace(_filterGridOptions.FormClass))
-                    javaScriptBuilder.AppendFormat("formclass: '{0}',", _filterGridOptions.FormClass);
-
-                if (_filterGridOptions.MarkSearched.HasValue)
-                    javaScriptBuilder.AppendFormat("marksearched: {0},", _filterGridOptions.MarkSearched.Value.ToString().ToLower());
-
-                if (_filterGridOptions.SearchEnabled.HasValue)
-                    javaScriptBuilder.AppendFormat("enableSearch: {0},", _filterGridOptions.SearchEnabled.Value.ToString().ToLower());
-
-                if (!String.IsNullOrWhiteSpace(_filterGridOptions.SearchText))
-                    javaScriptBuilder.AppendFormat("searchButton: '{0}',", _filterGridOptions.SearchText);
-
-                if (!String.IsNullOrWhiteSpace(_filterGridOptions.TableClass))
-                    javaScriptBuilder.AppendFormat("tableclass: '{0}',", _filterGridOptions.TableClass);
-
-                if (_filterGridOptions.Type.HasValue)
-                    javaScriptBuilder.AppendFormat("formtype: '{0}',", _filterGridOptions.Type.Value.ToString().ToLower());
-
-                if (!String.IsNullOrWhiteSpace(_filterGridOptions.Url))
-                    javaScriptBuilder.AppendFormat("url: '{0}',", _filterGridOptions.Url);
-
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
-            }
-
-            javaScriptBuilder.AppendLine("});");
-        }
-
-        private static void AppendFilterOptions(JqGridFilterOptions options, StringBuilder javaScriptBuilder)
-        {
-            if (options != null)
-            {
-                if (!String.IsNullOrWhiteSpace(options.AfterClear))
-                    javaScriptBuilder.AppendFormat("afterClear: {0},", options.AfterClear);
-
-                if (!String.IsNullOrWhiteSpace(options.AfterSearch))
-                    javaScriptBuilder.AppendFormat("afterSearch: {0},", options.AfterSearch);
-
-                if (options.AutoSearch.HasValue)
-                    javaScriptBuilder.AppendFormat("autosearch: {0},", options.AutoSearch.Value.ToString().ToLower());
-
-                if (!String.IsNullOrWhiteSpace(options.BeforeClear))
-                    javaScriptBuilder.AppendFormat("beforeClear: {0},", options.BeforeClear);
-
-                if (!String.IsNullOrWhiteSpace(options.BeforeSearch))
-                    javaScriptBuilder.AppendFormat("beforeSearch: {0},", options.BeforeSearch);
-            }
-        }
-
-        private void AppendFooterData(StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.Append(".jqGrid('footerData', 'set', { ");
-
-            foreach(KeyValuePair<string, object> footerValue in _footerData)
-                javaScriptBuilder.AppendFormat(" {0}: '{1}', ", footerValue.Key, Convert.ToString(footerValue.Value));
-
-            javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-            javaScriptBuilder.AppendFormat(" }}, {0})", _footerDataUseFormatters.ToString().ToLower());
-        }
-
-        private void AppendGroupHeaders(StringBuilder javaScriptBuilder)
-        {
-            javaScriptBuilder.Append(".jqGrid('setGroupHeaders', { ");
-
-            if (_groupHeadersUseColSpanStyle)
-                javaScriptBuilder.Append("useColSpanStyle: true, ");
-
-            javaScriptBuilder.Append("groupHeaders: [ ");
-            foreach (JqGridGroupHeader groupHeader in _groupHeaders)
-                javaScriptBuilder.AppendFormat("{{ startColumnName: '{0}', numberOfColumns: {1}, titleText: '{2}' }}, ", groupHeader.StartColumn, groupHeader.NumberOfColumns, groupHeader.Title);
-            javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2).Append(" ]");
-
-            javaScriptBuilder.Append("})");
-        }
-
-        private static void AppendColumnLabelOptions(string columnName, JqGridColumnLabelOptions options, StringBuilder javaScriptBuilder)
-        {
-            if (options != null)
-            {
-                JavaScriptSerializer serializer = new JavaScriptSerializer();
-                javaScriptBuilder.AppendFormat(".jqGrid('setLabel', '{0}', ", columnName);
-                javaScriptBuilder.AppendFormat("'{0}', ", String.IsNullOrWhiteSpace(options.Label) ? String.Empty : options.Label);
-
-                if (String.IsNullOrWhiteSpace(options.Class))
-                {
-                    if (options.CssStyles != null)
-                        javaScriptBuilder.AppendFormat("{0}, ", serializer.Serialize(options.CssStyles));
-                    else if (options.HtmlAttributes != null)
-                        javaScriptBuilder.Append("null, ");
-                }
-                else
-                    javaScriptBuilder.AppendFormat("'{0}', ", options.Class);
-
-                if (options.HtmlAttributes != null)
-                    javaScriptBuilder.AppendFormat("{0}, ", serializer.Serialize(options.HtmlAttributes));
-
-                javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
-                javaScriptBuilder.Append(" )");
-            }
-        }
-
-        private static IDictionary<string, object> AnonymousObjectToDictionary(object anonymousObject)
-        {
-            Dictionary<string, object> dictionary = new Dictionary<string, object>();
-
-            if (anonymousObject != null)
-            {
-                foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(anonymousObject))
-                    dictionary.Add(property.Name, property.GetValue(anonymousObject));
-            }
-
-            return dictionary;
-        }
-        #endregion
-
-        #region Fluent API
-        /// <summary>
-        /// Adds column with actions predefined formatter.
-        /// </summary>
-        /// <param name="name">Name for the column.</param>
-        /// <param name="position">Position of the column.</param>
-        /// <param name="width">Width of the column.</param>
-        /// <param name="editButton">Value indicating if edit button is enabled.</param>
-        /// <param name="deleteButton">Value indicating if delete button is enabled.</param>
-        /// <param name="useFormEditing">Value indicating if form editing should be used instead of inline editing.</param>
-        /// <param name="inlineEditingOptions">Options for inline editing (RestoreAfterError and MethodType options are ignored in this context).</param>
-        /// <param name="formEditingOptions">Options for form editing.</param>
-        /// <param name="deleteOptions">Options for deleting.</param>
-        /// <returns>JqGridHelper instance.</returns>
-        /// <remarks>It is adviced to set JqGridResponse.JsonReader.RepeatItems to false if you want to use this method, otherwise jqGrid will not skip this column while mapping data.</remarks>
-        public JqGridHelper<TModel> AddActionsColumn(string name, int position = 0, int width = 60, bool editButton = true, bool deleteButton = true, bool useFormEditing = false, JqGridInlineNavigatorActionOptions inlineEditingOptions = null, JqGridNavigatorEditActionOptions formEditingOptions = null, JqGridNavigatorDeleteActionOptions deleteOptions = null)
-        {
-            JqGridColumnModel actionsColumnModel = new JqGridColumnModel(name);
-            actionsColumnModel.Width = width;
-            actionsColumnModel.Resizable = false;
-            actionsColumnModel.Searchable = false;
-            actionsColumnModel.Sortable = false;
-            actionsColumnModel.Viewable = false;
-            actionsColumnModel.Formatter = JqGridColumnPredefinedFormatters.Actions;
-            actionsColumnModel.FormatterOptions = new JqGridColumnFormatterOptions()
-            {
-                EditButton = editButton,
-                DeleteButton = deleteButton,
-                UseFormEditing = useFormEditing,
-                InlineEditingOptions = inlineEditingOptions,
-                FormEditingOptions = formEditingOptions,
-                DeleteOptions = deleteOptions
-            };
-
-            if (position <= 0)
-            {
-                _options.ColumnsNames.Insert(0, String.Empty);
-                _options.ColumnsModels.Insert(0, actionsColumnModel);
-            }
-            else if (position >= _options.ColumnsModels.Count)
-            {
-                _options.ColumnsNames.Add(String.Empty);
-                _options.ColumnsModels.Add(actionsColumnModel);
-            }
-            else
-            {
-                _options.ColumnsNames.Insert(position, String.Empty);
-                _options.ColumnsModels.Insert(position, actionsColumnModel);
-            }
-
-            return this;
-        }
-
-        /// <summary>
-        /// Enables Navigator for this JqGridHelper instance.
-        /// </summary>
-        /// <param name="options">The options for the Navigator.</param>
-        /// <param name="editActionOptions">The options for the edit action.</param>
-        /// <param name="addActionOptions">The options for the add action.</param>
-        /// <param name="deleteActionOptions">The options for the delete action.</param>
-        /// <param name="searchActionOptions">The options for the search action.</param>
-        /// <param name="viewActionOptions">The options for the view action.</param>
-        /// <returns>JqGridHelper instance with enabled Navigator.</returns>
-        /// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
-        public JqGridHelper<TModel> Navigator(JqGridNavigatorOptions options, JqGridNavigatorEditActionOptions editActionOptions = null, JqGridNavigatorEditActionOptions addActionOptions = null, JqGridNavigatorDeleteActionOptions deleteActionOptions = null, JqGridNavigatorSearchActionOptions searchActionOptions = null, JqGridNavigatorViewActionOptions viewActionOptions = null)
-        {
-            if (options == null)
-                throw new ArgumentNullException("options");
-
-            _navigatorOptions = options;
-            _navigatorEditActionOptions = editActionOptions;
-            _navigatorAddActionOptions = addActionOptions;
-            _navigatorDeleteActionOptions = deleteActionOptions;
-            _navigatorSearchActionOptions = searchActionOptions;
-            _navigatorViewActionOptions = viewActionOptions;
-
-            return this;
-        }
-
-        /// <summary>
-        /// Enables Inline Navigator for this JqGridHelper instance.
-        /// </summary>
-        /// <param name="options">The options for the Inline Navigator.</param>
-        /// <returns>JqGridHelper instance with enabled Inline Navigator.</returns>
-        /// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
-        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-        public JqGridHelper<TModel> InlineNavigator(JqGridInlineNavigatorOptions options)
-        {
-            if (_navigatorOptions == null)
-                throw new InvalidOperationException("In order to call InlineNavigator method you must call Navigator method first.");
-
-            if (options == null)
-                throw new ArgumentNullException("options");
-
-            _inlineNavigatorOptions = options;
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds button to this JqGridHelper instance Navigator.
-        /// </summary>
-        /// <param name="caption">The caption for the button.</param>
-        /// <param name="icon">The icon (form UI theme images) for the button. If this is set to "none" only text will appear.</param>
-        /// <param name="onClick">The function for button click action.</param>
-        /// <param name="position">The position where the button will be added.</param>
-        /// <param name="toolTip">The tooltip for the button.</param>
-        /// <param name="cursor">The value which determines the cursor when user mouseover the button.</param>
-        /// <param name="cloneToTop">The value which defines if the button added to the bottom pager should be coppied to the top pager.</param>
-        /// <returns>JqGridHelper instance.</returns>
-        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-        public JqGridHelper<TModel> AddNavigatorButton(string caption = JqGridNavigatorDefaults.ButtonCaption, string icon = JqGridNavigatorDefaults.ButtonIcon, string onClick = null, JqGridNavigatorButtonPositions position = JqGridNavigatorButtonPositions.Last, string toolTip = "", string cursor = JqGridNavigatorDefaults.ButtonCursor, bool cloneToTop = false)
-        {
-            if (_navigatorOptions == null)
-                throw new InvalidOperationException("In order to call AddNavigatorButton method you must call Navigator method first.");
-
-            _navigatorControlsOptions.Add(new JqGridNavigatorButtonOptions()
-            {
-                CloneToTop = cloneToTop,
-                Caption = caption,
-                Icon = icon,
-                OnClick = onClick,
-                Position = position,
-                ToolTip = toolTip,
-                Cursor = cursor
-            });
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds button to this JqGridHelper instance Navigator.
-        /// </summary>
-        /// <param name="options">The options for the button.</param>
-        /// <returns>JqGridHelper instance.</returns>
-        /// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
-        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-        public JqGridHelper<TModel> AddNavigatorButton(JqGridNavigatorButtonOptions options)
-        {
-            if (options == null)
-                throw new ArgumentNullException("options");
-
-            if (_navigatorOptions == null)
-                throw new InvalidOperationException("In order to call AddNavigatorButton method you must call Navigator method first.");
-
-            _navigatorControlsOptions.Add(options);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds separator to this JqGridHelper instance Navigator.
-        /// </summary>
-        /// <param name="class">The class for the separator.</param>
-        /// <param name="content">The content for the separator.</param>
-        /// <param name="cloneToTop">The value which defines if the separator added to the bottom pager should be coppied to the top pager.</param>
-        /// <returns>JqGridHelper instance.</returns>
-        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-        public JqGridHelper<TModel> AddNavigatorSeparator(string @class = JqGridNavigatorDefaults.SeparatorClass, string content = "", bool cloneToTop = false)
-        {
-            if (_navigatorOptions == null)
-                throw new InvalidOperationException("In order to call AddNavigatorSeparator method you must call Navigator method first.");
-
-            _navigatorControlsOptions.Add(new JqGridNavigatorSeparatorOptions()
-            {
-                CloneToTop = cloneToTop,
-                Class = @class,
-                Content = content
-            });
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds separator to this JqGridHelper instance Navigator.
-        /// </summary>
-        /// <param name="options">The options for the separator.</param>
-        /// <returns>JqGridHelper instance.</returns>
-        /// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
-        public JqGridHelper<TModel> AddNavigatorSeparator(JqGridNavigatorSeparatorOptions options)
-        {
-            if (options == null)
-                throw new ArgumentNullException("options");
-
-            if (_navigatorOptions == null)
-                throw new InvalidOperationException("In order to call AddNavigatorSeparator method you must call Navigator method first.");
-
-            _navigatorControlsOptions.Add(options);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Enables filter toolbar for this JqGridHelper instance.
-        /// </summary>
-        /// <param name="options">The options for the filter toolbar.</param>
-        /// <returns>JqGridHelper instance with enabled filter toolbar.</returns>
-        public JqGridHelper<TModel> FilterToolbar(JqGridFilterToolbarOptions options = null)
-        {
-            _filterToolbar = true;
-            _filterToolbarOptions = options;
-
-            return this;
-        }
-
-        /// <summary>
-        /// Enables filter grid for this JqGridHelper instance.
-        /// </summary>
-        /// <param name="model">The model for the filter grid (if null, the model will be build based on ColumnsModels and ColumnsNames).</param>
-        /// <param name="options">The options for the filter grid.</param>
-        /// <returns>JqGridHelper instance with enabled filter grid.</returns>
-        /// <exception cref="System.InvalidOperationException">The filter grid model has not been provided and the automatic generation is not possible because the count of items in ColumnsModel  is different from ColumnsNames.</exception>
-        public JqGridHelper<TModel> FilterGrid(List<JqGridFilterGridRowModel> model = null, JqGridFilterGridOptions options = null)
-        {
-            if (model == null)
-            {
-                if (_options.ColumnsModels.Count != _options.ColumnsNames.Count)
-                    throw new InvalidOperationException("Can't build filter grid model because ColumnsModels.Count is not equal to ColumnsNames.Count");
-
-                _filterGridModel = new List<JqGridFilterGridRowModel>();
-                for (int i = 0; i < _options.ColumnsModels.Count; i++)
-                {
-                    if (_options.ColumnsModels[i].Searchable)
-                    {
-                        _filterGridModel.Add(new JqGridFilterGridRowModel(_options.ColumnsModels[i].Name, _options.ColumnsNames[i])
-                        {
-                            DefaultValue = _options.ColumnsModels[i].SearchOptions != null ? _options.ColumnsModels[i].SearchOptions.DefaultValue : String.Empty,
-                            SearchType = _options.ColumnsModels[i].SearchType,
-                            SelectUrl = _options.ColumnsModels[i].SearchOptions != null ? _options.ColumnsModels[i].SearchOptions.DataUrl : String.Empty
-                        });
-                    }
-                }
-            }
-            else
-                _filterGridModel = model;
-            _filterGridOptions = options;
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets data on footer of this JqGridHelper instance (requires footerEnabled = true).
-        /// </summary>
-        /// <param name="data">The object with values for the footer. Should have names which are the same as names from ColumnsModels.</param>
-        /// <param name="useFormatters">The value indicating if the formatters from columns should be used for footer.</param>
-        /// <returns>JqGridHelper instance with footer data.</returns>
-        public JqGridHelper<TModel> SetFooterData(object data, bool useFormatters = true)
-        {
-            return SetFooterData(AnonymousObjectToDictionary(data), useFormatters);
-        }
-
-        /// <summary>
-        /// Sets data on footer of this JqGridHelper instance (requires footerEnabled = true).
-        /// </summary>
-        /// <param name="data">The dictionary with values for the footer. Should have keys which are the same as names from ColumnsModels.</param>
-        /// <param name="useFormatters">The value indicating if the formatters from columns should be used for footer.</param>
-        /// <returns>JqGridHelper instance with footer data.</returns>
-        public JqGridHelper<TModel> SetFooterData(IDictionary<string, object> data, bool useFormatters = true)
-        {
-            _footerData = data;
-            _footerDataUseFormatters = useFormatters;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets grouping headers for this JqGridHelper instance.
-        /// </summary>
-        /// <param name="groupHeaders">Settings for grouping headers.</param>
-        /// <param name="useColSpanStyle">The value which determines if the non grouping header cell should have cell above it (false), or the column should be treated as one combining boot (true).</param>
-        /// <returns>JqGridHelper instance with grouping header.</returns>
-        /// <exception cref="System.InvalidOperationException">Columns sorting (reordering) is enabled. </exception>
-        public JqGridHelper<TModel> SetGroupHeaders(IEnumerable<JqGridGroupHeader> groupHeaders, bool useColSpanStyle = false)
-        {
-            if (_options.Sortable)
-                throw new InvalidOperationException("Header grouping can not be set-up when columns sorting (reordering) is enabled.");
-
-            _groupHeaders = groupHeaders;
-            _groupHeadersUseColSpanStyle = useColSpanStyle;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets frozen columns for this JqGridHelper instance.
-        /// </summary>
-        /// <returns>JqGridHelper instance with frozen columns.</returns>
-        /// <exception cref="System.InvalidOperationException">
-        /// <list type="bullet">
-        /// <item><description>TreeGrid is enabled.</description></item>
-        /// <item><description>SubGrid is enabled.</description></item>
-        /// <item><description>Columns sorting (reordering) is enabled.</description></item>
-        /// <item><description>Dynamic scrolling is enabled.</description></item>
-        /// <item><description>Data grouping is enabled.</description></item>
-        /// </list> 
-        /// </exception>
-        public JqGridHelper<TModel> SetFrozenColumns()
-        {
-            if (_options.TreeGridEnabled)
-                throw new InvalidOperationException("Frozen columns can not be set-up when TreeGrid is enabled.");
-
-            if (_options.SubgridEnabled)
-                throw new InvalidOperationException("Frozen columns can not be set-up when SubGrid is enabled.");
-
-            if (_options.Sortable)
-                throw new InvalidOperationException("Frozen columns can not be set-up when columns sorting (reordering) is enabled.");
-
-            if (_options.DynamicScrollingMode != JqGridDynamicScrollingModes.Disabled)
-                throw new InvalidOperationException("Frozen columns can not be set-up when dynamic scrolling is enabled.");
-
-            if (_options.GroupingEnabled)
-                throw new InvalidOperationException("Frozen columns can not be set-up when data grouping is enabled.");
-
-            _setFrozenColumns = true;
-            return this;
-        }
-        #endregion
-    }
+	/// <summary>
+	/// Helper class for generating jqGrid HMTL and JavaScript
+	/// </summary>
+	/// <typeparam name="TModel">Type of model for this grid</typeparam>
+	public class JqGridHelper<TModel> : IJqGridHelper
+	{
+		#region Fields
+		private JqGridOptions _options;
+		private JqGridInlineNavigatorOptions _inlineNavigatorOptions;
+		private JqGridNavigatorOptions _navigatorOptions;
+		private JqGridNavigatorActionOptions _navigatorEditActionOptions;
+		private JqGridNavigatorActionOptions _navigatorAddActionOptions;
+		private JqGridNavigatorActionOptions _navigatorDeleteActionOptions;
+		private JqGridNavigatorActionOptions _navigatorSearchActionOptions;
+		private JqGridNavigatorActionOptions _navigatorViewActionOptions;
+		private List<JqGridNavigatorControlOptions> _navigatorControlsOptions = new List<JqGridNavigatorControlOptions>();
+		private bool _filterToolbar = false;
+		private JqGridFilterToolbarOptions _filterToolbarOptions;
+		private List<JqGridFilterGridRowModel> _filterGridModel;
+		private JqGridFilterGridOptions _filterGridOptions;
+		private IDictionary<string, object> _footerData = null;
+		private bool _footerDataUseFormatters = true;
+		private bool _groupHeadersUseColSpanStyle = false;
+		private IEnumerable<JqGridGroupHeader> _groupHeaders = null;
+		private bool _setFrozenColumns = false;
+		private bool _asSubgrid = false;
+		private object _subgridHelper = null;
+		#endregion
+
+		#region Properties
+		/// <summary>
+		/// Gets the grid identifier.
+		/// </summary>
+		public string Id => _options.Id;
+
+		private string GridSelector => _asSubgrid ? "'#' + subgridTableId" : $"'#{Id}'";
+
+		/// <summary>
+		/// Gets the grid pager identifier.
+		/// </summary>
+		public string PagerId => _options.Id + "Pager";
+
+		private string TopPagerSelector => _asSubgrid ? "'#' + subgridTableId + '_toppager'" : $"'#{Id}_toppager'";
+
+		private string PagerSelector => _asSubgrid ? "'#' + subgridPagerId" : $"'#{PagerId}'";
+
+		/// <summary>
+		/// Gets the filter grid (div) placeholder identifier.
+		/// </summary>
+		public string FilterGridId => _options.Id + "Search";
+
+		private string FilterGridSelector => _asSubgrid ? "'#' + subgridFilterGridId" : $"'#{FilterGridId}'";
+
+		#endregion
+
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridHelper class.
+		/// </summary>
+		/// <param name="id">Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div (id='{0}Search') and in JavaScript.</param>
+		/// <param name="afterInsertRow">The function for event which is raised after every inserted row.</param>
+		/// <param name="afterEditCell">The function for event which is raised after the edited cell is edited.</param>
+		/// <param name="afterRestoreCell">The function for event which is raised after calling the method restoreCell or the user press ESC leaving the changes.</param>
+		/// <param name="afterSaveCell">The function for event which is raised after the cell has been successfully saved.</param>
+		/// <param name="afterSubmitCell">The function for event which is raised after the cell and other data is posted to the server.</param>
+		/// <param name="altClass">The class that is used for alternate rows.</param>
+		/// <param name="altRows">The value indicating if the grid should be "zebra-striped".</param>
+		/// <param name="autoEncode">The value indicating if the grid should auto encode/decode the data.</param>
+		/// <param name="autoWidth">The value indicating if the grid width will be recalculated automatically to the width of the parent element.</param>
+		/// <param name="beforeRequest">The function for event which is raised before requesting any data.</param>
+		/// <param name="beforeSelectRow">The function for event which is raised when the user click on the row, but before selecting it.</param>
+		/// <param name="beforeEditCell">The function for event which is raised before editing the cell.</param>
+		/// <param name="beforeSaveCell">The function for event which is raised before validation of values if any.</param>
+		/// <param name="beforeSubmitCell">The function for event which is raised before submit the cell content to the server.</param>
+		/// <param name="beforeProcessing">This function for event which is raised before proccesing the data returned from the server.</param>
+		/// <param name="caption">The caption for the grid.</param>
+		/// <param name="cellLayout">The padding plus border width of the cell.</param>
+		/// <param name="cellEditingEnabled">The value indicating if cell editing is enabled.</param>
+		/// <param name="cellEditingSubmitMode">The cell editing submit mode.</param>
+		/// <param name="cellEditingUrl">The URL for cell editing submit.</param>
+		/// <param name="dataString">The string of data which will be used when DataType is set to JqGridDataTypes.XmlString or JqGridDataTypes.JsonString.</param>
+		/// <param name="dataType">The type of information to expect to represent data in the grid.</param>
+		/// <param name="deepEmpty">The value indicating if jqGrid should be using jQuery.empty for the the row and all its children elements.</param>
+		/// <param name="direction">The language direction in grid.</param>
+		/// <param name="dynamicScrollingMode">The value which defines if dynamic scrolling is enabled.</param>
+		/// <param name="dynamicScrollingTimeout">The timeout (in miliseconds) if DynamicScrollingMode is set to JqGridDynamicScrollingModes.HoldVisibleRows.</param>
+		/// <param name="editingUrl">The url for inline and form editing</param>
+		/// <param name="emptyRecords">The information to be displayed when the returned (or the current) number of records is zero.</param>
+		/// <param name="expandColumnClick">The value which defines whether the tree is expanded and/or collapsed when user clicks on the text of the expanded column, not only on the image.</param>
+		/// <param name="expandColumn">The name of column which should be used to expand the tree grid.</param>
+		/// <param name="errorCell">The function for event which is raised when there is a server error while saving cell.</param>
+		/// <param name="formatCell">The function for event which allows formatting the cell content before editing.</param>
+		/// <param name="footerEnabled">The value indicating if the footer table (with one row) will be placed below the grid records and above the pager.</param>
+		/// <param name="gridView">The value indicating if all the data should be inserted into DOM with one jQuery call.</param>
+		/// <param name="groupingEnabled">The value indicating if the grouping is enabled.</param>
+		/// <param name="groupingView">The grouping view options.</param>
+		/// <param name="height">The height of the grid in pixels (default 'auto').</param>
+		/// <param name="headerTitles">The value which defines whether the title attribute is added to the column headers.</param>
+		/// <param name="hidden">The value which defines whether the grid is initialy hidden (no data loaded, only caption layer is shown). Takes effect only if the caption is not empty string and hiddenEnabled is true.</param>
+		/// <param name="hoverRows">The value which defines whether the mouse hovering over the grid data rows is enabled</param>
+		/// <param name="ignoreCase">The value which defines whether the local searching is case-sensitive.</param>
+		/// <param name="hiddenEnabled">The value which defines whether the show/hide grid button is enabled. Takes effect only if the caption is not empty string.</param>
+		/// <param name="jsonReader">The JSON reader for the grid.</param>
+		/// <param name="loadBeforeSend">The function for pre-callback to modify the XMLHttpRequest object before it is sent.</param>
+		/// <param name="loadError">The function for event which is raised after the request fails.</param>
+		/// <param name="loadComplete">The function for event which is raised immediately after every server request.</param>
+		/// <param name="loadOnce">The value which defines whether the grid should load the data only once and all further manipulationsshould be done on the client side.</param>
+		/// <param name="methodType">The type of request to make.</param>
+		/// <param name="multiKey">The key which should be pressed when the user makes multiselection.</param>
+		/// <param name="multiBoxOnly">The value which defines whether the multiselection is done only when the checkbox is clicked.</param>
+		/// <param name="multiSelect">The value which defines whether the multiselection is enabled.</param>
+		/// <param name="multiSelectWidth">The width of the multiselect colum.</param>
+		/// <param name="multiSort">The value which defines whether the sorting by multiple columns is enabled.</param>
+		/// <param name="gridComplete">The function for event which is raised after all the data is loaded into the grid and all other processes are complete.</param>
+		/// <param name="onCellSelect">The function for event which is raised when user clicks on particular cell in the grid.</param>
+		/// <param name="onDoubleClickRow">The function for event which is raised immediately after row was double clicked.</param>
+		/// <param name="onHeaderClick">The function for event which is raised after clicking to hide or show grid.</param>
+		/// <param name="onInitGrid">The function for event which is raised only once before populating the data.</param>
+		/// <param name="onPaging">The function for event which is raised before populating the data after page index/size change.</param>
+		/// <param name="onRightClickRow">The function for event which is raised immediately after row was right clicked.</param>
+		/// <param name="onSelectAll">The function for event which is raised when MultipleSelect option is true and user clicks on the header checkbox.</param>
+		/// <param name="onSelectCell">The function for event which is raised after the cell is selected for editing.</param>
+		/// <param name="onSelectRow">The function for event which is raised immediately after row was clicked.</param>
+		/// <param name="onSortCol">The function for event which is raised immediately after sortable column was clicked and before sorting the data.</param>
+		/// <param name="pager">If grid should use a pager bar to navigate through the records.</param>
+		/// <param name="parametersNames">The customized names for jqGrid request parameters.</param>
+		/// <param name="postData">The additional data which will be added to the request.</param>
+		/// <param name="postDataScript">The JavaScript which will dynamically generate the additional data which will be added to the request (this property takes precedence over postData).</param>
+		/// <param name="resizeStart">The function for event which is raised when user starts resizing a column.</param>
+		/// <param name="resizeStop">The function for event which is raised after the column is resized.</param>
+		/// <param name="rowAttributes">The function which can add attributes to the row during the creation of the data (dynamically).</param>
+		/// <param name="rowsList">The array to construct a select box element in the pager in which user can change the number of the visible rows.</param>
+		/// <param name="rowsNumber">How many records should be displayed in the grid.</param>
+		/// <param name="rowsNumbers">The value which defines whether a new column, which purpose is to count the number of available rows, should be added at left of the grid.</param>
+		/// <param name="rowsNumbersWidth">The width of the row number column.</param>
+		/// <param name="shrinkToFit">The value which defines whether the columns width should be recalculated to fit the width of the grid.</param>
+		/// <param name="scrollOffset">The width of vertical scrollbar.</param>
+		/// <param name="serializeCellData">The function for event which can serialize the data passed to the ajax request when the cell is being saved.</param>
+		/// <param name="serializeGridData">The function for event which can serialize the data passed to the ajax request.</param>
+		/// <param name="serializeSubGridData">The function for event which can serialize the data passed to the subgrid ajax request.</param>
+		/// <param name="sortable">The value which defines whether the columns can be reordered by dragging and dropping them with the mouse.</param>
+		/// <param name="sortingName">The initial sorting column index, when  using data returned from server.</param>
+		/// <param name="sortingOrder">The initial sorting order, when  using data returned from server.</param>
+		/// <param name="styleUI">The CSS framework.</param>
+		/// <param name="subgridEnabled">The value which defines if subgrid is enabled.</param>
+		/// <param name="subgridModel">The subgrid model.</param>
+		/// <param name="subgridHelper">The subgrid helper for "Subgrid as Grid" scenario. If this option has value, the SugridModel, SubgridUrl and SubGridRowExpanded options are ignored. It will also add additional parameter 'id' to the request.</param>
+		/// <param name="subgridUrl">The url for subgrid data requests.</param>
+		/// <param name="subgridColumnWidth">The width of subgrid expand/colapse column.</param>
+		/// <param name="subGridBeforeExpand">The function for event which is raised just before expanding the subgrid.</param>
+		/// <param name="subGridRowColapsed">The function for event which is raised when the user clicks on the plus icon of the grid.</param>
+		/// <param name="subGridRowExpanded">The function for event which is raised when the user clicks on the minus icon of the grid.</param>
+		/// <param name="topPager">The value indicating if jqGrid should place a pager element at top of the grid below the caption (if available).</param>
+		/// <param name="treeGridEnabled">The value which defines if TreeGrid is enabled.</param>
+		/// <param name="treeGridModel">The model for TreeGrid.</param>
+		/// <param name="url">The url for data requests.</param>
+		/// <param name="userDataOnFooter">The value indicating if the values from user data should be placed on footer.</param>
+		/// <param name="viewRecords">If grid should display the beginning and ending record number out of the total number of records in the query.</param>
+		/// <param name="width">The width of the grid in pixels.</param>
+		/// <param name="compatibilityMode">The compatibility mode.</param>
+		[Obsolete("Now this constructor creates more redurant JavaScript code. Use new constructor with JqGridOption parameter")]
+		public JqGridHelper(string id, string afterInsertRow = null, string afterEditCell = null, string afterRestoreCell = null, string afterSaveCell = null, string afterSubmitCell = null, string altClass = JqGridOptionsDefaults.AltClass, bool altRows = false, bool autoEncode = false, bool autoWidth = false, string beforeRequest = null, string beforeSelectRow = null, string beforeEditCell = null, string beforeSaveCell = null, string beforeSubmitCell = null, string beforeProcessing = null, string caption = null, int cellLayout = JqGridOptionsDefaults.CellLayout, bool cellEditingEnabled = false, JqGridCellEditingSubmitModes cellEditingSubmitMode = JqGridCellEditingSubmitModes.remote, string cellEditingUrl = null, string dataString = null, JqGridDataTypes dataType = JqGridDataTypes.Xml, bool deepEmpty = false, JqGridLanguageDirections direction = JqGridLanguageDirections.Ltr, JqGridDynamicScrollingModes dynamicScrollingMode = JqGridDynamicScrollingModes.Disabled, int dynamicScrollingTimeout = 200, string editingUrl = null, string emptyRecords = JqGridOptionsDefaults.EmptyRecords, bool expandColumnClick = true, string expandColumn = null, int? height = null, string errorCell = null, string formatCell = null, bool footerEnabled = false, bool gridView = false, bool groupingEnabled = false, JqGridGroupingView groupingView = null, bool headerTitles = false, bool hidden = false, bool hiddenEnabled = true, bool hoverRows = true, bool ignoreCase = false, JqGridJsonReader jsonReader = null, string loadBeforeSend = null, string loadError = null, string loadComplete = null, bool loadOnce = false, JqGridMethodTypes methodType = JqGridMethodTypes.Default, JqGridMultiKeys multiKey = JqGridMultiKeys.Default, bool multiBoxOnly = false, bool multiSelect = false, int multiSelectWidth = 20, bool multiSort = false, string gridComplete = null, string onCellSelect = null, string onDoubleClickRow = null, string onHeaderClick = null, string onInitGrid = null, string onPaging = null, string onRightClickRow = null, string onSelectAll = null, string onSelectCell = null, string onSelectRow = null, string onSortCol = null, bool pager = false, JqGridParametersNames parametersNames = null, object postData = null, string postDataScript = null, string resizeStart = null, string resizeStop = null, string rowAttributes = null, List<int> rowsList = null, int rowsNumber = 20, bool rowsNumbers = false, int rowsNumbersWidth = 25, bool shrinkToFit = true, int scrollOffset = 18, string serializeCellData = null, string serializeGridData = null, string serializeSubGridData = null, bool sortable = false, string sortingName = "", JqGridSortingOrders sortingOrder = JqGridSortingOrders.Asc, JqGridStyleUIOptions styleUI = JqGridStyleUIOptions.jQueryUI, bool subgridEnabled = false, JqGridSubgridModel subgridModel = null, object subgridHelper = null, string subgridUrl = null, int subgridColumnWidth = 20, string subGridBeforeExpand = null, string subGridRowColapsed = null, string subGridRowExpanded = null, bool topPager = false, bool treeGridEnabled = false, JqGridTreeGridModels treeGridModel = JqGridTreeGridModels.Nested, string url = null, bool userDataOnFooter = false, bool viewRecords = false, int? width = null, JqGridCompatibilityModes compatibilityMode = JqGridCompatibilityModes.JqGrid)
+			: this(new JqGridOptions<TModel>(id) { CompatibilityMode = compatibilityMode, AfterInsertRow = afterInsertRow, AfterEditCell = afterEditCell, AfterRestoreCell = afterRestoreCell, AfterSaveCell = afterSaveCell, AfterSubmitCell = afterSubmitCell, AltClass = altClass, AltRows = altRows, AutoEncode = autoEncode, AutoWidth = autoWidth, BeforeRequest = beforeRequest, BeforeSelectRow = beforeSelectRow, BeforeEditCell = beforeEditCell, BeforeSaveCell = beforeSaveCell, BeforeSubmitCell = beforeSubmitCell, BeforeProcessing = beforeProcessing, Caption = caption, CellLayout = cellLayout, CellEditingEnabled = cellEditingEnabled, CellEditingSubmitMode = cellEditingSubmitMode, CellEditingUrl = cellEditingUrl, DataString = dataString, DataType = dataType, DeepEmpty = deepEmpty, Direction = direction, DynamicScrollingMode = dynamicScrollingMode, DynamicScrollingTimeout = dynamicScrollingTimeout, EditingUrl = editingUrl, EmptyRecords = emptyRecords, ExpandColumnClick = expandColumnClick, ExpandColumn = expandColumn, ErrorCell = errorCell, FormatCell = formatCell, FooterEnabled = footerEnabled, GridView = gridView, GroupingEnabled = groupingEnabled, GroupingView = groupingView, Height = height, HeaderTitles = headerTitles, Hidden = hidden, HiddenEnabled = hiddenEnabled, HoverRows = hoverRows, IgnoreCase = ignoreCase, JsonReader = jsonReader, LoadBeforeSend = loadBeforeSend, LoadError = loadError, LoadComplete = loadComplete, LoadOnce = loadOnce, MethodType = methodType, MultiBoxOnly = multiBoxOnly, MultiKey = multiKey, MultiSelect = multiSelect, MultiSelectWidth = multiSelectWidth, MultiSort = multiSort, GridComplete = gridComplete, OnCellSelect = onCellSelect, OnDoubleClickRow = onDoubleClickRow, OnHeaderClick = onHeaderClick, OnInitGrid = onInitGrid, OnPaging = onPaging, OnRightClickRow = onRightClickRow, OnSelectAll = onSelectAll, OnSelectRow = onSelectRow, OnSelectCell = onSelectCell, OnSortCol = onSortCol, Pager = pager, ParametersNames = parametersNames, PostData = postData, PostDataScript = postDataScript, RowAttributes = rowAttributes, RowsList = rowsList, RowsNumber = rowsNumber, RowsNumbers = rowsNumbers, RowsNumbersWidth = rowsNumbersWidth, ShrinkToFit = shrinkToFit, ScrollOffset = scrollOffset, SerializeCellData = serializeCellData, SerializeGridData = serializeGridData, SerializeSubGridData = serializeSubGridData, Sortable = sortable, SortingName = sortingName, SortingOrder = sortingOrder, StyleUI = styleUI, SubgridEnabled = subgridEnabled, SubgridModel = subgridModel, SubgridUrl = subgridUrl, SubgridColumnWidth = subgridColumnWidth, SubGridBeforeExpand = subGridBeforeExpand, SubGridRowColapsed = subGridRowColapsed, SubGridRowExpanded = subGridRowExpanded, TopPager = topPager, TreeGridEnabled = treeGridEnabled, TreeGridModel = treeGridModel, Url = url, UserDataOnFooter = userDataOnFooter, ViewRecords = viewRecords, Width = width }, subgridHelper)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the JqGridHelper class.
+		/// </summary>
+		/// <param name="options">Options for the grid</param>
+		/// <param name="subgridHelper">The subgrid helper for "Subgrid as Grid" scenario. If this option has value, the SugridModel, SubgridUrl and SubGridRowExpanded options are ignored. It will also add additional parameter 'id' to the request.</param>
+		public JqGridHelper(JqGridOptions options, object subgridHelper = null)
+		{
+			_options = options;
+			_options.SetModel(typeof(TModel));
+
+			if (subgridHelper != null)
+			{
+				var subgridHelperType = subgridHelper.GetType();
+				if (!subgridHelperType.IsGenericType || subgridHelperType.GetGenericTypeDefinition() != typeof(JqGridHelper<>))
+					throw new ArgumentException("The object must be of type JqGridHelper<T>.", nameof(subgridHelper));
+				_subgridHelper = subgridHelper;
+			}
+		}
+		#endregion
+
+		#region Methods
+		/// <summary>
+		/// Returns the HTML that is used to render the table placeholder for the grid. 
+		/// </summary>
+		/// <returns>The HTML that represents the table placeholder for jqGrid</returns>
+		public MvcHtmlString GetTableHtml()
+		{
+			return MvcHtmlString.Create($"<table id='{Id}'></table>");
+		}
+
+		/// <summary>
+		/// Returns the HTML that is used to render the pager (div) placeholder for the grid. 
+		/// </summary>
+		/// <returns>The HTML that represents the pager (div) placeholder for jqGrid</returns>
+		public MvcHtmlString GetPagerHtml()
+		{
+			return MvcHtmlString.Create($"<div id='{PagerId}'></div>");
+		}
+
+		/// <summary>
+		/// Returns the HTML that is used to render the filter grid (div) placeholder for the grid. 
+		/// </summary>
+		/// <returns>The HTML that represents the filter grid (div) placeholder for jqGrid</returns>
+		public MvcHtmlString GetFilterGridHtml()
+		{
+			return MvcHtmlString.Create($"<div id='{FilterGridId}'></div>");
+		}
+
+		/// <summary>
+		/// Returns the HTML that is used to render the table placeholder for the grid with pager placeholder below it and filter grid (if enabled) placeholder above it.
+		/// </summary>
+		/// <returns>The HTML that represents the table placeholder for jqGrid with pager placeholder below i</returns>
+		public MvcHtmlString GetHtml()
+		{
+			if (_filterGridModel != null && _options.Pager)
+				return MvcHtmlString.Create(GetFilterGridHtml().ToHtmlString() + GetTableHtml().ToHtmlString() + GetPagerHtml().ToHtmlString());
+			if (_filterGridModel != null)
+				return MvcHtmlString.Create(GetFilterGridHtml().ToHtmlString() + GetTableHtml().ToHtmlString());
+			if (_options.Pager)
+				return MvcHtmlString.Create(GetTableHtml().ToHtmlString() + GetPagerHtml().ToHtmlString());
+			return GetTableHtml();
+		}
+
+		/// <summary>
+		/// Return the JavaScript that is used to initialize jqGrid with given options.
+		/// </summary>
+		/// <returns>The JavaScript that initializes jqGrid with give options</returns>
+		/// <exception cref="System.InvalidOperationException">
+		/// <list type="bullet">
+		/// <item><description>TreeGrid and data grouping are both enabled.</description></item>
+		/// <item><description>Rows numbers and data grouping are both enabled.</description></item>
+		/// <item><description>Dynamic scrolling and data grouping are both enabled.</description></item>
+		/// <item><description>TreeGrid and GridView are both enabled.</description></item>
+		/// <item><description>SubGrid and GridView are both enabled.</description></item>
+		/// <item><description>AfterInsertRow event and GridView are both enabled.</description></item>
+		/// </list> 
+		/// </exception>
+		public MvcHtmlString GetJavaScript()
+		{
+			ValidateLimitations();
+
+			var javaScriptBuilder = new StringBuilder();
+
+			javaScriptBuilder.AppendFormat("$({0}).jqGrid({{", GridSelector).AppendLine();
+			AppendColumnsNames(javaScriptBuilder);
+			AppendColumnsModels(javaScriptBuilder);
+			AppendOptions(javaScriptBuilder);
+			javaScriptBuilder.Append("})");
+
+			foreach (var columnModel in _options.ColumnsModels)
+			{
+				if (columnModel.LabelOptions != null)
+					AppendColumnLabelOptions(columnModel.Name, columnModel.LabelOptions, javaScriptBuilder);
+			}
+
+			if (_options.FooterEnabled.GetValueOrDefault() && _footerData != null && _footerData.Any())
+				AppendFooterData(javaScriptBuilder);
+
+			if (_navigatorOptions != null)
+				AppendNavigator(javaScriptBuilder);
+
+			if (_inlineNavigatorOptions != null)
+				AppendInlineNavigator(javaScriptBuilder);
+
+			if (_filterToolbar)
+				AppendFilterToolbar(javaScriptBuilder);
+
+			if (_groupHeaders != null && _groupHeaders.Any())
+				AppendGroupHeaders(javaScriptBuilder);
+
+			if (_setFrozenColumns)
+				javaScriptBuilder.Append(".jqGrid('setFrozenColumns')");
+
+			javaScriptBuilder.AppendLine(";");
+
+			if (_filterGridModel != null)
+				AppendFilterGrid(javaScriptBuilder);
+
+			return MvcHtmlString.Create(javaScriptBuilder.ToString());
+		}
+
+		internal string GetSubGridRowExpanded()
+		{
+			_asSubgrid = true;
+
+			StringBuilder subGridRowExpandedBuilder = new StringBuilder();
+			subGridRowExpandedBuilder.AppendLine("function(subgridId, rowId) {");
+
+			if (_filterGridModel != null)
+			{
+				subGridRowExpandedBuilder.AppendLine("var subgridFilterGridId = subgridId + '_s';");
+				subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<div id=\"' + subgridFilterGridId + '\"></div>');");
+			}
+
+			subGridRowExpandedBuilder.AppendLine("var subgridTableId = subgridId + '_t';");
+			subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<table id=\"' + subgridTableId + '\"></table>');");
+
+			if (_options.Pager)
+			{
+				subGridRowExpandedBuilder.AppendLine("var subgridPagerId = subgridId + '_p';");
+				subGridRowExpandedBuilder.AppendLine("jQuery('#' + subgridId).append('<div id=\"' + subgridPagerId + '\"></div>');");
+			}
+
+			subGridRowExpandedBuilder.AppendLine(GetJavaScript().ToString());
+
+			subGridRowExpandedBuilder.Append("}");
+			return subGridRowExpandedBuilder.ToString();
+		}
+
+		private void ValidateLimitations()
+		{
+			if (_options.TreeGridEnabled.GetValueOrDefault() && _options.GroupingEnabled.GetValueOrDefault())
+				throw new InvalidOperationException("TreeGrid and data grouping can not be enabled at the same time.");
+
+			if (_options.RowsNumbers.GetValueOrDefault() && _options.GroupingEnabled.GetValueOrDefault())
+				throw new InvalidOperationException("Rows numbers and data grouping can not be enabled at the same time.");
+
+			if (_options.DynamicScrollingMode != JqGridDynamicScrollingModes.Disabled && _options.GroupingEnabled.GetValueOrDefault())
+				throw new InvalidOperationException("Dynamic scrolling and data grouping can not be enabled at the same time.");
+
+			if (_options.TreeGridEnabled.GetValueOrDefault() && _options.GridView.GetValueOrDefault())
+				throw new InvalidOperationException("TreeGrid and GridView can not be enabled at the same time.");
+
+			if (_options.SubgridEnabled.GetValueOrDefault() && _options.GridView.GetValueOrDefault())
+				throw new InvalidOperationException("SubGrid and GridView can not be enabled at the same time.");
+
+			if (!string.IsNullOrWhiteSpace(_options.AfterInsertRow) && _options.GridView.GetValueOrDefault())
+				throw new InvalidOperationException("AfterInsertRow event and GridView can not be enabled at the same time.");
+		}
+
+		private void AppendColumnsNames(StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.Append("colNames: [");
+
+			foreach (var columnName in _options.ColumnsNames)
+				javaScriptBuilder.AppendFormat("'{0}',", columnName);
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 1] == ',')
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+
+			javaScriptBuilder.AppendLine("],");
+		}
+
+		private void AppendColumnsModels(StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.AppendLine("colModel: [");
+
+			var lastColumnModelIndex = _options.ColumnsModels.Count - 1;
+			for (var columnModelIndex = 0; columnModelIndex < _options.ColumnsModels.Count; columnModelIndex++)
+			{
+				var columnModel = _options.ColumnsModels[columnModelIndex];
+				javaScriptBuilder.Append("{ ");
+
+				if (columnModel.Alignment != JqGridAlignments.Default)
+					javaScriptBuilder.AppendFormat("align: '{0}', ", columnModel.Alignment.ToString().ToLower());
+
+				if (columnModel.Index?.IsSetted ?? false)
+					javaScriptBuilder.AppendFormat("index: '{0}', ", columnModel.Index.Value);
+
+				if (columnModel.CellAttributes?.IsSetted ?? false)
+					javaScriptBuilder.AppendFormat("cellattr: {0}, ", columnModel.CellAttributes.Value);
+
+				if (columnModel.Classes?.IsSetted ?? false)
+					javaScriptBuilder.AppendFormat("classes: '{0}', ", columnModel.Classes.Value);
+
+				if (columnModel.DateFormat?.IsSetted ?? false)
+					javaScriptBuilder.AppendFormat("datefmt: '{0}', ", columnModel.DateFormat.Value);
+
+				if (columnModel.Editable.HasValue)
+				{
+					javaScriptBuilder.AppendFormat("editable: {0}, ", columnModel.Editable.Value.ToString().ToLower());
+					if (columnModel.Editable.Value)
+					{
+						if (columnModel.EditType != JqGridColumnEditTypes.Default)
+							javaScriptBuilder.AppendFormat("edittype: '{0}', ", columnModel.EditType.ToString().ToLower());
+						AppendEditOptions(columnModel.EditOptions, javaScriptBuilder);
+						AppendColumnRules("editrules", columnModel.EditRules, javaScriptBuilder);
+						AppendFormOptions(columnModel.FormOptions, javaScriptBuilder);
+					}
+				}
+
+				if (columnModel.Fixed.HasValue)
+					javaScriptBuilder.AppendFormat("fixed: {0}, ", columnModel.Fixed.ToString().ToLower());
+
+				if (columnModel.Frozen.HasValue)
+					javaScriptBuilder.AppendFormat("frozen: {0}, ", columnModel.Frozen.ToString().ToLower());
+
+				if (columnModel.Formatter?.IsSetted ?? false)
+				{
+					javaScriptBuilder.AppendFormat("formatter: {0}, ", columnModel.Formatter.Value);
+					AppendFormatterOptions(columnModel.Formatter.Value, columnModel.FormatterOptions, javaScriptBuilder);
+					if (columnModel.UnFormatter?.IsSetted ?? false)
+						javaScriptBuilder.AppendFormat("unformat: {0}, ", columnModel.UnFormatter.Value);
+				}
+
+				if (columnModel.InitialSortingOrder != JqGridSortingOrders.Default)
+					javaScriptBuilder.AppendFormat("firstsortorder: '{0}', ", columnModel.InitialSortingOrder.ToString().ToLower());
+
+				if (columnModel.Hidden.HasValue)
+					javaScriptBuilder.AppendFormat("hidden: {0}, ", columnModel.Hidden.Value.ToString().ToLower());
+
+				if (columnModel.HideInDialog.HasValue)
+					javaScriptBuilder.AppendFormat("hidedlg: {0}, ", columnModel.HideInDialog.Value.ToString().ToLower());
+
+				if (!string.IsNullOrWhiteSpace(columnModel.JsonMapping))
+					javaScriptBuilder.AppendFormat("jsonmap: '{0}', ", columnModel.JsonMapping);
+
+				if (columnModel.Key.HasValue)
+					javaScriptBuilder.AppendFormat("key: {0}, ", columnModel.Key.Value.ToString().ToLower());
+
+				if (columnModel.Resizable.HasValue)
+					javaScriptBuilder.AppendFormat("resizable: {0}, ", columnModel.Resizable.Value.ToString().ToLower());
+
+				if (columnModel.Searchable.HasValue)
+				{
+					javaScriptBuilder.AppendFormat("search: {0}, ", columnModel.Searchable.Value.ToString().ToLower());
+					if (columnModel.Searchable.Value)
+					{
+						if (columnModel.SearchType != JqGridColumnSearchTypes.Default)
+							javaScriptBuilder.AppendFormat("stype: '{0}', ", columnModel.SearchType.ToString().ToLower());
+						AppendSearchOptions(columnModel.SearchOptions, javaScriptBuilder);
+						AppendColumnRules("searchrules", columnModel.SearchRules, javaScriptBuilder);
+					}
+				}
+
+				if (_options.GroupingEnabled.GetValueOrDefault())
+				{
+					if (columnModel.SummaryType.HasValue)
+					{
+						if (columnModel.SummaryType.Value != JqGridColumnSummaryTypes.Custom)
+							javaScriptBuilder.AppendFormat("summaryType: '{0}', ", columnModel.SummaryType.Value.ToString().ToLower());
+						else
+							javaScriptBuilder.AppendFormat("summaryType: {0}, ", columnModel.SummaryFunction);
+					}
+
+					if (columnModel.SummaryTemplate?.IsSetted ?? false)
+						javaScriptBuilder.AppendFormat("summaryTpl: '{0}', ", columnModel.SummaryTemplate.Value);
+				}
+
+				if (columnModel.Sortable.HasValue)
+				{
+					javaScriptBuilder.AppendFormat("sortable: {0}, ", columnModel.Sortable.Value.ToString().ToLower());
+					if (columnModel.Sortable.Value && columnModel.SortType != JqGridColumnSortTypes.Default)
+					{
+						if (columnModel.SortType == JqGridColumnSortTypes.Function && (columnModel.SortFunction?.IsSetted ?? false))
+							javaScriptBuilder.AppendFormat("sorttype: {0}, ", columnModel.SortFunction);
+						else if (columnModel.SortType != JqGridColumnSortTypes.Function)
+							javaScriptBuilder.AppendFormat("sorttype: '{0}', ", columnModel.SortType.ToString().ToLower());
+
+					}
+				}
+
+				if (columnModel.Title.HasValue)
+					javaScriptBuilder.AppendFormat("title: {0}, ", columnModel.Title.Value.ToString().ToLower());
+
+				if (columnModel.Width.HasValue)
+					javaScriptBuilder.AppendFormat("width: {0}, ", columnModel.Width.Value);
+
+				if (columnModel.Viewable.HasValue)
+					javaScriptBuilder.AppendFormat("viewable: {0}, ", columnModel.Viewable.ToString().ToLower());
+
+				if (!string.IsNullOrWhiteSpace(columnModel.XmlMapping))
+					javaScriptBuilder.AppendFormat("xmlmap: '{0}', ", columnModel.XmlMapping);
+
+				javaScriptBuilder.AppendFormat("name: '{0}' }}", columnModel.Name);
+
+				if (lastColumnModelIndex == columnModelIndex)
+					javaScriptBuilder.AppendLine();
+				else
+					javaScriptBuilder.AppendLine(",");
+			}
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 1);
+
+			javaScriptBuilder.AppendLine("],");
+		}
+
+		private void AppendEditOptions(JqGridColumnEditOptions editOptions, StringBuilder javaScriptBuilder)
+		{
+			if (editOptions != null)
+			{
+				var serializer = new JavaScriptSerializer();
+				javaScriptBuilder.Append("editoptions: { ");
+
+				if (editOptions.IsCustomElementFunctionSetted)
+					javaScriptBuilder.AppendFormat("custom_element: {0}, ", editOptions.CustomElementFunction);
+
+				if (editOptions.IsCustomValueFunctionSetted)
+					javaScriptBuilder.AppendFormat("custom_value: {0}, ", editOptions.CustomValueFunction);
+
+				if (editOptions.InternalDataEvents != null)
+				{
+					if (editOptions.DataEvents == null)
+						editOptions.DataEvents = new List<JqGridColumnDataEvent>();
+
+					foreach (var dataEvent in editOptions.InternalDataEvents)
+						editOptions.DataEvents.Add(new JqGridColumnDataEvent(dataEvent.Type, string.Format(dataEvent.Function, _options.Id)));
+				}
+				AppendElementOptions(editOptions, serializer, javaScriptBuilder);
+
+				if (editOptions.NullIfEmpty.HasValue)
+					javaScriptBuilder.AppendFormat("NullIfEmpty: {0}, ", editOptions.NullIfEmpty.Value.ToString().ToLower());
+
+				if (editOptions.HtmlAttributes != null && editOptions.HtmlAttributes.Any())
+				{
+					var htmlAttributesSerialized = serializer.Serialize(editOptions.HtmlAttributes);
+					javaScriptBuilder.AppendFormat("{0}, ", htmlAttributesSerialized.Substring(1, htmlAttributesSerialized.Length - 2));
+				}
+
+				if (editOptions.IsPostDataScriptsSetted)
+					javaScriptBuilder.AppendFormat("postData: {0}, ", editOptions.PostDataScript);
+				else if (editOptions.PostData != null)
+				{
+					serializer = new JavaScriptSerializer();
+					javaScriptBuilder.AppendFormat("postData: {0}, ", serializer.Serialize(editOptions.PostData));
+				}
+
+				if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+				{
+					javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+					javaScriptBuilder.Append(" }, ");
+				}
+				else
+					javaScriptBuilder.Remove(javaScriptBuilder.Length - 15, 15);
+			}
+		}
+
+		private void AppendElementOptions(JqGridColumnElementOptions elementOptions, JavaScriptSerializer serializer, StringBuilder javaScriptBuilder)
+		{
+			if (elementOptions.IsBuildSelectSetted)
+				javaScriptBuilder.AppendFormat("buildSelect: {0}, ", elementOptions.BuildSelect);
+
+			if (elementOptions.DataEvents != null && elementOptions.DataEvents.Any())
+			{
+				javaScriptBuilder.Append("dataEvents: [ ");
+				foreach (var dataEvent in elementOptions.DataEvents)
+				{
+					if (dataEvent.Data == null)
+						javaScriptBuilder.AppendFormat("{{ type: '{0}', fn: {1} }}, ", dataEvent.Type, dataEvent.Function);
+					else
+						javaScriptBuilder.AppendFormat("{{ type: '{0}', data: {1}, fn: {2} }}, ", dataEvent.Type, serializer.Serialize(dataEvent.Data), dataEvent.Function);
+				}
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" ], ");
+			}
+
+			if (elementOptions.JQueryUIWidgetDataInitRenderer != null)
+				javaScriptBuilder.AppendFormat("dataInit: {0}, ", elementOptions.JQueryUIWidgetDataInitRenderer(_options.CompatibilityMode, GridSelector));
+			else if (elementOptions.IsDataInitSetted)
+				javaScriptBuilder.AppendFormat("dataInit: {0}, ", elementOptions.DataInit);
+
+			if (elementOptions.IsDataUrlSetted)
+				javaScriptBuilder.AppendFormat("dataUrl: '{0}', ", elementOptions.DataUrl);
+
+			if (elementOptions.IsDefaultValueSetted)
+				javaScriptBuilder.AppendFormat("defaultValue: '{0}', ", elementOptions.DefaultValue);
+
+			if (elementOptions.IsValueSetted)
+				javaScriptBuilder.AppendFormat("value: '{0}', ", elementOptions.Value);
+			else if (elementOptions.ValueDictionary != null)
+				javaScriptBuilder.AppendFormat("value: {0}, ", serializer.Serialize(elementOptions.ValueDictionary));
+		}
+
+		private static void AppendColumnRules(string rulesName, JqGridColumnRules rules, StringBuilder javaScriptBuilder)
+		{
+			if (rules == null) return;
+			javaScriptBuilder.AppendFormat("{0}: {{ ", rulesName);
+
+			if (rules.Custom.HasValue)
+			{
+				javaScriptBuilder.AppendFormat("custom: {0}, ", rules.Custom.Value.ToString().ToLower());
+
+				if (rules.IsCustomFunctionSetted)
+					javaScriptBuilder.AppendFormat("custom_func: {0}, ", rules.CustomFunction);
+			}
+
+			if (rules.Date.HasValue)
+				javaScriptBuilder.AppendFormat("date: {0}, ", rules.Date.Value.ToString().ToLower());
+
+			if (rules.EditHidden.HasValue)
+				javaScriptBuilder.AppendFormat("edithidden: {0}, ", rules.EditHidden.Value.ToString().ToLower());
+
+			if (rules.Email.HasValue)
+				javaScriptBuilder.AppendFormat("email: {0}, ", rules.Email.Value.ToString().ToLower());
+
+			if (rules.Integer)
+				javaScriptBuilder.Append("integer: true, ");
+
+			if (rules.MaxValue.HasValue)
+				javaScriptBuilder.AppendFormat("maxValue: {0}, ", rules.MaxValue.Value);
+
+			if (rules.MinValue.HasValue)
+				javaScriptBuilder.AppendFormat("minValue: {0}, ", rules.MinValue.Value);
+
+			if (rules.Number)
+				javaScriptBuilder.Append("number: true, ");
+
+			if (rules.Required.HasValue)
+				javaScriptBuilder.AppendFormat("required: {0}, ", rules.Required.Value.ToString().ToLower());
+
+			if (rules.Time.HasValue)
+				javaScriptBuilder.AppendFormat("time: {0}, ", rules.Time.Value.ToString().ToLower());
+
+			if (rules.Url.HasValue)
+				javaScriptBuilder.AppendFormat("url: {0}, ", rules.Url.Value.ToString().ToLower());
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" }, ");
+			}
+			else
+			{
+				var rulesNameLength = rulesName.Length + 4;
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - rulesNameLength, rulesNameLength);
+			}
+		}
+
+		private static void AppendFormOptions(JqGridColumnFormOptions formOptions, StringBuilder javaScriptBuilder)
+		{
+			if (formOptions == null) return;
+			javaScriptBuilder.Append("formoptions: { ");
+
+			if (formOptions.ColumnPosition.HasValue)
+				javaScriptBuilder.AppendFormat("colpos: {0},", formOptions.ColumnPosition.Value);
+
+			if (formOptions.IsElementPrefixSetted)
+				javaScriptBuilder.AppendFormat("elmprefix: '{0}',", formOptions.ElementPrefix);
+
+			if (formOptions.IsElementSuffixSetted)
+				javaScriptBuilder.AppendFormat("elmsuffix: '{0}',", formOptions.ElementSuffix);
+
+			if (formOptions.IsLabelSetted)
+				javaScriptBuilder.AppendFormat("label: '{0}',", formOptions.Label);
+
+			if (formOptions.RowPosition.HasValue)
+				javaScriptBuilder.AppendFormat("rowpos: {0},", formOptions.RowPosition.Value);
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 1] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+				javaScriptBuilder.Append(" }, ");
+			}
+			else
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 15, 15);
+		}
+
+		private static void AppendFormatterOptions(string formatter, JqGridColumnFormatterOptions formatterOptions, StringBuilder javaScriptBuilder)
+		{
+			if (formatterOptions == null || formatterOptions.IsDefault(formatter)) return;
+			javaScriptBuilder.Append("formatoptions: { ");
+
+			switch (formatter)
+			{
+				case JqGridColumnPredefinedFormatters.Integer:
+					javaScriptBuilder.AppendFormat("{0}{1}", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
+					break;
+				case JqGridColumnPredefinedFormatters.Number:
+					javaScriptBuilder.AppendFormat("{0}{1}{2}{3}", !formatterOptions.DecimalPlaces.HasValue ? string.Empty : $"decimalPlaces: {formatterOptions.DecimalPlaces.Value}, ", !formatterOptions.IsDecimalSeparatorSetted ? string.Empty : $"decimalSeparator: '{formatterOptions.DecimalSeparator}', ", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
+					break;
+				case JqGridColumnPredefinedFormatters.Currency:
+					javaScriptBuilder.AppendFormat("{0}{1}{2}{3}{4}{5}", !formatterOptions.DecimalPlaces.HasValue ? string.Empty : $"decimalPlaces: {formatterOptions.DecimalPlaces.Value}, ", !formatterOptions.IsDecimalSeparatorSetted ? string.Empty : $"decimalSeparator: '{formatterOptions.DecimalSeparator}', ", !formatterOptions.IsDefaultValueSetted ? string.Empty : $"defaultValue: '{formatterOptions.DefaultValue}', ", !formatterOptions.IsPrefixSetted ? string.Empty : $"prefix: '{formatterOptions.Prefix}', ", !formatterOptions.IsSuffixSetted ? string.Empty : $"suffix: '{formatterOptions.Suffix}', ", !formatterOptions.IsThousandsSeparatorSetted ? string.Empty : $"thousandsSeparator: '{formatterOptions.ThousandsSeparator}', ");
+					break;
+				case JqGridColumnPredefinedFormatters.Date:
+					javaScriptBuilder.AppendFormat("{0}{1}", !formatterOptions.IsSourceFormatSetted ? string.Empty : $"srcformat: '{formatterOptions.SourceFormat}', ", !formatterOptions.IsOutputFormatSetted ? string.Empty : $"newformat: '{formatterOptions.OutputFormat}', ");
+					break;
+				case JqGridColumnPredefinedFormatters.Link:
+					javaScriptBuilder.AppendFormat("target: '{0}', ", formatterOptions.Target);
+					break;
+				case JqGridColumnPredefinedFormatters.ShowLink:
+					javaScriptBuilder.AppendFormat("{0}{1}{2}{3}{4}", !formatterOptions.IsBaseLinkUrlSetted ? string.Empty : $"baseLinkUrl: '{formatterOptions.BaseLinkUrl}', ", !formatterOptions.IsShowActionSetted ? string.Empty : $"showAction: '{formatterOptions.ShowAction}', ", !formatterOptions.IsAddParamSetted ? string.Empty : $"addParam: '{formatterOptions.AddParam}', ", !formatterOptions.IsTargetSetted ? string.Empty : $"target: '{formatterOptions.Target}', ", !formatterOptions.IsIdNameSetted ? string.Empty : $"idName: '{formatterOptions.IdName}', ");
+					break;
+				case JqGridColumnPredefinedFormatters.CheckBox:
+					javaScriptBuilder.Append("disabled: false, ");
+					break;
+				case JqGridColumnPredefinedFormatters.Actions:
+					javaScriptBuilder.AppendFormat("{0}{1}{2}", formatterOptions.EditButton ? string.Empty : "editbutton: false, ", formatterOptions.DeleteButton ? string.Empty : "delbutton: false, ", !formatterOptions.UseFormEditing ? string.Empty : "editformbutton: true, ");
+
+					if (formatterOptions.EditButton)
+					{
+						if (!formatterOptions.UseFormEditing && formatterOptions.InlineEditingOptions != null)
+						{
+							if (formatterOptions.InlineEditingOptions.Keys)
+								javaScriptBuilder.Append("keys: true, ");
+
+							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.OnEditFunction))
+								javaScriptBuilder.AppendFormat("onEdit: {0}, ", formatterOptions.InlineEditingOptions.OnEditFunction);
+
+							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.SuccessFunction))
+								javaScriptBuilder.AppendFormat("onSuccess: {0}, ", formatterOptions.InlineEditingOptions.SuccessFunction);
+
+							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.Url))
+								javaScriptBuilder.AppendFormat("url: '{0}', ", formatterOptions.InlineEditingOptions.Url);
+
+							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.ExtraParamScript))
+								javaScriptBuilder.AppendFormat("extraparam: {0}, ", formatterOptions.InlineEditingOptions.ExtraParamScript);
+							else if (formatterOptions.InlineEditingOptions.ExtraParam != null)
+							{
+								JavaScriptSerializer serializer = new JavaScriptSerializer();
+								javaScriptBuilder.AppendFormat("extraparam: {0}, ", serializer.Serialize(formatterOptions.InlineEditingOptions.ExtraParam));
+							}
+
+							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.AfterSaveFunction))
+								javaScriptBuilder.AppendFormat("afterSave: {0}, ", formatterOptions.InlineEditingOptions.AfterSaveFunction);
+
+							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.ErrorFunction))
+								javaScriptBuilder.AppendFormat("onError: {0}, ", formatterOptions.InlineEditingOptions.ErrorFunction);
+
+							if (!string.IsNullOrWhiteSpace(formatterOptions.InlineEditingOptions.AfterRestoreFunction))
+								javaScriptBuilder.AppendFormat("afterRestore: {0}, ", formatterOptions.InlineEditingOptions.AfterRestoreFunction);
+
+							if (!formatterOptions.InlineEditingOptions.RestoreAfterError)
+								javaScriptBuilder.Append("restoreAfterError: false, ");
+
+							if (formatterOptions.InlineEditingOptions.MethodType != JqGridMethodTypes.Post)
+								javaScriptBuilder.Append("mtype: 'GET', ");
+						}
+						else if (formatterOptions.UseFormEditing && formatterOptions.FormEditingOptions != null)
+							AppendNavigatorActionOptions("editOptions: ", formatterOptions.FormEditingOptions, javaScriptBuilder);
+					}
+
+					if (formatterOptions.DeleteButton && formatterOptions.DeleteOptions != null)
+						AppendNavigatorActionOptions("delOptions: ", formatterOptions.DeleteOptions, javaScriptBuilder);
+					break;
+			}
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" }, ");
+			}
+			else
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 17, 17);
+		}
+
+		private void AppendSearchOptions(JqGridColumnSearchOptions searchOptions, StringBuilder javaScriptBuilder)
+		{
+			if (searchOptions == null) return;
+			var serializer = new JavaScriptSerializer();
+			javaScriptBuilder.Append("searchoptions: { ");
+
+			AppendElementOptions(searchOptions, serializer, javaScriptBuilder);
+
+			if (searchOptions.HtmlAttributes != null && searchOptions.HtmlAttributes.Count > 0)
+				javaScriptBuilder.AppendFormat("attr: {0}, ", serializer.Serialize(searchOptions.HtmlAttributes));
+
+			if (searchOptions.ClearSearch.HasValue)
+				javaScriptBuilder.AppendFormat("clearSearch: {0}, ", searchOptions.ClearSearch.Value.ToString().ToLower());
+
+			if (searchOptions.SearchHidden.HasValue)
+				javaScriptBuilder.AppendFormat("searchhidden: {0}, ", searchOptions.SearchHidden.Value.ToString().ToLower());
+
+			AppendSearchOperators(searchOptions.SearchOperators, javaScriptBuilder);
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" }, ");
+			}
+			else
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 17, 17);
+		}
+
+		private static void AppendSearchOperators(JqGridSearchOperators? searchOperators, StringBuilder javaScriptBuilder)
+		{
+			if (searchOperators.HasValue && searchOperators.Value != JqGridSearchOperators.Default)
+			{
+				javaScriptBuilder.Append("sopt: [ ");
+				foreach (JqGridSearchOperators searchOperator in Enum.GetValues(typeof(JqGridSearchOperators)))
+				{
+					if (searchOperator == JqGridSearchOperators.Default) continue;
+					if (searchOperator != JqGridSearchOperators.EqualOrNotEqual && searchOperator != JqGridSearchOperators.NoTextOperators && searchOperator != JqGridSearchOperators.TextOperators && (searchOperators.Value & searchOperator) == searchOperator)
+						javaScriptBuilder.AppendFormat("'{0}',", Enum.GetName(typeof(JqGridSearchOperators), searchOperator).ToLower());
+				}
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+				javaScriptBuilder.Append("], ");
+			}
+		}
+
+		private void AppendOptions(StringBuilder javaScriptBuilder)
+		{
+			if (_options.IsAfterInsertRowSetted)
+				javaScriptBuilder.AppendFormat("afterInsertRow: {0},", _options.AfterInsertRow.ToNullString()).AppendLine();
+
+			if (_options.IsAfterEditCellSetted)
+				javaScriptBuilder.AppendFormat("afterEditCell: {0},", _options.AfterEditCell.ToNullString()).AppendLine();
+
+			if (_options.IsAfterRestoreCellSetted)
+				javaScriptBuilder.AppendFormat("afterRestoreCell: {0},", _options.AfterRestoreCell.ToNullString()).AppendLine();
+
+			if (_options.IsAfterSaveCellSetted)
+				javaScriptBuilder.AppendFormat("afterSaveCell: {0},", _options.AfterSaveCell.ToNullString()).AppendLine();
+
+			if (_options.IsAfterSumbitCellSetted)
+				javaScriptBuilder.AppendFormat("afterSubmitCell: {0},", _options.AfterSubmitCell.ToNullString()).AppendLine();
+
+			if (_options.IsAltClassSetted)
+				javaScriptBuilder.AppendFormat("altclass: '{0}',", _options.AltClass.ToNullString()).AppendLine();
+
+			if (_options.AltRows.HasValue)
+				javaScriptBuilder.AppendFormat("altRows: {0},", _options.AltRows.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.AutoEncode.HasValue)
+				javaScriptBuilder.AppendFormat("autoencode: {0},", _options.AutoEncode.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.AutoWidth.HasValue)
+				javaScriptBuilder.AppendFormat("autowidth: {0},", _options.AutoWidth.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.IsBeforeRequestSetted)
+				javaScriptBuilder.AppendFormat("beforeRequest: {0},", _options.BeforeRequest.ToNullString()).AppendLine();
+
+			if (_options.IsBeforeSelectRowSetted)
+				javaScriptBuilder.AppendFormat("beforeSelectRow: {0},", _options.BeforeSelectRow.ToNullString()).AppendLine();
+
+			if (_options.IsBeforeEditCellSetted)
+				javaScriptBuilder.AppendFormat("beforeEditCell: {0},", _options.BeforeEditCell.ToNullString()).AppendLine();
+
+			if (_options.IsBeforeSaveCellSetted)
+				javaScriptBuilder.AppendFormat("beforeSaveCell: {0},", _options.BeforeSaveCell.ToNullString()).AppendLine();
+
+			if (_options.IsBeforeSubmitCellSetted)
+				javaScriptBuilder.AppendFormat("beforeSubmitCell: {0},", _options.BeforeSubmitCell.ToNullString()).AppendLine();
+
+			if (_options.IsBeforeProcessingSetted)
+				javaScriptBuilder.AppendFormat("beforeProcessing: {0},", _options.BeforeProcessing.ToNullString()).AppendLine();
+
+			if (_options.CellLayout.HasValue)
+				javaScriptBuilder.AppendFormat("cellLayout: {0},", _options.CellLayout.Value).AppendLine();
+
+			if (_options.CellEditingEnabled.HasValue)
+			{
+				javaScriptBuilder.AppendFormat("cellEdit: {0},", _options.CellEditingEnabled.Value.ToString().ToLower()).AppendLine();
+				if (_options.CellEditingEnabled.Value)
+				{
+					if (_options.CellEditingSubmitMode != JqGridCellEditingSubmitModes.Default)
+						javaScriptBuilder.AppendFormat("cellsubmit: '{0}',", _options.CellEditingSubmitMode).AppendLine();
+
+					if (_options.IsCellEditingUrlSetted)
+						javaScriptBuilder.AppendFormat("cellurl: '{0}',", _options.CellEditingUrl.ToNullString()).AppendLine();
+				}
+			}
+
+			if (_options.IsCaptionSetted)
+				javaScriptBuilder.AppendFormat("caption: '{0}',", _options.Caption.ToNullString()).AppendLine();
+
+			if (_options.HiddenEnabled.HasValue)
+				javaScriptBuilder.AppendFormat("hidegrid: {0},", _options.HiddenEnabled.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.Hidden.HasValue)
+				javaScriptBuilder.AppendFormat("hiddengrid: {0},", _options.Hidden.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.IsUsedDataString)
+				javaScriptBuilder.AppendFormat("datastr: '{0}',", _options.DataString).AppendLine();
+			else if (_asSubgrid)
+			{
+				if (_options.Url.Contains("?"))
+					javaScriptBuilder.AppendFormat("url: '{0}&id=' + encodeURIComponent(rowId),", _options.Url).AppendLine();
+				else
+					javaScriptBuilder.AppendFormat("url: '{0}?id=' + encodeURIComponent(rowId),", _options.Url).AppendLine();
+			}
+			else
+				javaScriptBuilder.AppendFormat("url: '{0}',", _options.Url).AppendLine();
+
+			if (_options.DataType != JqGridDataTypes.Default)
+				javaScriptBuilder.AppendFormat("datatype: '{0}',", _options.DataType.ToString().ToLower()).AppendLine();
+
+			if (_options.DeepEmpty.HasValue)
+				javaScriptBuilder.AppendFormat("deepempty: {0},", _options.DeepEmpty.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.Direction != JqGridLanguageDirections.Default)
+				javaScriptBuilder.AppendFormat("direction: '{0}',", _options.Direction.ToString().ToLower()).AppendLine();
+
+			if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.Disabled)
+				javaScriptBuilder.Append("scroll: false,").AppendLine();
+			else if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldAllRows)
+				javaScriptBuilder.Append("scroll: true,").AppendLine();
+			else if (_options.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldVisibleRows)
+			{
+				javaScriptBuilder.Append("scroll: 10,").AppendLine();
+				if (_options.DynamicScrollingTimeout.HasValue)
+					javaScriptBuilder.AppendFormat("scrollTimeout: {0},", _options.DynamicScrollingTimeout.Value).AppendLine();
+			}
+
+			if (_options.IsEmptyRecordsSetted)
+				javaScriptBuilder.AppendFormat("emptyrecords: '{0}',", _options.EmptyRecords.ToNullString()).AppendLine();
+
+			if (_options.IsEditingUrlSetted)
+				javaScriptBuilder.AppendFormat("editurl: '{0}',", _options.EditingUrl.ToNullString()).AppendLine();
+
+			if (_options.IsErrorCellSetted)
+				javaScriptBuilder.AppendFormat("errorCell: {0},", _options.ErrorCell.ToNullString()).AppendLine();
+
+			if (_options.IsFormatCellSetted)
+				javaScriptBuilder.AppendFormat("formatCell: {0},", _options.FormatCell.ToNullString()).AppendLine();
+
+			if (_options.FooterEnabled.HasValue)
+				javaScriptBuilder.AppendFormat("footerrow: {0},", _options.FooterEnabled.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.UserDataOnFooter.HasValue)
+				javaScriptBuilder.AppendFormat("userDataOnFooter: {0},", _options.UserDataOnFooter.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.GridView.HasValue)
+				javaScriptBuilder.AppendFormat("gridview: {0},", _options.GridView.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.GroupingEnabled.HasValue)
+			{
+				javaScriptBuilder.AppendFormat("grouping: {0},", _options.GroupingEnabled.Value.ToString().ToLower()).AppendLine();
+				if (_options.GroupingEnabled.Value)
+					AppendGroupingView(javaScriptBuilder);
+			}
+
+			if (_options.HeaderTitles.HasValue)
+				javaScriptBuilder.AppendFormat("headertitles: {0},", _options.HeaderTitles.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.HoverRows.HasValue)
+				javaScriptBuilder.AppendFormat("hoverrows: {0},", _options.HoverRows.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.IgnoreCase.HasValue)
+				javaScriptBuilder.AppendFormat("ignoreCase: {0},", _options.IgnoreCase.Value.ToString().ToLower()).AppendLine();
+
+			AppendJsonReader(javaScriptBuilder);
+
+			if (_options.IsLoadBeforeSendSetted)
+				javaScriptBuilder.AppendFormat("loadBeforeSend: {0},", _options.LoadBeforeSend.ToNullString()).AppendLine();
+
+			if (_options.IsLoadCompleteSetted)
+				javaScriptBuilder.AppendFormat("loadComplete: {0},", _options.LoadComplete.ToNullString()).AppendLine();
+
+			if (_options.IsLoadErrorSetted)
+				javaScriptBuilder.AppendFormat("loadError: {0},", _options.LoadError.ToNullString()).AppendLine();
+
+			if (_options.LoadOnce.HasValue)
+				javaScriptBuilder.AppendFormat("loadonce: {0},", _options.LoadOnce.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.MethodType != JqGridMethodTypes.Default)
+				javaScriptBuilder.AppendFormat("mtype: '{0}',", _options.MethodType.ToString().ToUpper()).AppendLine();
+
+			if (_options.MultiKey != JqGridMultiKeys.Default)
+				if (_options.MultiKey == JqGridMultiKeys.Disable)
+					javaScriptBuilder.Append("multikey: null,").AppendLine();
+				else
+					javaScriptBuilder.AppendFormat("multikey: '{0}Key',", _options.MultiKey.ToString().ToLower()).AppendLine();
+
+			if (_options.MultiBoxOnly.HasValue)
+				javaScriptBuilder.AppendFormat("multiboxonly: {0},", _options.MultiBoxOnly.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.MultiSelect.HasValue)
+				javaScriptBuilder.AppendFormat("multiselect: {0},", _options.MultiSelect.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.MultiSelectWidth.HasValue)
+				javaScriptBuilder.AppendFormat("multiselectWidth: {0},", _options.MultiSelectWidth.Value).AppendLine();
+
+			if (_options.MultiSort.HasValue)
+				javaScriptBuilder.AppendFormat("multiSort: {0},", _options.MultiSort.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.IsGridCompleteSetted)
+				javaScriptBuilder.AppendFormat("gridComplete: {0},", _options.GridComplete.ToNullString()).AppendLine();
+
+			if (_options.IsOnCellSelectSetted)
+				javaScriptBuilder.AppendFormat("onCellSelect: {0},", _options.OnCellSelect.ToNullString()).AppendLine();
+
+			if (_options.IsOnDoubleClickRowSetted)
+				javaScriptBuilder.AppendFormat("ondblClickRow: {0},", _options.OnDoubleClickRow.ToNullString()).AppendLine();
+
+			if (_options.IsOnHeaderClickSetted)
+				javaScriptBuilder.AppendFormat("onHeaderClick: {0},", _options.OnHeaderClick.ToNullString()).AppendLine();
+
+			if (_options.IsOnInitGridSetted)
+				javaScriptBuilder.AppendFormat("onInitGrid: {0},", _options.OnInitGrid.ToNullString()).AppendLine();
+
+			if (_options.IsOnPagingSetted)
+				javaScriptBuilder.AppendFormat("onPaging: {0},", _options.OnPaging.ToNullString()).AppendLine();
+
+			if (_options.IsOnRightClickRowSetted)
+				javaScriptBuilder.AppendFormat("onRightClickRow: {0},", _options.OnRightClickRow.ToNullString()).AppendLine();
+
+			if (_options.IsOnSelectAllSetted)
+				javaScriptBuilder.AppendFormat("onSelectAll: {0},", _options.OnSelectAll.ToNullString()).AppendLine();
+
+			if (_options.IsOnSelectCellSetted)
+				javaScriptBuilder.AppendFormat("onSelectCell: {0},", _options.OnSelectCell.ToNullString()).AppendLine();
+
+			if (_options.IsOnSelectRowSetted)
+				javaScriptBuilder.AppendFormat("onSelectRow: {0},", _options.OnSelectRow.ToNullString()).AppendLine();
+
+			if (_options.IsOnSortColSetted)
+				javaScriptBuilder.AppendFormat("onSortCol: {0},", _options.OnSortCol.ToNullString()).AppendLine();
+
+			if (_options.Pager)
+				javaScriptBuilder.AppendFormat("pager: {0},", PagerSelector).AppendLine();
+
+			AppendParametersNames(javaScriptBuilder);
+
+			if (_options.IsPostDataScriptSetted)
+				javaScriptBuilder.AppendFormat("postData: {0},", string.IsNullOrWhiteSpace(_options.PostDataScript) ? "{}" : _options.PostDataScript).AppendLine();
+			else if (_options.IsPostDataSetted)
+			{
+				var serializer = new JavaScriptSerializer();
+				if (_options.PostData == null)
+					javaScriptBuilder.Append("postData: {},");
+				else
+					javaScriptBuilder.AppendFormat("postData: {0},", serializer.Serialize(_options.PostData));
+			}
+
+			if (_options.IsResizeStartSetted)
+				javaScriptBuilder.AppendFormat("resizeStart: {0},", _options.ResizeStart.ToNullString()).AppendLine();
+
+			if (_options.IsResizeStopSetted)
+				javaScriptBuilder.AppendFormat("resizeStop: {0},", _options.ResizeStop.ToNullString()).AppendLine();
+
+			if (_options.IsRowAttributesSetted)
+				javaScriptBuilder.AppendFormat("rowattr: {0},", _options.RowAttributes.ToNullString()).AppendLine();
+
+			if (_options.RowsList != null && _options.RowsList.Any())
+			{
+				javaScriptBuilder.Append("rowList: [");
+				javaScriptBuilder.Append(string.Join(",", _options.RowsList));
+				javaScriptBuilder.Append("],").AppendLine();
+			}
+
+			if (_options.RowsNumber.HasValue)
+				javaScriptBuilder.AppendFormat("rowNum: {0},", _options.RowsNumber.Value).AppendLine();
+
+			if (_options.RowsNumbers.HasValue)
+				javaScriptBuilder.AppendFormat("rownumbers: {0},", _options.RowsNumbers.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.RowsNumbersWidth.HasValue)
+				javaScriptBuilder.AppendFormat("rownumWidth: {0},", _options.RowsNumbersWidth.Value).AppendLine();
+
+			if (_options.ColumnsRemaping != null && _options.ColumnsRemaping.Any())
+			{
+				javaScriptBuilder.Append("remapColumns: [");
+				javaScriptBuilder.Append(string.Join(",", _options.ColumnsRemaping));
+				javaScriptBuilder.Append("],").AppendLine();
+			}
+
+			if (_options.ShrinkToFit.HasValue)
+				javaScriptBuilder.AppendFormat("shrinkToFit: {0},", _options.ShrinkToFit.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.ScrollOffset.HasValue)
+				javaScriptBuilder.AppendFormat("scrollOffset: {0},", _options.ScrollOffset.Value).AppendLine();
+
+			if (_options.IsSerializeCellDataSetted)
+				javaScriptBuilder.AppendFormat("serializeCellData: {0},", _options.SerializeCellData.ToNullString()).AppendLine();
+
+			if (_options.IsSerializeGridDataSetted)
+				javaScriptBuilder.AppendFormat("serializeGridData: {0},", _options.SerializeGridData.ToNullString()).AppendLine();
+
+			if (_options.IsSerializeSubGridDataSetted)
+				javaScriptBuilder.AppendFormat("serializeSubGridData: {0},", _options.SerializeSubGridData.ToNullString()).AppendLine();
+
+			if (_options.Sortable.HasValue)
+				javaScriptBuilder.AppendFormat("sortable: {0},", _options.Sortable.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.IsSortingNameSetted)
+				javaScriptBuilder.AppendFormat("sortname: '{0}',", _options.SortingName.ToNullString()).AppendLine();
+
+			if (_options.SortingOrder != JqGridSortingOrders.Default)
+				javaScriptBuilder.AppendFormat("sortorder: '{0}',", _options.SortingOrder.ToString().ToLower()).AppendLine();
+
+			if (_options.StyleUI != JqGridStyleUIOptions.Default)
+				javaScriptBuilder.AppendFormat("styleUI: '{0}',", _options.StyleUI.ToString()).AppendLine();
+
+			if (_options.IconSet != JqGridBootstrap4IconSet.Default)
+				javaScriptBuilder.AppendFormat("iconSet: '{0}',", _options.IconSet);
+
+			if (_options.SubgridEnabled.HasValue)
+			{
+				javaScriptBuilder.AppendFormat("subGrid: {0},", _options.SubgridEnabled.Value.ToString().ToLower()).AppendLine();
+
+				if (_options.SubgridColumnWidth.HasValue)
+					javaScriptBuilder.AppendFormat("subGridWidth: {0},", _options.SubgridColumnWidth.Value).AppendLine();
+
+				if (_options.IsSubGridBeforeExpandSetted)
+					javaScriptBuilder.AppendFormat("subGridBeforeExpand: {0},", _options.SubGridBeforeExpand.ToNullString()).AppendLine();
+
+				if (_subgridHelper != null)
+				{
+					var subgridHelperType = _subgridHelper.GetType();
+					javaScriptBuilder.AppendFormat("subGridRowExpanded: {0},", subgridHelperType.GetMethod("GetSubGridRowExpanded", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).Invoke(_subgridHelper, null)).AppendLine();
+				}
+				else
+				{
+					AppendSubgridModel(javaScriptBuilder);
+
+					if (_options.IsSubgridUrlSetted)
+						javaScriptBuilder.AppendFormat("subGridUrl: '{0}',", _options.SubgridUrl.ToNullString()).AppendLine();
+
+
+					if (_options.IsSubGridRowExpandedSetted)
+						javaScriptBuilder.AppendFormat("subGridRowExpanded: {0},", _options.SubGridRowExpanded.ToNullString()).AppendLine();
+				}
+
+				if (_options.IsSubGridRowColapsedSetted)
+					javaScriptBuilder.AppendFormat("subGridRowColapsed: {0},", _options.SubGridRowColapsed.ToNullString()).AppendLine();
+			}
+
+			if (_options.TopPager.HasValue)
+				javaScriptBuilder.AppendFormat("toppager: {0},", _options.TopPager.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.TreeGridEnabled.HasValue)
+			{
+				javaScriptBuilder.AppendFormat("treeGrid: {0},", _options.TreeGridEnabled.Value.ToString().ToLower()).AppendLine();
+				if (_options.TreeGridEnabled.Value)
+				{
+
+					if (_options.ExpandColumnClick.HasValue)
+						javaScriptBuilder.AppendFormat("ExpandColClick: {0},", _options.ExpandColumnClick.Value.ToString().ToLower()).AppendLine();
+
+					if (_options.IsExpandColumnSetted)
+						javaScriptBuilder.AppendFormat("ExpandColumn: '{0}',", _options.ExpandColumn.ToNullString()).AppendLine();
+
+					if (_options.TreeGridModel != JqGridTreeGridModels.Default)
+						javaScriptBuilder.AppendFormat("treeGridModel: '{0}',", _options.TreeGridModel.ToString().ToLower()).AppendLine();
+				}
+			}
+
+			if (_options.ViewRecords.HasValue)
+				javaScriptBuilder.AppendFormat("viewrecords: {0},", _options.ViewRecords.Value.ToString().ToLower()).AppendLine();
+
+			if (_options.Width.HasValue)
+				javaScriptBuilder.AppendFormat("width: {0},", _options.Width.Value).AppendLine();
+
+			if (_options.Height.HasValue)
+				javaScriptBuilder.AppendFormat("height: {0}", _options.Height.Value).AppendLine();
+			else
+				javaScriptBuilder.AppendLine("height: '100%'");
+		}
+
+		private void AppendJsonReader(StringBuilder javaScriptBuilder)
+		{
+			if (_options.JsonReader == null || _options.JsonReader.IsGlobal) return;
+			javaScriptBuilder.Append("jsonReader: { ");
+
+			if (_options.JsonReader.Records != JqGridResponse.JsonReader.Records)
+				javaScriptBuilder.AppendFormat("root: '{0}', ", _options.JsonReader.Records);
+
+			if (_options.JsonReader.PageIndex != JqGridResponse.JsonReader.PageIndex)
+				javaScriptBuilder.AppendFormat("page: '{0}', ", _options.JsonReader.PageIndex);
+
+			if (_options.JsonReader.TotalPagesCount != JqGridResponse.JsonReader.TotalPagesCount)
+				javaScriptBuilder.AppendFormat("total: '{0}', ", _options.JsonReader.TotalPagesCount);
+
+			if (_options.JsonReader.TotalRecordsCount != JqGridResponse.JsonReader.TotalRecordsCount)
+				javaScriptBuilder.AppendFormat("records: '{0}', ", _options.JsonReader.TotalRecordsCount);
+
+			if (_options.JsonReader.RepeatItems != JqGridResponse.JsonReader.RepeatItems)
+				javaScriptBuilder.AppendFormat("repeatitems: {0}, ", _options.JsonReader.RepeatItems.ToString().ToLower());
+
+			if (_options.JsonReader.RecordValues != JqGridOptionsDefaults.ResponseRecordValues)
+				javaScriptBuilder.AppendFormat("cell: '{0}', ", _options.JsonReader.RecordValues);
+
+			if (_options.JsonReader.RecordId != JqGridResponse.JsonReader.RecordId)
+				javaScriptBuilder.AppendFormat("id: '{0}', ", _options.JsonReader.RecordId);
+
+			if (_options.JsonReader.UserData != JqGridResponse.JsonReader.UserData)
+				javaScriptBuilder.AppendFormat("userdata: '{0}', ", _options.JsonReader.UserData);
+
+			if (!_options.JsonReader.SubgridReader.IsGlobal)
+			{
+				javaScriptBuilder.Append("subgrid: { ");
+
+				if (_options.JsonReader.SubgridReader.Records != JqGridResponse.JsonReader.SubgridReader.Records)
+					javaScriptBuilder.AppendFormat("root: '{0}', ", _options.JsonReader.SubgridReader.Records);
+
+				if (_options.JsonReader.SubgridReader.RepeatItems != JqGridResponse.JsonReader.SubgridReader.RepeatItems)
+					javaScriptBuilder.AppendFormat("repeatitems: {0}, ", _options.JsonReader.SubgridReader.RepeatItems.ToString().ToLower());
+
+				if (_options.JsonReader.SubgridReader.RecordValues != JqGridResponse.JsonReader.SubgridReader.RecordValues)
+					javaScriptBuilder.AppendFormat("cell: '{0}', ", _options.JsonReader.SubgridReader.RecordValues);
+
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" }, ");
+			}
+
+			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+			javaScriptBuilder.Append(" }, ").AppendLine();
+		}
+
+		private void AppendParametersNames(StringBuilder javaScriptBuilder)
+		{
+			if (_options.ParametersNames == null || _options.ParametersNames.IsGlobal) return;
+			javaScriptBuilder.Append("prmNames: { ");
+
+			if (_options.ParametersNames.PageIndex != JqGridRequest.ParameterNames.PageIndex)
+				javaScriptBuilder.AppendFormat("page: '{0}', ", _options.ParametersNames.PageIndex);
+
+			if (_options.ParametersNames.RecordsCount != JqGridRequest.ParameterNames.RecordsCount)
+				javaScriptBuilder.AppendFormat("rows: '{0}', ", _options.ParametersNames.RecordsCount);
+
+			if (_options.ParametersNames.SortingName != JqGridRequest.ParameterNames.SortingName)
+				javaScriptBuilder.AppendFormat("sort: '{0}', ", _options.ParametersNames.SortingName);
+
+			if (_options.ParametersNames.SortingOrder != JqGridRequest.ParameterNames.SortingOrder)
+				javaScriptBuilder.AppendFormat("order: '{0}', ", _options.ParametersNames.SortingOrder);
+
+			if (_options.ParametersNames.Searching != JqGridRequest.ParameterNames.Searching)
+				javaScriptBuilder.AppendFormat("search: '{0}', ", _options.ParametersNames.Searching);
+
+			if (_options.ParametersNames.Id != JqGridRequest.ParameterNames.Id)
+				javaScriptBuilder.AppendFormat("id: '{0}', ", _options.ParametersNames.Id);
+
+			if (_options.ParametersNames.Operator != JqGridRequest.ParameterNames.Operator)
+				javaScriptBuilder.AppendFormat("oper: '{0}', ", _options.ParametersNames.Operator);
+
+			if (_options.ParametersNames.EditOperator != JqGridRequest.ParameterNames.EditOperator)
+				javaScriptBuilder.AppendFormat("editoper: '{0}', ", _options.ParametersNames.EditOperator);
+
+			if (_options.ParametersNames.AddOperator != JqGridRequest.ParameterNames.AddOperator)
+				javaScriptBuilder.AppendFormat("addoper: '{0}', ", _options.ParametersNames.AddOperator);
+
+			if (_options.ParametersNames.DeleteOperator != JqGridRequest.ParameterNames.DeleteOperator)
+				javaScriptBuilder.AppendFormat("deloper: '{0}', ", _options.ParametersNames.DeleteOperator);
+
+			if (_options.ParametersNames.SubgridId != JqGridRequest.ParameterNames.SubgridId)
+				javaScriptBuilder.AppendFormat("subgridid: '{0}', ", _options.ParametersNames.SubgridId);
+
+			if (_options.ParametersNames.PagesCount != JqGridRequest.ParameterNames.PagesCount)
+				javaScriptBuilder.AppendFormat("npage: '{0}', ", _options.ParametersNames.PagesCount);
+
+			if (_options.ParametersNames.TotalRows != JqGridRequest.ParameterNames.TotalRows)
+				javaScriptBuilder.AppendFormat("totalrows: '{0}', ", _options.ParametersNames.TotalRows);
+
+			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+			javaScriptBuilder.Append(" }, ").AppendLine();
+		}
+
+		private void AppendGroupingView(StringBuilder javaScriptBuilder)
+		{
+			if (_options.GroupingView == null) return;
+			javaScriptBuilder.Append("groupingView: { ");
+
+			if (_options.GroupingView.Fields != null && _options.GroupingView.Fields.Length > 0)
+			{
+				javaScriptBuilder.Append("groupField: [");
+				foreach (var field in _options.GroupingView.Fields)
+					javaScriptBuilder.AppendFormat("'{0}', ", field);
+				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+			}
+
+			if (_options.GroupingView.Orders != null && _options.GroupingView.Orders.Length > 0 && _options.GroupingView.Orders.Contains(JqGridSortingOrders.Desc))
+			{
+				javaScriptBuilder.Append("groupOrder: [");
+				foreach (var order in _options.GroupingView.Orders)
+					javaScriptBuilder.AppendFormat("'{0}', ", order.ToString().ToLower());
+				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+			}
+
+			if (_options.GroupingView.Texts != null && _options.GroupingView.Texts.Length > 0)
+			{
+				javaScriptBuilder.Append("groupText: [");
+				foreach (var text in _options.GroupingView.Texts)
+					javaScriptBuilder.AppendFormat("'{0}', ", text);
+				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+			}
+
+			if (_options.GroupingView.Summary != null && _options.GroupingView.Summary.Length > 0 && _options.GroupingView.Summary.Contains(true))
+			{
+				javaScriptBuilder.Append("groupSummary: [");
+				foreach (var summary in _options.GroupingView.Summary)
+					javaScriptBuilder.AppendFormat("{0}, ", summary.ToString().ToLower());
+				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+			}
+
+			if (_options.GroupingView.ColumnShow != null && _options.GroupingView.ColumnShow.Length > 0 && _options.GroupingView.ColumnShow.Contains(false))
+			{
+				javaScriptBuilder.Append("groupColumnShow: [");
+				foreach (var columnShow in _options.GroupingView.ColumnShow)
+					javaScriptBuilder.AppendFormat("{0}, ", columnShow.ToString().ToLower());
+				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+			}
+
+			if (_options.GroupingView.IsInTheSameGroupCallbacks != null && _options.GroupingView.IsInTheSameGroupCallbacks.Length > 0)
+			{
+				javaScriptBuilder.Append("isInTheSameGroup: [");
+				foreach (var isInTheSameGroupCallback in _options.GroupingView.IsInTheSameGroupCallbacks)
+					javaScriptBuilder.AppendFormat("{0}, ", isInTheSameGroupCallback);
+				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+			}
+
+			if (_options.GroupingView.FormatDisplayFieldCallbacks != null && _options.GroupingView.FormatDisplayFieldCallbacks.Length > 0)
+			{
+				javaScriptBuilder.Append("formatDisplayField: [");
+				foreach (var formatDisplayFieldCallback in _options.GroupingView.FormatDisplayFieldCallbacks)
+					javaScriptBuilder.AppendFormat("{0}, ", formatDisplayFieldCallback);
+				javaScriptBuilder.Insert(javaScriptBuilder.Length - 2, ']');
+			}
+
+			if (_options.GroupingView.SummaryOnHide)
+				javaScriptBuilder.Append("showSummaryOnHide: true, ");
+
+			if (_options.GroupingView.DataSorted)
+				javaScriptBuilder.Append("groupDataSorted: true, ");
+
+			if (_options.GroupingView.Collapse)
+				javaScriptBuilder.Append("groupCollapse: true, ");
+
+			if (_options.GroupingView.PlusIcon != JqGridOptionsDefaults.GroupingPlusIcon)
+				javaScriptBuilder.AppendFormat("plusicon: '{0}', ", _options.GroupingView.PlusIcon);
+
+			if (_options.GroupingView.MinusIcon != JqGridOptionsDefaults.GroupingMinusIcon)
+				javaScriptBuilder.AppendFormat("minusicon: '{0}', ", _options.GroupingView.MinusIcon);
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" }, ").AppendLine();
+			}
+			else
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 16, 16);
+		}
+
+		private void AppendSubgridModel(StringBuilder javaScriptBuilder)
+		{
+			if (_options.SubgridModel == null) return;
+			javaScriptBuilder.AppendLine("subGridModel: [{ ");
+
+			javaScriptBuilder.Append("name: [");
+			foreach (var columnName in _options.SubgridModel.ColumnsNames)
+				javaScriptBuilder.AppendFormat("'{0}',", columnName);
+			if (_options.SubgridModel.ColumnsNames.Any())
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+			javaScriptBuilder.AppendLine("],");
+
+			javaScriptBuilder.Append("align: [");
+			foreach (var alignments in _options.SubgridModel.ColumnsAlignments)
+			{
+				var align = alignments == JqGridAlignments.Default ? JqGridAlignments.Left : alignments;
+				javaScriptBuilder.AppendFormat("'{0}',", align.ToString().ToLower());
+			}
+
+			if (_options.SubgridModel.ColumnsAlignments.Any())
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+			javaScriptBuilder.AppendLine("],");
+
+			javaScriptBuilder.Append("width: [");
+			foreach (var width in _options.SubgridModel.ColumnsWidths)
+				javaScriptBuilder.AppendFormat("{0},", width);
+			if (_options.SubgridModel.ColumnsWidths.Any())
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+			javaScriptBuilder.AppendLine("]");
+
+			javaScriptBuilder.AppendLine(" }],");
+		}
+
+		private void AppendNavigator(StringBuilder javaScriptBuilder)
+		{
+			var navigatorPagerSelector = _navigatorOptions.Pager == JqGridNavigatorPagers.Top ? TopPagerSelector : PagerSelector;
+			javaScriptBuilder.AppendFormat(".jqGrid('navGrid', {0},", navigatorPagerSelector).AppendLine();
+			AppendNavigatorOptions(javaScriptBuilder);
+
+			if (_navigatorEditActionOptions != null || _navigatorAddActionOptions != null || _navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
+			{
+				javaScriptBuilder.AppendLine(",");
+				AppendNavigatorActionOptions(string.Empty, _navigatorEditActionOptions, javaScriptBuilder);
+				if (_navigatorAddActionOptions != null || _navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
+				{
+					javaScriptBuilder.AppendLine(",");
+					AppendNavigatorActionOptions(string.Empty, _navigatorAddActionOptions, javaScriptBuilder);
+					if (_navigatorDeleteActionOptions != null || _navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
+					{
+						javaScriptBuilder.AppendLine(",");
+						AppendNavigatorActionOptions(string.Empty, _navigatorDeleteActionOptions, javaScriptBuilder);
+						if (_navigatorSearchActionOptions != null || _navigatorViewActionOptions != null)
+						{
+							javaScriptBuilder.AppendLine(",");
+							AppendNavigatorActionOptions(string.Empty, _navigatorSearchActionOptions, javaScriptBuilder);
+							if (_navigatorViewActionOptions != null)
+							{
+								javaScriptBuilder.AppendLine(",");
+								AppendNavigatorActionOptions(string.Empty, _navigatorViewActionOptions, javaScriptBuilder);
+							}
+						}
+					}
+				}
+			}
+
+			javaScriptBuilder.Append(")");
+
+			foreach (var controlOptions in _navigatorControlsOptions)
+			{
+				if (controlOptions is JqGridNavigatorButtonOptions buttonOptions)
+				{
+					AppendNavigatorButton(navigatorPagerSelector, buttonOptions, javaScriptBuilder);
+					if (_navigatorOptions.Pager == JqGridNavigatorPagers.Standard && controlOptions.CloneToTop)
+						AppendNavigatorButton(TopPagerSelector, buttonOptions, javaScriptBuilder);
+				}
+				else if (controlOptions is JqGridNavigatorSeparatorOptions separatorOptions)
+				{
+					AppendNavigatorSeparator(navigatorPagerSelector, separatorOptions, javaScriptBuilder);
+					if (_navigatorOptions.Pager == JqGridNavigatorPagers.Standard && controlOptions.CloneToTop)
+						AppendNavigatorSeparator(TopPagerSelector, separatorOptions, javaScriptBuilder);
+				}
+			}
+		}
+
+		private static void AppendBaseNavigatorOptions(JqGridNavigatorOptionsBase baseNavigatorOptions, StringBuilder javaScriptBuilder)
+		{
+			if (!baseNavigatorOptions.Add)
+				javaScriptBuilder.Append("add: false, ");
+
+			if (baseNavigatorOptions.AddIcon != JqGridNavigatorDefaults.AddIcon)
+				javaScriptBuilder.AppendFormat("addicon: '{0}', ", baseNavigatorOptions.AddIcon);
+
+			if (!string.IsNullOrEmpty(baseNavigatorOptions.AddText))
+				javaScriptBuilder.AppendFormat("addtext: '{0}', ", baseNavigatorOptions.AddText);
+
+			if (baseNavigatorOptions.AddToolTip != JqGridNavigatorDefaults.AddToolTip)
+				javaScriptBuilder.AppendFormat("addtitle: '{0}', ", baseNavigatorOptions.AddToolTip);
+
+			if (!baseNavigatorOptions.Edit)
+				javaScriptBuilder.Append("edit: false, ");
+
+			if (baseNavigatorOptions.EditIcon != JqGridNavigatorDefaults.EditIcon)
+				javaScriptBuilder.AppendFormat("editicon: '{0}', ", baseNavigatorOptions.EditIcon);
+
+			if (!string.IsNullOrEmpty(baseNavigatorOptions.EditText))
+				javaScriptBuilder.AppendFormat("edittext: '{0}', ", baseNavigatorOptions.EditText);
+
+			if (baseNavigatorOptions.EditToolTip != JqGridNavigatorDefaults.EditToolTip)
+				javaScriptBuilder.AppendFormat("edittitle: '{0}', ", baseNavigatorOptions.EditToolTip);
+
+			if (baseNavigatorOptions.Position != JqGridAlignments.Left)
+				javaScriptBuilder.AppendFormat("position: '{0}', ", baseNavigatorOptions.Position.ToString().ToLower());
+		}
+
+		private void AppendNavigatorOptions(StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.Append("{ ");
+
+			AppendBaseNavigatorOptions(_navigatorOptions, javaScriptBuilder);
+
+			if (_navigatorOptions.AlertCaption != JqGridNavigatorDefaults.AlertCaption)
+				javaScriptBuilder.AppendFormat("alertcap: '{0}', ", _navigatorOptions.AlertCaption);
+
+			if (_navigatorOptions.AlertText != JqGridNavigatorDefaults.AlertText)
+				javaScriptBuilder.AppendFormat("alerttext: '{0}', ", _navigatorOptions.AlertText);
+
+			if (_navigatorOptions.CloneToTop)
+				javaScriptBuilder.Append("cloneToTop: true, ");
+
+			if (!_navigatorOptions.CloseOnEscape)
+				javaScriptBuilder.Append("closeOnEscape: false, ");
+
+			if (!_navigatorOptions.Delete)
+				javaScriptBuilder.Append("del: false, ");
+
+			if (_navigatorOptions.DeleteIcon != JqGridNavigatorDefaults.DeleteIcon)
+				javaScriptBuilder.AppendFormat("delicon: '{0}', ", _navigatorOptions.DeleteIcon);
+
+			if (!string.IsNullOrEmpty(_navigatorOptions.DeleteText))
+				javaScriptBuilder.AppendFormat("deltext: '{0}', ", _navigatorOptions.DeleteText);
+
+			if (_navigatorOptions.DeleteToolTip != JqGridNavigatorDefaults.DeleteToolTip)
+				javaScriptBuilder.AppendFormat("deltitle: '{0}', ", _navigatorOptions.DeleteToolTip);
+
+			if (!_navigatorOptions.Refresh)
+				javaScriptBuilder.Append("refresh: false, ");
+
+			if (_navigatorOptions.RefreshIcon != JqGridNavigatorDefaults.RefreshIcon)
+				javaScriptBuilder.AppendFormat("refreshicon: '{0}', ", _navigatorOptions.RefreshIcon);
+
+			if (!string.IsNullOrEmpty(_navigatorOptions.RefreshText))
+				javaScriptBuilder.AppendFormat("refreshtext: '{0}', ", _navigatorOptions.RefreshText);
+
+			if (_navigatorOptions.RefreshToolTip != JqGridNavigatorDefaults.RefreshToolTip)
+				javaScriptBuilder.AppendFormat("refreshtitle: '{0}', ", _navigatorOptions.RefreshToolTip);
+
+			if (_navigatorOptions.RefreshMode != JqGridRefreshModes.FirstPage)
+				javaScriptBuilder.Append("refreshstate: 'current', ");
+
+			if (!string.IsNullOrWhiteSpace(_navigatorOptions.AfterRefresh))
+				javaScriptBuilder.AppendFormat("afterRefresh: {0}, ", _navigatorOptions.AfterRefresh);
+
+			if (!string.IsNullOrWhiteSpace(_navigatorOptions.BeforeRefresh))
+				javaScriptBuilder.AppendFormat("beforeRefresh: {0}, ", _navigatorOptions.BeforeRefresh);
+
+			if (!_navigatorOptions.Search)
+				javaScriptBuilder.Append("search: false, ");
+
+			if (_navigatorOptions.SearchIcon != JqGridNavigatorDefaults.SearchIcon)
+				javaScriptBuilder.AppendFormat("searchicon: '{0}', ", _navigatorOptions.SearchIcon);
+
+			if (!string.IsNullOrEmpty(_navigatorOptions.SearchText))
+				javaScriptBuilder.AppendFormat("searchtext: '{0}', ", _navigatorOptions.SearchText);
+
+			if (_navigatorOptions.SearchToolTip != JqGridNavigatorDefaults.SearchToolTip)
+				javaScriptBuilder.AppendFormat("searchtitle: '{0}', ", _navigatorOptions.SearchToolTip);
+
+			if (_navigatorOptions.View)
+				javaScriptBuilder.Append("view: true, ");
+
+			if (_navigatorOptions.ViewIcon != JqGridNavigatorDefaults.ViewIcon)
+				javaScriptBuilder.AppendFormat("viewicon: '{0}', ", _navigatorOptions.ViewIcon);
+
+			if (!string.IsNullOrEmpty(_navigatorOptions.ViewText))
+				javaScriptBuilder.AppendFormat("viewtext: '{0}', ", _navigatorOptions.ViewText);
+
+			if (_navigatorOptions.ViewToolTip != JqGridNavigatorDefaults.ViewToolTip)
+				javaScriptBuilder.AppendFormat("viewtitle: '{0}', ", _navigatorOptions.ViewToolTip);
+
+			if (!string.IsNullOrWhiteSpace(_navigatorOptions.AddFunction))
+				javaScriptBuilder.AppendFormat("addfunc: {0}, ", _navigatorOptions.AddFunction);
+
+			if (!string.IsNullOrWhiteSpace(_navigatorOptions.EditFunction))
+				javaScriptBuilder.AppendFormat("editfunc: {0}, ", _navigatorOptions.EditFunction);
+
+			if (!string.IsNullOrWhiteSpace(_navigatorOptions.DeleteFunction))
+				javaScriptBuilder.AppendFormat("delfunc: {0}, ", _navigatorOptions.DeleteFunction);
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" }");
+			}
+			else
+				javaScriptBuilder.Append("}");
+		}
+
+		private static void AppendNavigatorActionOptions(string optionsName, JqGridNavigatorActionOptions actionOptions, StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.AppendFormat("{0}{{ ", optionsName);
+
+			if (actionOptions != null)
+			{
+				if (actionOptions.Left != 0)
+					javaScriptBuilder.AppendFormat("left: {0}, ", actionOptions.Left);
+
+				if (actionOptions.Top != 0)
+					javaScriptBuilder.AppendFormat("top: {0}, ", actionOptions.Top);
+
+				if (actionOptions.DataWidth.HasValue)
+					javaScriptBuilder.AppendFormat("datawidth: {0}, ", actionOptions.DataWidth.Value);
+
+				if (actionOptions.Height.HasValue)
+					javaScriptBuilder.AppendFormat("height: {0}, ", actionOptions.Height.Value);
+
+				if (actionOptions.DataHeight.HasValue)
+					javaScriptBuilder.AppendFormat("dataheight: {0}, ", actionOptions.DataHeight.Value);
+
+				if (actionOptions.Modal)
+					javaScriptBuilder.Append("modal: true, ");
+
+				if (!actionOptions.Dragable)
+					javaScriptBuilder.Append("drag: false, ");
+
+				if (!actionOptions.Resizable)
+					javaScriptBuilder.Append("resize: false, ");
+
+				if (!actionOptions.UseJqModal)
+					javaScriptBuilder.Append("jqModal: false, ");
+
+				if (actionOptions.CloseOnEscape)
+					javaScriptBuilder.Append("closeOnEscape: true, ");
+
+				if (actionOptions.Overlay != 30)
+					javaScriptBuilder.AppendFormat("overlay: {0}, ", actionOptions.Overlay);
+
+				if (!string.IsNullOrWhiteSpace(actionOptions.OnClose))
+					javaScriptBuilder.AppendFormat("onClose: {0}, ", actionOptions.OnClose);
+
+				JqGridNavigatorFormActionOptions formActionOptions = actionOptions as JqGridNavigatorFormActionOptions;
+				if (formActionOptions != null)
+				{
+					AppendNavigatorFormActionOptions(formActionOptions, javaScriptBuilder);
+
+					IJqGridNavigatorPageableFormActionOptions pageableFormActionOptions = formActionOptions as IJqGridNavigatorPageableFormActionOptions;
+					if (pageableFormActionOptions != null)
+						AppendNavigatorPageableFormActionOptions(pageableFormActionOptions, javaScriptBuilder);
+
+					JqGridNavigatorModifyActionOptions modifyActionOptions = formActionOptions as JqGridNavigatorModifyActionOptions;
+					if (modifyActionOptions != null)
+					{
+						AppendNavigatorModifyActionOptions(modifyActionOptions, javaScriptBuilder);
+						JqGridNavigatorEditActionOptions editActionOptions = modifyActionOptions as JqGridNavigatorEditActionOptions;
+						if (editActionOptions != null)
+							AppendNavigatorEditActionOptions(editActionOptions, javaScriptBuilder);
+						else
+							AppendNavigatorDeleteActionOptions(modifyActionOptions as JqGridNavigatorDeleteActionOptions, javaScriptBuilder);
+					}
+					else
+						AppendNavigatorViewActionOptions(formActionOptions as JqGridNavigatorViewActionOptions, javaScriptBuilder);
+				}
+				else
+					AppendNavigatorSearchActionOptions(actionOptions as JqGridNavigatorSearchActionOptions, javaScriptBuilder);
+
+			}
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				if (!string.IsNullOrEmpty(optionsName))
+					javaScriptBuilder.Append(" }, ");
+				else
+					javaScriptBuilder.Append(" }");
+			}
+			else if (!string.IsNullOrEmpty(optionsName))
+			{
+				int optionsNameLength = optionsName.Length + 2;
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - optionsNameLength, optionsNameLength);
+			}
+			else
+				javaScriptBuilder.Append("}");
+		}
+
+		private static void AppendNavigatorFormActionOptions(JqGridNavigatorFormActionOptions formActionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (!string.IsNullOrWhiteSpace(formActionOptions.BeforeInitData))
+				javaScriptBuilder.AppendFormat("beforeInitData: {0}, ", formActionOptions.BeforeInitData);
+
+			if (!string.IsNullOrWhiteSpace(formActionOptions.BeforeShowForm))
+				javaScriptBuilder.AppendFormat("beforeShowForm: {0}, ", formActionOptions.BeforeShowForm);
+		}
+
+		private static void AppendNavigatorPageableFormActionOptions(IJqGridNavigatorPageableFormActionOptions pageableFormActionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (!pageableFormActionOptions.NavigationKeys.IsDefault())
+				javaScriptBuilder.AppendFormat("navkeys: [{0}, {1}, {2}], ", pageableFormActionOptions.NavigationKeys.Enabled.ToString().ToLower(), (int)pageableFormActionOptions.NavigationKeys.RecordUp, (int)pageableFormActionOptions.NavigationKeys.RecordDown);
+
+			if (!pageableFormActionOptions.ViewPagerButtons)
+				javaScriptBuilder.Append("viewPagerButtons: false, ");
+
+			if (pageableFormActionOptions.RecreateForm)
+				javaScriptBuilder.Append("recreateForm: true, ");
+		}
+
+		private static void AppendNavigatorModifyActionOptions(JqGridNavigatorModifyActionOptions modifyActionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (!string.IsNullOrWhiteSpace(modifyActionOptions.Url))
+				javaScriptBuilder.AppendFormat("url: '{0}', ", modifyActionOptions.Url);
+
+			if (modifyActionOptions.MethodType != JqGridMethodTypes.Post)
+				javaScriptBuilder.Append("mtype: 'GET', ");
+
+			if (!modifyActionOptions.ReloadAfterSubmit)
+				javaScriptBuilder.Append("reloadAfterSubmit: false, ");
+
+			if (!string.IsNullOrWhiteSpace(modifyActionOptions.AfterShowForm))
+				javaScriptBuilder.AppendFormat("afterShowForm: {0}, ", modifyActionOptions.AfterShowForm);
+
+			if (!string.IsNullOrWhiteSpace(modifyActionOptions.AfterSubmit))
+				javaScriptBuilder.AppendFormat("afterSubmit: {0}, ", modifyActionOptions.AfterSubmit);
+
+			if (!string.IsNullOrWhiteSpace(modifyActionOptions.BeforeSubmit))
+				javaScriptBuilder.AppendFormat("beforeSubmit: {0}, ", modifyActionOptions.BeforeSubmit);
+
+			if (!string.IsNullOrWhiteSpace(modifyActionOptions.OnClickSubmit))
+				javaScriptBuilder.AppendFormat("onclickSubmit: {0}, ", modifyActionOptions.OnClickSubmit);
+
+			if (!string.IsNullOrWhiteSpace(modifyActionOptions.ErrorTextFormat))
+				javaScriptBuilder.AppendFormat("errorTextFormat: {0}, ", modifyActionOptions.ErrorTextFormat);
+		}
+
+		private static void AppendNavigatorEditActionOptions(JqGridNavigatorEditActionOptions editActionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (editActionOptions.Width != 300)
+				javaScriptBuilder.AppendFormat("width: {0}, ", editActionOptions.Width);
+
+			JavaScriptSerializer serializer = new JavaScriptSerializer();
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.ExtraDataScript))
+				javaScriptBuilder.AppendFormat("editData: {0},", editActionOptions.ExtraDataScript).AppendLine();
+			else if (editActionOptions.ExtraData != null)
+				javaScriptBuilder.AppendFormat("editData: {0}, ", serializer.Serialize(editActionOptions.ExtraData));
+
+			if (editActionOptions.AjaxOptions != null)
+				javaScriptBuilder.AppendFormat("ajaxEditOptions: {0}, ", serializer.Serialize(editActionOptions.AjaxOptions));
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.SerializeData))
+				javaScriptBuilder.AppendFormat("serializeEditData: {0}, ", editActionOptions.SerializeData);
+
+			if (editActionOptions.AddedRowPosition != JqGridNewRowPositions.First)
+				javaScriptBuilder.Append("addedrow: 'last', ");
+
+			if (!editActionOptions.ClearAfterAdd)
+				javaScriptBuilder.Append("clearAfterAdd: false, ");
+
+			if (editActionOptions.CloseAfterAdd)
+				javaScriptBuilder.Append("closeAfterAdd: true, ");
+
+			if (editActionOptions.CloseAfterEdit)
+				javaScriptBuilder.Append("closeAfterEdit: true, ");
+
+			if (editActionOptions.CheckOnSubmit)
+				javaScriptBuilder.Append("checkOnSubmit: true, ");
+
+			if (editActionOptions.CheckOnUpdate)
+				javaScriptBuilder.Append("checkOnUpdate: true, ");
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.TopInfo))
+				javaScriptBuilder.AppendFormat("topinfo: '{0}', ", editActionOptions.TopInfo);
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.BottomInfo))
+				javaScriptBuilder.AppendFormat("bottominfo: '{0}', ", editActionOptions.BottomInfo);
+
+			if (editActionOptions.SaveKeyEnabled || (editActionOptions.SaveKey != (char)13))
+				javaScriptBuilder.AppendFormat("savekey: [{0}, {1}], ", editActionOptions.SaveKeyEnabled.ToString().ToLower(), (int)editActionOptions.SaveKey);
+
+			if (!editActionOptions.SaveButtonIcon.Equals(JqGridFormButtonIcon.SaveIcon))
+				javaScriptBuilder.AppendFormat("saveicon: [{0}, '{1}', '{2}'], ", editActionOptions.SaveButtonIcon.Enabled.ToString().ToLower(), editActionOptions.SaveButtonIcon.Position.ToString().ToLower(), editActionOptions.SaveButtonIcon.Class);
+
+			if (!editActionOptions.CloseButtonIcon.Equals(JqGridFormButtonIcon.CloseIcon))
+				javaScriptBuilder.AppendFormat("closeicon: [{0}, '{1}', '{2}'], ", editActionOptions.CloseButtonIcon.Enabled.ToString().ToLower(), editActionOptions.CloseButtonIcon.Position.ToString().ToLower(), editActionOptions.CloseButtonIcon.Class);
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.AfterClickPgButtons))
+				javaScriptBuilder.AppendFormat("afterclickPgButtons: {0}, ", editActionOptions.AfterClickPgButtons);
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.AfterComplete))
+				javaScriptBuilder.AppendFormat("afterComplete: {0}, ", editActionOptions.AfterComplete);
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.BeforeCheckValues))
+				javaScriptBuilder.AppendFormat("beforeCheckValues: {0}, ", editActionOptions.BeforeCheckValues);
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.OnClickPgButtons))
+				javaScriptBuilder.AppendFormat("onclickPgButtons: {0}, ", editActionOptions.OnClickPgButtons);
+
+			if (!string.IsNullOrWhiteSpace(editActionOptions.OnInitializeForm))
+				javaScriptBuilder.AppendFormat("onInitializeForm: {0}, ", editActionOptions.OnInitializeForm);
+		}
+
+		private static void AppendNavigatorDeleteActionOptions(JqGridNavigatorDeleteActionOptions deleteActionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (deleteActionOptions.Width != 240)
+				javaScriptBuilder.AppendFormat("width: {0}, ", deleteActionOptions.Width);
+
+			JavaScriptSerializer serializer = new JavaScriptSerializer();
+
+			if (!string.IsNullOrWhiteSpace(deleteActionOptions.ExtraDataScript))
+				javaScriptBuilder.AppendFormat("delData: {0},", deleteActionOptions.ExtraDataScript).AppendLine();
+			else if (deleteActionOptions.ExtraData != null)
+				javaScriptBuilder.AppendFormat("delData: {0}, ", serializer.Serialize(deleteActionOptions.ExtraData));
+
+			if (deleteActionOptions.AjaxOptions != null)
+				javaScriptBuilder.AppendFormat("ajaxDelOptions: {0}, ", serializer.Serialize(deleteActionOptions.AjaxOptions));
+
+			if (!string.IsNullOrWhiteSpace(deleteActionOptions.SerializeData))
+				javaScriptBuilder.AppendFormat("serializeDelData: {0}, ", deleteActionOptions.SerializeData);
+
+			if (!deleteActionOptions.DeleteButtonIcon.Equals(JqGridFormButtonIcon.DeleteIcon))
+				javaScriptBuilder.AppendFormat("delicon: [{0}, '{1}', '{2}'], ", deleteActionOptions.DeleteButtonIcon.Enabled.ToString().ToLower(), deleteActionOptions.DeleteButtonIcon.Position.ToString().ToLower(), deleteActionOptions.DeleteButtonIcon.Class);
+
+			if (!deleteActionOptions.CancelButtonIcon.Equals(JqGridFormButtonIcon.CancelIcon))
+				javaScriptBuilder.AppendFormat("cancelicon: [{0}, '{1}', '{2}'], ", deleteActionOptions.CancelButtonIcon.Enabled.ToString().ToLower(), deleteActionOptions.CancelButtonIcon.Position.ToString().ToLower(), deleteActionOptions.CancelButtonIcon.Class);
+		}
+
+		private static void AppendNavigatorViewActionOptions(JqGridNavigatorViewActionOptions viewActionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (viewActionOptions.Width != 0)
+				javaScriptBuilder.AppendFormat("width: {0}, ", viewActionOptions.Width);
+
+			if (viewActionOptions.LabelsWidth != "30%")
+				javaScriptBuilder.AppendFormat("labelswidth: '{0}', ", viewActionOptions.LabelsWidth);
+
+			if (!viewActionOptions.CloseButtonIcon.Equals(JqGridFormButtonIcon.CloseIcon))
+				javaScriptBuilder.AppendFormat("closeicon: [{0}, '{1}', '{2}'], ", viewActionOptions.CloseButtonIcon.Enabled.ToString().ToLower(), viewActionOptions.CloseButtonIcon.Position.ToString().ToLower(), viewActionOptions.CloseButtonIcon.Class);
+		}
+
+		private static void AppendNavigatorSearchActionOptions(JqGridNavigatorSearchActionOptions searchActionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (searchActionOptions.Width != 450)
+				javaScriptBuilder.AppendFormat("width: {0}, ", searchActionOptions.Width);
+
+			if (!string.IsNullOrWhiteSpace(searchActionOptions.AfterRedraw))
+				javaScriptBuilder.AppendFormat("afterRedraw: {0}, ", searchActionOptions.AfterRedraw);
+
+			if (!string.IsNullOrWhiteSpace(searchActionOptions.AfterShowSearch))
+				javaScriptBuilder.AppendFormat("afterShowSearch: {0}, ", searchActionOptions.AfterShowSearch);
+
+			if (!string.IsNullOrWhiteSpace(searchActionOptions.BeforeShowSearch))
+				javaScriptBuilder.AppendFormat("beforeShowSearch: {0}, ", searchActionOptions.BeforeShowSearch);
+
+			if (!string.IsNullOrEmpty(searchActionOptions.Caption))
+				javaScriptBuilder.AppendFormat("caption: '{0}', ", searchActionOptions.Caption);
+
+			if (searchActionOptions.CloseAfterSearch)
+				javaScriptBuilder.Append("closeAfterSearch: true, ");
+
+			if (searchActionOptions.CloseAfterReset)
+				javaScriptBuilder.Append("closeAfterReset: true, ");
+
+			if (!searchActionOptions.ErrorCheck)
+				javaScriptBuilder.Append("errorcheck: false, ");
+
+			if (!string.IsNullOrEmpty(searchActionOptions.SearchText))
+				javaScriptBuilder.AppendFormat("Find: '{0}', ", searchActionOptions.SearchText);
+
+			if (searchActionOptions.AdvancedSearching)
+				javaScriptBuilder.Append("multipleSearch: true, ");
+
+			if (searchActionOptions.AdvancedSearchingWithGroups)
+				javaScriptBuilder.Append("multipleGroup: true, ");
+
+			if (!searchActionOptions.CloneSearchRowOnAdd)
+				javaScriptBuilder.Append("cloneSearchRowOnAdd: false, ");
+
+			if (!string.IsNullOrWhiteSpace(searchActionOptions.OnInitializeSearch))
+				javaScriptBuilder.AppendFormat("onInitializeSearch: {0}, ", searchActionOptions.OnInitializeSearch);
+
+			if (!string.IsNullOrWhiteSpace(searchActionOptions.OnReset))
+				javaScriptBuilder.AppendFormat("onReset: {0}, ", searchActionOptions.OnReset);
+
+			if (!string.IsNullOrWhiteSpace(searchActionOptions.OnSearch))
+				javaScriptBuilder.AppendFormat("onSearch: {0}, ", searchActionOptions.OnSearch);
+
+			if (searchActionOptions.RecreateFilter)
+				javaScriptBuilder.Append("recreateFilter: true, ");
+
+			if (!string.IsNullOrEmpty(searchActionOptions.ResetText))
+				javaScriptBuilder.AppendFormat("Reset: '{0}', ", searchActionOptions.ResetText);
+
+			AppendSearchOperators(searchActionOptions.SearchOperators, javaScriptBuilder);
+
+			if (searchActionOptions.ShowOnLoad)
+				javaScriptBuilder.Append("showOnLoad: true, ");
+
+			if (searchActionOptions.ShowQuery)
+				javaScriptBuilder.Append("showQuery: true, ");
+
+			if (!string.IsNullOrEmpty(searchActionOptions.Layer))
+				javaScriptBuilder.AppendFormat("layer: '{0}', ", searchActionOptions.Layer);
+
+			if (searchActionOptions.Templates != null && searchActionOptions.Templates.Count > 0)
+			{
+				JavaScriptSerializer serializer = new JavaScriptSerializer();
+				serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
+
+				javaScriptBuilder.Append("tmplNames: [],");
+				int templateNameIndex = javaScriptBuilder.Length - 2;
+				javaScriptBuilder.Append("tmplFilters: [");
+				foreach (KeyValuePair<string, JqGridRequestSearchingFilters> template in searchActionOptions.Templates)
+				{
+					javaScriptBuilder.Insert(templateNameIndex, "'" + template.Key + "', ");
+					templateNameIndex += template.Key.Length + 4;
+					javaScriptBuilder.Append(serializer.Serialize(template.Value) + ", ");
+				}
+				javaScriptBuilder.Remove(templateNameIndex - 2, 2);
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append("],");
+			}
+		}
+
+		private void AppendNavigatorButton(string navigatorPagerSelector, JqGridNavigatorButtonOptions buttonOptions, StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.AppendFormat(".jqGrid('navButtonAdd', {0}, {{ ", navigatorPagerSelector);
+			if (buttonOptions.Caption != JqGridNavigatorDefaults.ButtonCaption)
+				javaScriptBuilder.AppendFormat("caption: '{0}', ", buttonOptions.Caption);
+
+			if (buttonOptions.Icon != JqGridNavigatorDefaults.ButtonIcon)
+				javaScriptBuilder.AppendFormat("buttonicon: '{0}', ", buttonOptions.Icon);
+
+			if (!string.IsNullOrWhiteSpace(buttonOptions.OnClick))
+				javaScriptBuilder.AppendFormat("onClickButton: {0}, ", buttonOptions.OnClick);
+
+			if (buttonOptions.Position != JqGridNavigatorButtonPositions.Last)
+				javaScriptBuilder.Append("position: 'first', ");
+
+			if (!string.IsNullOrEmpty(buttonOptions.ToolTip))
+				javaScriptBuilder.AppendFormat("title: '{0}', ", buttonOptions.ToolTip);
+
+			if (buttonOptions.Cursor != JqGridNavigatorDefaults.ButtonCursor)
+				javaScriptBuilder.AppendFormat("cursor: '{0}', ", buttonOptions.Cursor);
+
+			if (!string.IsNullOrWhiteSpace(buttonOptions.Id))
+				javaScriptBuilder.AppendFormat("id: '{0}', ", buttonOptions.Id);
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" })");
+			}
+			else
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 4, 4);
+				javaScriptBuilder.Append(")");
+			}
+		}
+
+		private void AppendNavigatorSeparator(string navigatorPagerSelector, JqGridNavigatorSeparatorOptions separatorOptions, StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.AppendFormat(".jqGrid('navSeparatorAdd', {0}, {{ ", navigatorPagerSelector);
+
+			if (separatorOptions.Class != JqGridNavigatorDefaults.SeparatorClass)
+				javaScriptBuilder.AppendFormat("sepclass: '{0}', ", separatorOptions.Class);
+
+			if (!string.IsNullOrEmpty(separatorOptions.Content))
+				javaScriptBuilder.AppendFormat("sepcontent: '{0}', ", separatorOptions.Content);
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" })");
+			}
+			else
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 4, 4);
+				javaScriptBuilder.Append(")");
+			}
+		}
+
+		private void AppendInlineNavigator(StringBuilder javaScriptBuilder)
+		{
+			string navigatorPagerSelector = _navigatorOptions.Pager == JqGridNavigatorPagers.Top ? TopPagerSelector : PagerSelector;
+
+			javaScriptBuilder.AppendFormat(".jqGrid('inlineNav', {0}, ", navigatorPagerSelector).AppendLine();
+
+			AppendInlineNavigatorOptions(javaScriptBuilder);
+
+			javaScriptBuilder.Append(")");
+		}
+
+		private void AppendInlineNavigatorOptions(StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.Append("{ ");
+
+			AppendBaseNavigatorOptions(_inlineNavigatorOptions, javaScriptBuilder);
+
+			if (!_inlineNavigatorOptions.Save)
+				javaScriptBuilder.Append("save: false, ");
+
+			if (_inlineNavigatorOptions.SaveIcon != JqGridNavigatorDefaults.SaveIcon)
+				javaScriptBuilder.AppendFormat("saveicon: '{0}', ", _inlineNavigatorOptions.SaveIcon);
+
+			if (!string.IsNullOrEmpty(_inlineNavigatorOptions.SaveText))
+				javaScriptBuilder.AppendFormat("savetext: '{0}', ", _inlineNavigatorOptions.SaveText);
+
+			if (_inlineNavigatorOptions.SaveToolTip != JqGridNavigatorDefaults.SaveToolTip)
+				javaScriptBuilder.AppendFormat("savetitle: '{0}', ", _inlineNavigatorOptions.SaveToolTip);
+
+			if (!_inlineNavigatorOptions.Cancel)
+				javaScriptBuilder.Append("cancel: false, ");
+
+			if (_inlineNavigatorOptions.CancelIcon != JqGridNavigatorDefaults.CancelIcon)
+				javaScriptBuilder.AppendFormat("cancelicon: '{0}', ", _inlineNavigatorOptions.CancelIcon);
+
+			if (!string.IsNullOrEmpty(_inlineNavigatorOptions.CancelText))
+				javaScriptBuilder.AppendFormat("canceltext: '{0}', ", _inlineNavigatorOptions.CancelText);
+
+			if (_inlineNavigatorOptions.CancelToolTip != JqGridNavigatorDefaults.CancelToolTip)
+				javaScriptBuilder.AppendFormat("canceltitle: '{0}', ", _inlineNavigatorOptions.CancelToolTip);
+
+			AppendInlineNavigatorAddActionOptions(_inlineNavigatorOptions.AddActionOptions, javaScriptBuilder);
+			AppendInlineNavigatorActionOptions("editParams", _inlineNavigatorOptions.ActionOptions, javaScriptBuilder);
+
+			if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+			{
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+				javaScriptBuilder.Append(" }");
+			}
+			else
+				javaScriptBuilder.Append("}");
+		}
+
+		private static void AppendInlineNavigatorActionOptions(string actionName, JqGridInlineNavigatorActionOptions actionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (actionOptions != null)
+			{
+				javaScriptBuilder.AppendFormat("{0}: {{ ", actionName);
+
+				if (actionOptions.Keys)
+					javaScriptBuilder.Append("keys: true, ");
+
+				if (!string.IsNullOrWhiteSpace(actionOptions.OnEditFunction))
+					javaScriptBuilder.AppendFormat("oneditfunc: {0}, ", actionOptions.OnEditFunction);
+
+				if (!string.IsNullOrWhiteSpace(actionOptions.SuccessFunction))
+					javaScriptBuilder.AppendFormat("successfunc: {0}, ", actionOptions.SuccessFunction);
+
+				if (!string.IsNullOrWhiteSpace(actionOptions.Url))
+					javaScriptBuilder.AppendFormat("url: '{0}', ", actionOptions.Url);
+
+				if (!string.IsNullOrWhiteSpace(actionOptions.ExtraParamScript))
+					javaScriptBuilder.AppendFormat("extraparam: {0}, ", actionOptions.ExtraParamScript);
+				else if (actionOptions.ExtraParam != null)
+				{
+					JavaScriptSerializer serializer = new JavaScriptSerializer();
+					javaScriptBuilder.AppendFormat("extraparam: {0}, ", serializer.Serialize(actionOptions.ExtraParam));
+				}
+
+				if (!string.IsNullOrWhiteSpace(actionOptions.AfterSaveFunction))
+					javaScriptBuilder.AppendFormat("aftersavefunc: {0}, ", actionOptions.AfterSaveFunction);
+
+				if (!string.IsNullOrWhiteSpace(actionOptions.ErrorFunction))
+					javaScriptBuilder.AppendFormat("errorfunc: {0}, ", actionOptions.ErrorFunction);
+
+				if (!string.IsNullOrWhiteSpace(actionOptions.AfterRestoreFunction))
+					javaScriptBuilder.AppendFormat("afterrestorefunc: {0}, ", actionOptions.AfterRestoreFunction);
+
+				if (!actionOptions.RestoreAfterError)
+					javaScriptBuilder.Append("restoreAfterError: false, ");
+
+				if (actionOptions.MethodType != JqGridMethodTypes.Post)
+					javaScriptBuilder.Append("mtype: 'GET', ");
+
+				if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+				{
+					javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+					javaScriptBuilder.Append(" }, ");
+				}
+				else
+				{
+					int actionNameLength = actionName.Length + 4;
+					javaScriptBuilder.Remove(javaScriptBuilder.Length - actionNameLength, actionNameLength);
+				}
+			}
+		}
+
+		private static void AppendInlineNavigatorAddActionOptions(JqGridInlineNavigatorAddActionOptions actionOptions, StringBuilder javaScriptBuilder)
+		{
+			if (actionOptions != null)
+			{
+				javaScriptBuilder.Append("addParams: { ");
+
+				if (actionOptions.RowId != JqGridNavigatorDefaults.NewRowId)
+					javaScriptBuilder.AppendFormat("rowID: '{0}', ", actionOptions.RowId);
+
+				if (actionOptions.InitData != null)
+				{
+					JavaScriptSerializer serializer = new JavaScriptSerializer();
+					javaScriptBuilder.AppendFormat("initdata: {0}, ", serializer.Serialize(actionOptions.InitData));
+				}
+
+				if (actionOptions.Position != JqGridNewRowPositions.First)
+					javaScriptBuilder.AppendFormat("position: 'last', ");
+
+				if (actionOptions.UseDefaultValues)
+					javaScriptBuilder.Append("useDefValues: true, ");
+
+				if (actionOptions.UseFormatter)
+					javaScriptBuilder.Append("useFormatter: true, ");
+
+				AppendInlineNavigatorActionOptions("addRowParams", actionOptions.Options, javaScriptBuilder);
+
+				if (javaScriptBuilder[javaScriptBuilder.Length - 2] == ',')
+				{
+					javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+					javaScriptBuilder.Append(" }, ");
+				}
+				else
+				{
+					javaScriptBuilder.Remove(javaScriptBuilder.Length - 13, 13);
+				}
+			}
+		}
+
+		private void AppendFilterToolbar(StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.Append(".jqGrid('filterToolbar'");
+
+			if (_filterToolbarOptions != null)
+			{
+				javaScriptBuilder.Append(", { ");
+
+				AppendFilterOptions(_filterToolbarOptions, javaScriptBuilder);
+
+				if (_filterToolbarOptions.DefaultSearchOperator != JqGridSearchOperators.Bw)
+					javaScriptBuilder.AppendFormat("defaultSearch: '{0}',", _filterToolbarOptions.DefaultSearchOperator.ToString().ToLower());
+
+				if (_filterToolbarOptions.GroupingOperator != JqGridSearchGroupingOperators.And)
+					javaScriptBuilder.Append("groupOp: 'OR',");
+
+				if (!_filterToolbarOptions.SearchOnEnter)
+					javaScriptBuilder.Append("searchOnEnter: false,");
+
+				if (_filterToolbarOptions.SearchOperators)
+					javaScriptBuilder.Append("searchOperators: true,");
+
+				if (_filterToolbarOptions.OperandToolTip != JqGridFilterToolbarDefaults.OperandToolTip)
+					javaScriptBuilder.AppendFormat("operandTitle: '{0}',", _filterToolbarOptions.OperandToolTip);
+
+				if (_filterToolbarOptions.Operands != null && _filterToolbarOptions.Operands.Count > 0 && _filterToolbarOptions.Operands != JqGridFilterToolbarDefaults.Operands)
+				{
+					int javaScriptBuilderPosition = javaScriptBuilder.Length;
+
+					foreach (KeyValuePair<JqGridSearchOperators, string> operand in _filterToolbarOptions.Operands)
+					{
+						string defaultShortText;
+						if (JqGridFilterToolbarDefaults.Operands.TryGetValue(operand.Key, out defaultShortText) && operand.Value != defaultShortText)
+							javaScriptBuilder.AppendFormat("'{0}':'{1}',", operand.Key.ToString().ToLower(), operand.Value);
+					}
+
+					if (javaScriptBuilderPosition != javaScriptBuilder.Length)
+					{
+						javaScriptBuilder.Insert(javaScriptBuilderPosition, "operands: {");
+						javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+						javaScriptBuilder.Append("},");
+					}
+				}
+
+				if (_filterToolbarOptions.StringResult)
+					javaScriptBuilder.Append("stringResult: true,");
+
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+				javaScriptBuilder.Append(" }");
+			}
+
+			javaScriptBuilder.Append(")");
+		}
+
+		private void AppendFilterGrid(StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.AppendFormat("$({0}).jqGrid('filterGrid', {1}, {{", FilterGridSelector, GridSelector).AppendLine();
+			javaScriptBuilder.AppendLine("gridModel: false, gridNames: false,");
+
+			javaScriptBuilder.AppendLine("filterModel: [");
+
+			int lastGridModelIndex = _filterGridModel.Count - 1;
+			for (int gridModelIndex = 0; gridModelIndex < _filterGridModel.Count; gridModelIndex++)
+			{
+				JqGridFilterGridRowModel gridRowModel = _filterGridModel[gridModelIndex];
+				javaScriptBuilder.AppendFormat("{{ label: '{0}', name: '{1}', ", gridRowModel.Label, gridRowModel.ColumnName);
+
+				if (!string.IsNullOrWhiteSpace(gridRowModel.DefaultValue))
+					javaScriptBuilder.AppendFormat("defval: '{0}', ", gridRowModel.DefaultValue);
+
+				if (!string.IsNullOrWhiteSpace(gridRowModel.SelectUrl))
+					javaScriptBuilder.AppendFormat("surl: '{0}', ", gridRowModel.SelectUrl);
+
+				javaScriptBuilder.AppendFormat("stype: '{0}' }}", gridRowModel.SearchType.ToString().ToLower());
+
+				if (lastGridModelIndex == gridModelIndex)
+					javaScriptBuilder.AppendLine();
+				else
+					javaScriptBuilder.AppendLine(",");
+			}
+
+			javaScriptBuilder.Append("]");
+
+			if (_filterGridOptions != null)
+			{
+				javaScriptBuilder.AppendLine(",");
+				AppendFilterOptions(_filterGridOptions, javaScriptBuilder);
+
+				if (!string.IsNullOrWhiteSpace(_filterGridOptions.ButtonsClass))
+					javaScriptBuilder.AppendFormat("buttonclass: '{0}',", _filterGridOptions.ButtonsClass);
+
+				if (_filterGridOptions.ClearEnabled.HasValue)
+					javaScriptBuilder.AppendFormat("enableClear: {0},", _filterGridOptions.ClearEnabled.Value.ToString().ToLower());
+
+				if (!string.IsNullOrWhiteSpace(_filterGridOptions.ClearText))
+					javaScriptBuilder.AppendFormat("clearButton: '{0}',", _filterGridOptions.ClearText);
+
+				if (!string.IsNullOrWhiteSpace(_filterGridOptions.FormClass))
+					javaScriptBuilder.AppendFormat("formclass: '{0}',", _filterGridOptions.FormClass);
+
+				if (_filterGridOptions.MarkSearched.HasValue)
+					javaScriptBuilder.AppendFormat("marksearched: {0},", _filterGridOptions.MarkSearched.Value.ToString().ToLower());
+
+				if (_filterGridOptions.SearchEnabled.HasValue)
+					javaScriptBuilder.AppendFormat("enableSearch: {0},", _filterGridOptions.SearchEnabled.Value.ToString().ToLower());
+
+				if (!string.IsNullOrWhiteSpace(_filterGridOptions.SearchText))
+					javaScriptBuilder.AppendFormat("searchButton: '{0}',", _filterGridOptions.SearchText);
+
+				if (!string.IsNullOrWhiteSpace(_filterGridOptions.TableClass))
+					javaScriptBuilder.AppendFormat("tableclass: '{0}',", _filterGridOptions.TableClass);
+
+				if (_filterGridOptions.Type.HasValue)
+					javaScriptBuilder.AppendFormat("formtype: '{0}',", _filterGridOptions.Type.Value.ToString().ToLower());
+
+				if (!string.IsNullOrWhiteSpace(_filterGridOptions.Url))
+					javaScriptBuilder.AppendFormat("url: '{0}',", _filterGridOptions.Url);
+
+				javaScriptBuilder.Remove(javaScriptBuilder.Length - 1, 1);
+			}
+
+			javaScriptBuilder.AppendLine("});");
+		}
+
+		private static void AppendFilterOptions(JqGridFilterOptions options, StringBuilder javaScriptBuilder)
+		{
+			if (options != null)
+			{
+				if (!string.IsNullOrWhiteSpace(options.AfterClear))
+					javaScriptBuilder.AppendFormat("afterClear: {0},", options.AfterClear);
+
+				if (!string.IsNullOrWhiteSpace(options.AfterSearch))
+					javaScriptBuilder.AppendFormat("afterSearch: {0},", options.AfterSearch);
+
+				if (options.AutoSearch.HasValue)
+					javaScriptBuilder.AppendFormat("autosearch: {0},", options.AutoSearch.Value.ToString().ToLower());
+
+				if (!string.IsNullOrWhiteSpace(options.BeforeClear))
+					javaScriptBuilder.AppendFormat("beforeClear: {0},", options.BeforeClear);
+
+				if (!string.IsNullOrWhiteSpace(options.BeforeSearch))
+					javaScriptBuilder.AppendFormat("beforeSearch: {0},", options.BeforeSearch);
+			}
+		}
+
+		private void AppendFooterData(StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.Append(".jqGrid('footerData', 'set', { ");
+
+			foreach (var footerValue in _footerData)
+				javaScriptBuilder.AppendFormat(" {0}: '{1}', ", footerValue.Key, Convert.ToString(footerValue.Value));
+
+			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+			javaScriptBuilder.AppendFormat(" }}, {0})", _footerDataUseFormatters.ToString().ToLower());
+		}
+
+		private void AppendGroupHeaders(StringBuilder javaScriptBuilder)
+		{
+			javaScriptBuilder.Append(".jqGrid('setGroupHeaders', { ");
+
+			if (_groupHeadersUseColSpanStyle)
+				javaScriptBuilder.Append("useColSpanStyle: true, ");
+
+			javaScriptBuilder.Append("groupHeaders: [ ");
+			foreach (JqGridGroupHeader groupHeader in _groupHeaders)
+				javaScriptBuilder.AppendFormat("{{ startColumnName: '{0}', numberOfColumns: {1}, titleText: '{2}' }}, ", groupHeader.StartColumn, groupHeader.NumberOfColumns, groupHeader.Title);
+			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2).Append(" ]");
+
+			javaScriptBuilder.Append("})");
+		}
+
+		private static void AppendColumnLabelOptions(string columnName, JqGridColumnLabelOptions options, StringBuilder javaScriptBuilder)
+		{
+			if (options == null) return;
+			var serializer = new JavaScriptSerializer();
+			javaScriptBuilder.AppendFormat(".jqGrid('setLabel', '{0}', ", columnName);
+			javaScriptBuilder.AppendFormat("'{0}', ", string.IsNullOrWhiteSpace(options.Label) ? string.Empty : options.Label);
+
+			if (string.IsNullOrWhiteSpace(options.Class))
+			{
+				if (options.CssStyles != null)
+					javaScriptBuilder.AppendFormat("{0}, ", serializer.Serialize(options.CssStyles));
+				else if (options.HtmlAttributes != null)
+					javaScriptBuilder.Append("null, ");
+			}
+			else
+				javaScriptBuilder.AppendFormat("'{0}', ", options.Class);
+
+			if (options.HtmlAttributes != null)
+				javaScriptBuilder.AppendFormat("{0}, ", serializer.Serialize(options.HtmlAttributes));
+
+			javaScriptBuilder.Remove(javaScriptBuilder.Length - 2, 2);
+			javaScriptBuilder.Append(" )");
+		}
+
+		private static IDictionary<string, object> AnonymousObjectToDictionary(object anonymousObject)
+		{
+			Dictionary<string, object> dictionary = new Dictionary<string, object>();
+
+			if (anonymousObject != null)
+			{
+				foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(anonymousObject))
+					dictionary.Add(property.Name, property.GetValue(anonymousObject));
+			}
+
+			return dictionary;
+		}
+		#endregion
+
+		#region Fluent API
+		/// <summary>
+		/// Adds column with actions predefined formatter.
+		/// </summary>
+		/// <param name="name">Name for the column.</param>
+		/// <param name="position">Position of the column.</param>
+		/// <param name="width">Width of the column.</param>
+		/// <param name="editButton">Value indicating if edit button is enabled.</param>
+		/// <param name="deleteButton">Value indicating if delete button is enabled.</param>
+		/// <param name="useFormEditing">Value indicating if form editing should be used instead of inline editing.</param>
+		/// <param name="inlineEditingOptions">Options for inline editing (RestoreAfterError and MethodType options are ignored in this context).</param>
+		/// <param name="formEditingOptions">Options for form editing.</param>
+		/// <param name="deleteOptions">Options for deleting.</param>
+		/// <returns>JqGridHelper instance.</returns>
+		/// <remarks>It is adviced to set JqGridResponse.JsonReader.RepeatItems to false if you want to use this method, otherwise jqGrid will not skip this column while mapping data.</remarks>
+		public JqGridHelper<TModel> AddActionsColumn(string name, int position = 0, int width = 60, bool editButton = true, bool deleteButton = true, bool useFormEditing = false, JqGridInlineNavigatorActionOptions inlineEditingOptions = null, JqGridNavigatorEditActionOptions formEditingOptions = null, JqGridNavigatorDeleteActionOptions deleteOptions = null)
+		{
+			JqGridColumnModel actionsColumnModel = new JqGridColumnModel(name);
+			actionsColumnModel.Width = width;
+			actionsColumnModel.Resizable = false;
+			actionsColumnModel.Searchable = false;
+			actionsColumnModel.Sortable = false;
+			actionsColumnModel.Viewable = false;
+			actionsColumnModel.Formatter = new SettedString(true, JqGridColumnPredefinedFormatters.Actions);
+			actionsColumnModel.FormatterOptions = new JqGridColumnFormatterOptions()
+			{
+				EditButton = editButton,
+				DeleteButton = deleteButton,
+				UseFormEditing = useFormEditing,
+				InlineEditingOptions = inlineEditingOptions,
+				FormEditingOptions = formEditingOptions,
+				DeleteOptions = deleteOptions
+			};
+
+			if (position <= 0)
+			{
+				_options.ColumnsNames.Insert(0, string.Empty);
+				_options.ColumnsModels.Insert(0, actionsColumnModel);
+			}
+			else if (position >= _options.ColumnsModels.Count)
+			{
+				_options.ColumnsNames.Add(string.Empty);
+				_options.ColumnsModels.Add(actionsColumnModel);
+			}
+			else
+			{
+				_options.ColumnsNames.Insert(position, string.Empty);
+				_options.ColumnsModels.Insert(position, actionsColumnModel);
+			}
+
+			return this;
+		}
+
+		/// <summary>
+		/// Enables Navigator for this JqGridHelper instance.
+		/// </summary>
+		/// <param name="options">The options for the Navigator.</param>
+		/// <param name="editActionOptions">The options for the edit action.</param>
+		/// <param name="addActionOptions">The options for the add action.</param>
+		/// <param name="deleteActionOptions">The options for the delete action.</param>
+		/// <param name="searchActionOptions">The options for the search action.</param>
+		/// <param name="viewActionOptions">The options for the view action.</param>
+		/// <returns>JqGridHelper instance with enabled Navigator.</returns>
+		/// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
+		public JqGridHelper<TModel> Navigator(JqGridNavigatorOptions options, JqGridNavigatorEditActionOptions editActionOptions = null, JqGridNavigatorEditActionOptions addActionOptions = null, JqGridNavigatorDeleteActionOptions deleteActionOptions = null, JqGridNavigatorSearchActionOptions searchActionOptions = null, JqGridNavigatorViewActionOptions viewActionOptions = null)
+		{
+			_navigatorOptions = options ?? throw new ArgumentNullException(nameof(options));
+			_navigatorEditActionOptions = editActionOptions;
+			_navigatorAddActionOptions = addActionOptions;
+			_navigatorDeleteActionOptions = deleteActionOptions;
+			_navigatorSearchActionOptions = searchActionOptions;
+			_navigatorViewActionOptions = viewActionOptions;
+
+			return this;
+		}
+
+		/// <summary>
+		/// Enables Inline Navigator for this JqGridHelper instance.
+		/// </summary>
+		/// <param name="options">The options for the Inline Navigator.</param>
+		/// <returns>JqGridHelper instance with enabled Inline Navigator.</returns>
+		/// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
+		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+		public JqGridHelper<TModel> InlineNavigator(JqGridInlineNavigatorOptions options)
+		{
+			if (_navigatorOptions == null)
+				throw new InvalidOperationException("In order to call InlineNavigator method you must call Navigator method first.");
+			_inlineNavigatorOptions = options ?? throw new ArgumentNullException(nameof(options));
+
+			return this;
+		}
+
+		/// <summary>
+		/// Adds button to this JqGridHelper instance Navigator.
+		/// </summary>
+		/// <param name="caption">The caption for the button.</param>
+		/// <param name="icon">The icon (form UI theme images) for the button. If this is set to "none" only text will appear.</param>
+		/// <param name="onClick">The function for button click action.</param>
+		/// <param name="position">The position where the button will be added.</param>
+		/// <param name="toolTip">The tooltip for the button.</param>
+		/// <param name="cursor">The value which determines the cursor when user mouseover the button.</param>
+		/// <param name="cloneToTop">The value which defines if the button added to the bottom pager should be coppied to the top pager.</param>
+		/// <returns>JqGridHelper instance.</returns>
+		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+		public JqGridHelper<TModel> AddNavigatorButton(string caption = JqGridNavigatorDefaults.ButtonCaption, string icon = JqGridNavigatorDefaults.ButtonIcon, string onClick = null, JqGridNavigatorButtonPositions position = JqGridNavigatorButtonPositions.Last, string toolTip = "", string cursor = JqGridNavigatorDefaults.ButtonCursor, bool cloneToTop = false)
+		{
+			if (_navigatorOptions == null)
+				throw new InvalidOperationException("In order to call AddNavigatorButton method you must call Navigator method first.");
+
+			_navigatorControlsOptions.Add(new JqGridNavigatorButtonOptions()
+			{
+				CloneToTop = cloneToTop,
+				Caption = caption,
+				Icon = icon,
+				OnClick = onClick,
+				Position = position,
+				ToolTip = toolTip,
+				Cursor = cursor
+			});
+
+			return this;
+		}
+
+		/// <summary>
+		/// Adds button to this JqGridHelper instance Navigator.
+		/// </summary>
+		/// <param name="options">The options for the button.</param>
+		/// <returns>JqGridHelper instance.</returns>
+		/// <exception cref="System.ArgumentNullException">The <paramref name="options"/> parameter is null.</exception>
+		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+		public JqGridHelper<TModel> AddNavigatorButton(JqGridNavigatorButtonOptions options)
+		{
+			if (options == null)
+				throw new ArgumentNullException(nameof(options));
+
+			if (_navigatorOptions == null)
+				throw new InvalidOperationException("In order to call AddNavigatorButton method you must call Navigator method first.");
+
+			_navigatorControlsOptions.Add(options);
+
+			return this;
+		}
+
+		/// <summary>
+		/// Adds separator to this JqGridHelper instance Navigator.
+		/// </summary>
+		/// <param name="class">The class for the separator.</param>
+		/// <param name="content">The content for the separator.</param>
+		/// <param name="cloneToTop">The value which defines if the separator added to the bottom pager should be coppied to the top pager.</param>
+		/// <returns>JqGridHelper instance.</returns>
+		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+		public JqGridHelper<TModel> AddNavigatorSeparator(string @class = JqGridNavigatorDefaults.SeparatorClass, string content = "", bool cloneToTop = false)
+		{
+			if (_navigatorOptions == null)
+				throw new InvalidOperationException("In order to call AddNavigatorSeparator method you must call Navigator method first.");
+
+			_navigatorControlsOptions.Add(new JqGridNavigatorSeparatorOptions()
+			{
+				CloneToTop = cloneToTop,
+				Class = @class,
+				Content = content
+			});
+
+			return this;
+		}
+
+		/// <summary>
+		/// Adds separator to this JqGridHelper instance Navigator.
+		/// </summary>
+		/// <param name="options">The options for the separator.</param>
+		/// <returns>JqGridHelper instance.</returns>
+		/// <exception cref="System.InvalidOperationException">Navigator method has not been called.</exception>
+		public JqGridHelper<TModel> AddNavigatorSeparator(JqGridNavigatorSeparatorOptions options)
+		{
+			if (options == null)
+				throw new ArgumentNullException(nameof(options));
+
+			if (_navigatorOptions == null)
+				throw new InvalidOperationException("In order to call AddNavigatorSeparator method you must call Navigator method first.");
+
+			_navigatorControlsOptions.Add(options);
+
+			return this;
+		}
+
+		/// <summary>
+		/// Enables filter toolbar for this JqGridHelper instance.
+		/// </summary>
+		/// <param name="options">The options for the filter toolbar.</param>
+		/// <returns>JqGridHelper instance with enabled filter toolbar.</returns>
+		public JqGridHelper<TModel> FilterToolbar(JqGridFilterToolbarOptions options = null)
+		{
+			_filterToolbar = true;
+			_filterToolbarOptions = options;
+
+			return this;
+		}
+
+		/// <summary>
+		/// Enables filter grid for this JqGridHelper instance.
+		/// </summary>
+		/// <param name="model">The model for the filter grid (if null, the model will be build based on ColumnsModels and ColumnsNames).</param>
+		/// <param name="options">The options for the filter grid.</param>
+		/// <returns>JqGridHelper instance with enabled filter grid.</returns>
+		/// <exception cref="System.InvalidOperationException">The filter grid model has not been provided and the automatic generation is not possible because the count of items in ColumnsModel  is different from ColumnsNames.</exception>
+		public JqGridHelper<TModel> FilterGrid(List<JqGridFilterGridRowModel> model = null, JqGridFilterGridOptions options = null)
+		{
+			if (model == null)
+			{
+				if (_options.ColumnsModels.Count != _options.ColumnsNames.Count)
+					throw new InvalidOperationException("Can't build filter grid model because ColumnsModels.Count is not equal to ColumnsNames.Count");
+
+				_filterGridModel = new List<JqGridFilterGridRowModel>();
+				for (var i = 0; i < _options.ColumnsModels.Count; i++)
+				{
+					if (_options.ColumnsModels[i].Searchable.GetValueOrDefault())
+					{
+						_filterGridModel.Add(new JqGridFilterGridRowModel(_options.ColumnsModels[i].Name, _options.ColumnsNames[i])
+						{
+							DefaultValue = _options.ColumnsModels[i].SearchOptions != null ? _options.ColumnsModels[i].SearchOptions.DefaultValue : string.Empty,
+							SearchType = _options.ColumnsModels[i].SearchType,
+							SelectUrl = _options.ColumnsModels[i].SearchOptions != null ? _options.ColumnsModels[i].SearchOptions.DataUrl : string.Empty
+						});
+					}
+				}
+			}
+			else
+				_filterGridModel = model;
+			_filterGridOptions = options;
+
+			return this;
+		}
+
+		/// <summary>
+		/// Sets data on footer of this JqGridHelper instance (requires footerEnabled = true).
+		/// </summary>
+		/// <param name="data">The object with values for the footer. Should have names which are the same as names from ColumnsModels.</param>
+		/// <param name="useFormatters">The value indicating if the formatters from columns should be used for footer.</param>
+		/// <returns>JqGridHelper instance with footer data.</returns>
+		public JqGridHelper<TModel> SetFooterData(object data, bool useFormatters = true)
+		{
+			return SetFooterData(AnonymousObjectToDictionary(data), useFormatters);
+		}
+
+		/// <summary>
+		/// Sets data on footer of this JqGridHelper instance (requires footerEnabled = true).
+		/// </summary>
+		/// <param name="data">The dictionary with values for the footer. Should have keys which are the same as names from ColumnsModels.</param>
+		/// <param name="useFormatters">The value indicating if the formatters from columns should be used for footer.</param>
+		/// <returns>JqGridHelper instance with footer data.</returns>
+		public JqGridHelper<TModel> SetFooterData(IDictionary<string, object> data, bool useFormatters = true)
+		{
+			_footerData = data;
+			_footerDataUseFormatters = useFormatters;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets grouping headers for this JqGridHelper instance.
+		/// </summary>
+		/// <param name="groupHeaders">Settings for grouping headers.</param>
+		/// <param name="useColSpanStyle">The value which determines if the non grouping header cell should have cell above it (false), or the column should be treated as one combining boot (true).</param>
+		/// <returns>JqGridHelper instance with grouping header.</returns>
+		/// <exception cref="System.InvalidOperationException">Columns sorting (reordering) is enabled. </exception>
+		public JqGridHelper<TModel> SetGroupHeaders(IEnumerable<JqGridGroupHeader> groupHeaders, bool useColSpanStyle = false)
+		{
+			if (_options.Sortable.GetValueOrDefault())
+				throw new InvalidOperationException("Header grouping can not be set-up when columns sorting (reordering) is enabled.");
+
+			_groupHeaders = groupHeaders;
+			_groupHeadersUseColSpanStyle = useColSpanStyle;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets frozen columns for this JqGridHelper instance.
+		/// </summary>
+		/// <returns>JqGridHelper instance with frozen columns.</returns>
+		/// <exception cref="System.InvalidOperationException">
+		/// <list type="bullet">
+		/// <item><description>TreeGrid is enabled.</description></item>
+		/// <item><description>SubGrid is enabled.</description></item>
+		/// <item><description>Columns sorting (reordering) is enabled.</description></item>
+		/// <item><description>Dynamic scrolling is enabled.</description></item>
+		/// <item><description>Data grouping is enabled.</description></item>
+		/// </list> 
+		/// </exception>
+		public JqGridHelper<TModel> SetFrozenColumns()
+		{
+			if (_options.TreeGridEnabled.GetValueOrDefault())
+				throw new InvalidOperationException("Frozen columns can not be set-up when TreeGrid is enabled.");
+
+			if (_options.SubgridEnabled.GetValueOrDefault())
+				throw new InvalidOperationException("Frozen columns can not be set-up when SubGrid is enabled.");
+
+			if (_options.Sortable.GetValueOrDefault())
+				throw new InvalidOperationException("Frozen columns can not be set-up when columns sorting (reordering) is enabled.");
+
+			if (_options.DynamicScrollingMode != JqGridDynamicScrollingModes.Disabled)
+				throw new InvalidOperationException("Frozen columns can not be set-up when dynamic scrolling is enabled.");
+
+			if (_options.GroupingEnabled.GetValueOrDefault())
+				throw new InvalidOperationException("Frozen columns can not be set-up when data grouping is enabled.");
+
+			_setFrozenColumns = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets some column options with dynamic data, that we can't set in attributes
+		/// </summary>
+		/// <param name="column">Name of column</param>
+		/// <param name="model">Model with data to set</param>
+		/// <returns>This JqGridHelper</returns>
+		/// <exception cref="ArgumentNullException">If column and/or model not defined</exception>
+		/// <exception cref="KeyNotFoundException">If column doesn't exist in model</exception>
+		public JqGridHelper<TModel> ExtendColumnOptions(string column, JqGridExtendColumnModel model)
+		{
+			if (string.IsNullOrWhiteSpace(column))
+				throw new ArgumentNullException(nameof(column));
+			if (_options.ColumnsModels.All(m => m.Name != column))
+				throw new KeyNotFoundException("This column doesn't exist in model.");
+			if (model == null)
+				throw new ArgumentNullException(nameof(model));
+
+			var columnModel = _options.ColumnsModels.Single(c => c.Name == column);
+
+			if (model.IsEditOptionsPostDataSetted)
+				columnModel.EditOptions.PostData = model.EditOptionsPostData;
+
+			if (model.IsEditOptionsHtmlAttributesSetted)
+				columnModel.EditOptions.HtmlAttributes = model.EditOptionsHtmlAttributes;
+
+			if (model.IsEditOptionsValueDictionarySetted)
+				columnModel.EditOptions.ValueDictionary = model.EditOptionsValueDictionary;
+
+			if (model.IsLabelOptionsHtmlAttributesSetted)
+				columnModel.LabelOptions.HtmlAttributes = model.LabelOptionsHtmlAttributes;
+
+			if (model.IsLabelOptionsCssStylesSetted)
+				columnModel.LabelOptions.CssStyles = model.LabelOptionsCssStyles;
+
+			if (model.IsSearchOptionsHtmlAttributesSetted)
+				columnModel.SearchOptions.HtmlAttributes = model.SearchOptionsHtmlAttributes;
+
+			if (model.IsSearchOptionsValueDictionarySetted)
+				columnModel.SearchOptions.ValueDictionary = model.SearchOptionsValueDictionary;
+
+			return this;
+		}
+		#endregion
+	}
 }
+

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorActionOptions.cs
@@ -1,82 +1,77 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Inline Navigator action.
-    /// </summary>
-    public class JqGridInlineNavigatorActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the value indicating if user can use [Enter] key to save and [Esc] key to cancel.
-        /// </summary>
-        public bool Keys { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Inline Navigator action.
+	/// </summary>
+	public class JqGridInlineNavigatorActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the value indicating if user can use [Enter] key to save and [Esc] key to cancel.
+		/// </summary>
+		public bool Keys { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised after successfully accessing the row for editing.
-        /// </summary>
-        public string OnEditFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after successfully accessing the row for editing.
+		/// </summary>
+		public string OnEditFunction { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised immediately after the successful request to the server.
-        /// </summary>
-        public string SuccessFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised immediately after the successful request to the server.
+		/// </summary>
+		public string SuccessFunction { get; set; }
 
-        /// <summary>
-        /// Gets or sets URL for the request (replaces the EditingUrl from JqGridOptions).
-        /// </summary>
-        public string Url { get; set; }
+		/// <summary>
+		/// Gets or sets URL for the request (replaces the EditingUrl from JqGridOptions).
+		/// </summary>
+		public string Url { get; set; }
 
-        /// <summary>
-        /// Gets or sets the extra values that will be posted with row values to the server.
-        /// </summary>
-        public object ExtraParam { get; set; }
+		/// <summary>
+		/// Gets or sets the extra values that will be posted with row values to the server.
+		/// </summary>
+		public object ExtraParam { get; set; }
 
-        /// <summary>
-        /// Gets or sets the JavaScript which will dynamically generate the extra values that will be posted with row values to the server (this property takes precedence over ExtraParam).
-        /// </summary>
-        public string ExtraParamScript { get; set; }
+		/// <summary>
+		/// Gets or sets the JavaScript which will dynamically generate the extra values that will be posted with row values to the server (this property takes precedence over ExtraParam).
+		/// </summary>
+		public string ExtraParamScript { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the data is saved to the server.
-        /// </summary>
-        public string AfterSaveFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the data is saved to the server.
+		/// </summary>
+		public string AfterSaveFunction { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised when error occurs during saving to the server.
-        /// </summary>
-        public string ErrorFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when error occurs during saving to the server.
+		/// </summary>
+		public string ErrorFunction { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised after restoring the row.
-        /// </summary>
-        public string AfterRestoreFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after restoring the row.
+		/// </summary>
+		public string AfterRestoreFunction { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the row should be restored in case of error while saving to the server.
-        /// </summary>
-        public bool RestoreAfterError { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the row should be restored in case of error while saving to the server.
+		/// </summary>
+		public bool RestoreAfterError { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type or request to make when data is sent to the server.
-        /// </summary>
-        public JqGridMethodTypes MethodType { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the type or request to make when data is sent to the server.
+		/// </summary>
+		public JqGridMethodTypes MethodType { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridInlineNavigatorActionOptions class.
-        /// </summary>
-        public JqGridInlineNavigatorActionOptions()
-        {
-            Keys = false;
-            RestoreAfterError = true;
-            MethodType = JqGridMethodTypes.Post;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridInlineNavigatorActionOptions class.
+		/// </summary>
+		public JqGridInlineNavigatorActionOptions()
+		{
+			Keys = false;
+			RestoreAfterError = true;
+			MethodType = JqGridMethodTypes.Post;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorActionOptions.cs
@@ -1,77 +1,77 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Inline Navigator action.
-	/// </summary>
-	public class JqGridInlineNavigatorActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the value indicating if user can use [Enter] key to save and [Esc] key to cancel.
-		/// </summary>
-		public bool Keys { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Inline Navigator action.
+    /// </summary>
+    public class JqGridInlineNavigatorActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the value indicating if user can use [Enter] key to save and [Esc] key to cancel.
+        /// </summary>
+        public bool Keys { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised after successfully accessing the row for editing.
-		/// </summary>
-		public string OnEditFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after successfully accessing the row for editing.
+        /// </summary>
+        public string OnEditFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised immediately after the successful request to the server.
-		/// </summary>
-		public string SuccessFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised immediately after the successful request to the server.
+        /// </summary>
+        public string SuccessFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets URL for the request (replaces the EditingUrl from JqGridOptions).
-		/// </summary>
-		public string Url { get; set; }
+        /// <summary>
+        /// Gets or sets URL for the request (replaces the EditingUrl from JqGridOptions).
+        /// </summary>
+        public string Url { get; set; }
 
-		/// <summary>
-		/// Gets or sets the extra values that will be posted with row values to the server.
-		/// </summary>
-		public object ExtraParam { get; set; }
+        /// <summary>
+        /// Gets or sets the extra values that will be posted with row values to the server.
+        /// </summary>
+        public object ExtraParam { get; set; }
 
-		/// <summary>
-		/// Gets or sets the JavaScript which will dynamically generate the extra values that will be posted with row values to the server (this property takes precedence over ExtraParam).
-		/// </summary>
-		public string ExtraParamScript { get; set; }
+        /// <summary>
+        /// Gets or sets the JavaScript which will dynamically generate the extra values that will be posted with row values to the server (this property takes precedence over ExtraParam).
+        /// </summary>
+        public string ExtraParamScript { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the data is saved to the server.
-		/// </summary>
-		public string AfterSaveFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the data is saved to the server.
+        /// </summary>
+        public string AfterSaveFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised when error occurs during saving to the server.
-		/// </summary>
-		public string ErrorFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when error occurs during saving to the server.
+        /// </summary>
+        public string ErrorFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised after restoring the row.
-		/// </summary>
-		public string AfterRestoreFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after restoring the row.
+        /// </summary>
+        public string AfterRestoreFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the row should be restored in case of error while saving to the server.
-		/// </summary>
-		public bool RestoreAfterError { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the row should be restored in case of error while saving to the server.
+        /// </summary>
+        public bool RestoreAfterError { get; set; }
 
-		/// <summary>
-		/// Gets or sets the type or request to make when data is sent to the server.
-		/// </summary>
-		public JqGridMethodTypes MethodType { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the type or request to make when data is sent to the server.
+        /// </summary>
+        public JqGridMethodTypes MethodType { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridInlineNavigatorActionOptions class.
-		/// </summary>
-		public JqGridInlineNavigatorActionOptions()
-		{
-			Keys = false;
-			RestoreAfterError = true;
-			MethodType = JqGridMethodTypes.Post;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridInlineNavigatorActionOptions class.
+        /// </summary>
+        public JqGridInlineNavigatorActionOptions()
+        {
+            Keys = false;
+            RestoreAfterError = true;
+            MethodType = JqGridMethodTypes.Post;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorAddActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorAddActionOptions.cs
@@ -2,55 +2,55 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Inline Navigator add action.
-	/// </summary>
-	public class JqGridInlineNavigatorAddActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the id for the new row
-		/// </summary>
-		public string RowId { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Inline Navigator add action.
+    /// </summary>
+    public class JqGridInlineNavigatorAddActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the id for the new row
+        /// </summary>
+        public string RowId { get; set; }
 
-		/// <summary>
-		/// Gets or sets the initial values for the new row.
-		/// </summary>
-		public object InitData { get; set; }
+        /// <summary>
+        /// Gets or sets the initial values for the new row.
+        /// </summary>
+        public object InitData { get; set; }
 
-		/// <summary>
-		/// Gets or sets the new row position.
-		/// </summary>
-		public JqGridNewRowPositions Position { get; set; }
+        /// <summary>
+        /// Gets or sets the new row position.
+        /// </summary>
+        public JqGridNewRowPositions Position { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if the DefaultValue from ColumnsModel should be used.
-		/// </summary>
-		public bool UseDefaultValues { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if the DefaultValue from ColumnsModel should be used.
+        /// </summary>
+        public bool UseDefaultValues { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if formatters should be used.
-		/// </summary>
-		public bool UseFormatter { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if formatters should be used.
+        /// </summary>
+        public bool UseFormatter { get; set; }
 
-		/// <summary>
-		/// Gets or sets edit options.
-		/// </summary>
-		public JqGridInlineNavigatorActionOptions Options { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets edit options.
+        /// </summary>
+        public JqGridInlineNavigatorActionOptions Options { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridInlineNavigatorAddActionOptions class.
-		/// </summary>
-		public JqGridInlineNavigatorAddActionOptions()
-		{
-			RowId = JqGridNavigatorDefaults.NewRowId;
-			Position = JqGridNewRowPositions.First;
-			UseDefaultValues = false;
-			UseFormatter = false;
-			Options = null;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridInlineNavigatorAddActionOptions class.
+        /// </summary>
+        public JqGridInlineNavigatorAddActionOptions()
+        {
+            RowId = JqGridNavigatorDefaults.NewRowId;
+            Position = JqGridNewRowPositions.First;
+            UseDefaultValues = false;
+            UseFormatter = false;
+            Options = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorAddActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorAddActionOptions.cs
@@ -1,60 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Inline Navigator add action.
-    /// </summary>
-    public class JqGridInlineNavigatorAddActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the id for the new row
-        /// </summary>
-        public string RowId { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Inline Navigator add action.
+	/// </summary>
+	public class JqGridInlineNavigatorAddActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the id for the new row
+		/// </summary>
+		public string RowId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the initial values for the new row.
-        /// </summary>
-        public object InitData { get; set; }
+		/// <summary>
+		/// Gets or sets the initial values for the new row.
+		/// </summary>
+		public object InitData { get; set; }
 
-        /// <summary>
-        /// Gets or sets the new row position.
-        /// </summary>
-        public JqGridNewRowPositions Position { get; set; }
+		/// <summary>
+		/// Gets or sets the new row position.
+		/// </summary>
+		public JqGridNewRowPositions Position { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if the DefaultValue from ColumnsModel should be used.
-        /// </summary>
-        public bool UseDefaultValues { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if the DefaultValue from ColumnsModel should be used.
+		/// </summary>
+		public bool UseDefaultValues { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if formatters should be used.
-        /// </summary>
-        public bool UseFormatter { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if formatters should be used.
+		/// </summary>
+		public bool UseFormatter { get; set; }
 
-        /// <summary>
-        /// Gets or sets edit options.
-        /// </summary>
-        public JqGridInlineNavigatorActionOptions Options { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets edit options.
+		/// </summary>
+		public JqGridInlineNavigatorActionOptions Options { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridInlineNavigatorAddActionOptions class.
-        /// </summary>
-        public JqGridInlineNavigatorAddActionOptions()
-        {
-            RowId = JqGridNavigatorDefaults.NewRowId;
-            Position = JqGridNewRowPositions.First;
-            UseDefaultValues = false;
-            UseFormatter = false;
-            Options = null;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridInlineNavigatorAddActionOptions class.
+		/// </summary>
+		public JqGridInlineNavigatorAddActionOptions()
+		{
+			RowId = JqGridNavigatorDefaults.NewRowId;
+			Position = JqGridNewRowPositions.First;
+			UseDefaultValues = false;
+			UseFormatter = false;
+			Options = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorOptions.cs
@@ -3,81 +3,81 @@ using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Inline Navigator.
-	/// </summary>
-	public class JqGridInlineNavigatorOptions : JqGridNavigatorOptionsBase
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or set the value which defines if save action is enabled (default true).
-		/// </summary>
-		public bool Save { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Inline Navigator.
+    /// </summary>
+    public class JqGridInlineNavigatorOptions : JqGridNavigatorOptionsBase
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or set the value which defines if save action is enabled (default true).
+        /// </summary>
+        public bool Save { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for save action.
-		/// </summary>
-		public string SaveIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for save action.
+        /// </summary>
+        public string SaveIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for save action.
-		/// </summary>
-		public string SaveText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for save action.
+        /// </summary>
+        public string SaveText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for save action.
-		/// </summary>
-		public string SaveToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for save action.
+        /// </summary>
+        public string SaveToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or set the value which defines if cancel action is enabled (default true).
-		/// </summary>
-		public bool Cancel { get; set; }
+        /// <summary>
+        /// Gets or set the value which defines if cancel action is enabled (default true).
+        /// </summary>
+        public bool Cancel { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for cancel action.
-		/// </summary>
-		public string CancelIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for cancel action.
+        /// </summary>
+        public string CancelIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for cancel action.
-		/// </summary>
-		public string CancelText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for cancel action.
+        /// </summary>
+        public string CancelText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for cancel action.
-		/// </summary>
-		public string CancelToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for cancel action.
+        /// </summary>
+        public string CancelToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or sets the options for edit, save and cancel actions
-		/// </summary>
-		public JqGridInlineNavigatorActionOptions ActionOptions { get; set; }
+        /// <summary>
+        /// Gets or sets the options for edit, save and cancel actions
+        /// </summary>
+        public JqGridInlineNavigatorActionOptions ActionOptions { get; set; }
 
-		/// <summary>
-		/// Gets or sets the options for add action.
-		/// </summary>
-		public JqGridInlineNavigatorAddActionOptions AddActionOptions { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the options for add action.
+        /// </summary>
+        public JqGridInlineNavigatorAddActionOptions AddActionOptions { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridInlineNavigatorOptions class.
-		/// </summary>
-		public JqGridInlineNavigatorOptions()
-			: base()
-		{
-			Save = true;
-			SaveIcon = JqGridNavigatorDefaults.SaveIcon;
-			SaveText = String.Empty;
-			SaveToolTip = JqGridNavigatorDefaults.SaveToolTip;
-			Cancel = true;
-			CancelIcon = JqGridNavigatorDefaults.CancelIcon;
-			CancelText = String.Empty;
-			CancelToolTip = JqGridNavigatorDefaults.CancelToolTip;
-			ActionOptions = null;
-			AddActionOptions = null;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridInlineNavigatorOptions class.
+        /// </summary>
+        public JqGridInlineNavigatorOptions()
+            : base()
+        {
+            Save = true;
+            SaveIcon = JqGridNavigatorDefaults.SaveIcon;
+            SaveText = String.Empty;
+            SaveToolTip = JqGridNavigatorDefaults.SaveToolTip;
+            Cancel = true;
+            CancelIcon = JqGridNavigatorDefaults.CancelIcon;
+            CancelText = String.Empty;
+            CancelToolTip = JqGridNavigatorDefaults.CancelToolTip;
+            ActionOptions = null;
+            AddActionOptions = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridInlineNavigatorOptions.cs
@@ -1,86 +1,83 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Inline Navigator.
-    /// </summary>
-    public class JqGridInlineNavigatorOptions : JqGridNavigatorOptionsBase
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or set the value which defines if save action is enabled (default true).
-        /// </summary>
-        public bool Save { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Inline Navigator.
+	/// </summary>
+	public class JqGridInlineNavigatorOptions : JqGridNavigatorOptionsBase
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or set the value which defines if save action is enabled (default true).
+		/// </summary>
+		public bool Save { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for save action.
-        /// </summary>
-        public string SaveIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for save action.
+		/// </summary>
+		public string SaveIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for save action.
-        /// </summary>
-        public string SaveText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for save action.
+		/// </summary>
+		public string SaveText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for save action.
-        /// </summary>
-        public string SaveToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for save action.
+		/// </summary>
+		public string SaveToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or set the value which defines if cancel action is enabled (default true).
-        /// </summary>
-        public bool Cancel { get; set; }
+		/// <summary>
+		/// Gets or set the value which defines if cancel action is enabled (default true).
+		/// </summary>
+		public bool Cancel { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for cancel action.
-        /// </summary>
-        public string CancelIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for cancel action.
+		/// </summary>
+		public string CancelIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for cancel action.
-        /// </summary>
-        public string CancelText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for cancel action.
+		/// </summary>
+		public string CancelText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for cancel action.
-        /// </summary>
-        public string CancelToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for cancel action.
+		/// </summary>
+		public string CancelToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or sets the options for edit, save and cancel actions
-        /// </summary>
-        public JqGridInlineNavigatorActionOptions ActionOptions { get; set; }
+		/// <summary>
+		/// Gets or sets the options for edit, save and cancel actions
+		/// </summary>
+		public JqGridInlineNavigatorActionOptions ActionOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the options for add action.
-        /// </summary>
-        public JqGridInlineNavigatorAddActionOptions AddActionOptions { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the options for add action.
+		/// </summary>
+		public JqGridInlineNavigatorAddActionOptions AddActionOptions { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridInlineNavigatorOptions class.
-        /// </summary>
-        public JqGridInlineNavigatorOptions()
-            : base()
-        {
-            Save = true;
-            SaveIcon = JqGridNavigatorDefaults.SaveIcon;
-            SaveText = String.Empty;
-            SaveToolTip = JqGridNavigatorDefaults.SaveToolTip;
-            Cancel = true;
-            CancelIcon = JqGridNavigatorDefaults.CancelIcon;
-            CancelText = String.Empty;
-            CancelToolTip = JqGridNavigatorDefaults.CancelToolTip;
-            ActionOptions = null;
-            AddActionOptions = null;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridInlineNavigatorOptions class.
+		/// </summary>
+		public JqGridInlineNavigatorOptions()
+			: base()
+		{
+			Save = true;
+			SaveIcon = JqGridNavigatorDefaults.SaveIcon;
+			SaveText = String.Empty;
+			SaveToolTip = JqGridNavigatorDefaults.SaveToolTip;
+			Cancel = true;
+			CancelIcon = JqGridNavigatorDefaults.CancelIcon;
+			CancelText = String.Empty;
+			CancelToolTip = JqGridNavigatorDefaults.CancelToolTip;
+			ActionOptions = null;
+			AddActionOptions = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridJsonReader.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridJsonReader.cs
@@ -3,202 +3,202 @@ using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents JSON reader for jqGrid records.
-	/// </summary>
-	public class JqGridJsonRecordsReader
-	{
-		#region Fields
-		private string _records;
-		private string _recordValues;
-		#endregion
+    /// <summary>
+    /// Class which represents JSON reader for jqGrid records.
+    /// </summary>
+    public class JqGridJsonRecordsReader
+    {
+        #region Fields
+        private string _records;
+        private string _recordValues;
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets the name of an array that contains the actual data.
-		/// </summary>
-		public string Records
-		{
-			get => _records;
-			set
-			{
-				if (string.IsNullOrWhiteSpace(value))
-					throw new ArgumentNullException(nameof(value));
-				_records = value;
-			}
-		}
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of an array that contains the actual data.
+        /// </summary>
+        public string Records
+        {
+            get => _records;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentNullException(nameof(value));
+                _records = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the name of an array that contains record values.
-		/// </summary>
-		public string RecordValues
-		{
-			get => _recordValues;
-			set => _recordValues = value;
-		}
+        /// <summary>
+        /// Gets or sets the name of an array that contains record values.
+        /// </summary>
+        public string RecordValues
+        {
+            get => _recordValues;
+            set => _recordValues = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the information for the data in the row is repeatable.
-		/// </summary>
-		public bool RepeatItems { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the value indicating if the information for the data in the row is repeatable.
+        /// </summary>
+        public bool RepeatItems { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridJsonRecordsReader class.
-		/// </summary>
-		public JqGridJsonRecordsReader()
-		{
-			_records = JqGridOptionsDefaults.ResponseRecords;
-			_recordValues = JqGridOptionsDefaults.ResponseRecordValues;
-			RepeatItems = true;
-		}
-		#endregion
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridJsonRecordsReader class.
+        /// </summary>
+        public JqGridJsonRecordsReader()
+        {
+            _records = JqGridOptionsDefaults.ResponseRecords;
+            _recordValues = JqGridOptionsDefaults.ResponseRecordValues;
+            RepeatItems = true;
+        }
+        #endregion
 
-		#region Methods
-		internal virtual bool IsDefault()
-		{
-			return Records == JqGridOptionsDefaults.ResponseRecords && RecordValues == JqGridOptionsDefaults.ResponseRecordValues && RepeatItems;
-		}
-		internal virtual bool IsGlobal => Records == JqGridResponse.JsonReader.Records
-										 && RecordValues == JqGridResponse.JsonReader.RecordValues
-										 && RepeatItems == JqGridResponse.JsonReader.RepeatItems;
-		#endregion
-	}
+        #region Methods
+        internal virtual bool IsDefault()
+        {
+            return Records == JqGridOptionsDefaults.ResponseRecords && RecordValues == JqGridOptionsDefaults.ResponseRecordValues && RepeatItems;
+        }
+        internal virtual bool IsGlobal => Records == JqGridResponse.JsonReader.Records
+                                         && RecordValues == JqGridResponse.JsonReader.RecordValues
+                                         && RepeatItems == JqGridResponse.JsonReader.RepeatItems;
+        #endregion
+    }
 
-	/// <summary>
-	/// Class which represents JSON reader for jqGrid.
-	/// </summary>
-	public class JqGridJsonReader : JqGridJsonRecordsReader, ICloneable
-	{
-		#region Fields
-		private string _pageIndex;
-		private string _recordId;
-		private string _totalPagesCount;
-		private string _totalRecordsCount;
-		private string _userData;
-		#endregion
+    /// <summary>
+    /// Class which represents JSON reader for jqGrid.
+    /// </summary>
+    public class JqGridJsonReader : JqGridJsonRecordsReader, ICloneable
+    {
+        #region Fields
+        private string _pageIndex;
+        private string _recordId;
+        private string _totalPagesCount;
+        private string _totalRecordsCount;
+        private string _userData;
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets the name of a field that contains the current page index.
-		/// </summary>
-		public string PageIndex
-		{
-			get => _pageIndex;
-			set
-			{
-				if (string.IsNullOrWhiteSpace(value))
-					throw new ArgumentNullException(nameof(value));
-				_pageIndex = value;
-			}
-		}
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name of a field that contains the current page index.
+        /// </summary>
+        public string PageIndex
+        {
+            get => _pageIndex;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentNullException(nameof(value));
+                _pageIndex = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the name of a field that contains record identifier.
-		/// </summary>
-		public string RecordId
-		{
-			get => _recordId;
-			set
-			{
-				if (string.IsNullOrWhiteSpace(value))
-					throw new ArgumentNullException(nameof(value));
-				_recordId = value;
-			}
-		}
+        /// <summary>
+        /// Gets or sets the name of a field that contains record identifier.
+        /// </summary>
+        public string RecordId
+        {
+            get => _recordId;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentNullException(nameof(value));
+                _recordId = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets the settings for jqGrid subgrid JSON reader.
-		/// </summary>
-		public JqGridJsonRecordsReader SubgridReader { get; private set; }
+        /// <summary>
+        /// Gets the settings for jqGrid subgrid JSON reader.
+        /// </summary>
+        public JqGridJsonRecordsReader SubgridReader { get; private set; }
 
-		/// <summary>
-		/// Gets or sets the name of a field that contains total pages count.
-		/// </summary>
-		public string TotalPagesCount
-		{
-			get => _totalPagesCount;
-			set
-			{
-				if (string.IsNullOrWhiteSpace(value))
-					throw new ArgumentNullException(nameof(value));
-				_totalPagesCount = value;
-			}
-		}
+        /// <summary>
+        /// Gets or sets the name of a field that contains total pages count.
+        /// </summary>
+        public string TotalPagesCount
+        {
+            get => _totalPagesCount;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentNullException(nameof(value));
+                _totalPagesCount = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the name of a field that contains total records count.
-		/// </summary>
-		public string TotalRecordsCount
-		{
-			get => _totalRecordsCount;
-			set
-			{
-				if (string.IsNullOrWhiteSpace(value))
-					throw new ArgumentNullException(nameof(value));
-				_totalRecordsCount = value;
-			}
-		}
+        /// <summary>
+        /// Gets or sets the name of a field that contains total records count.
+        /// </summary>
+        public string TotalRecordsCount
+        {
+            get => _totalRecordsCount;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentNullException(nameof(value));
+                _totalRecordsCount = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the name of an array that contains custom data.
-		/// </summary>
-		public string UserData
-		{
-			get => _userData;
-			set
-			{
-				if (string.IsNullOrWhiteSpace(value))
-					throw new ArgumentNullException(nameof(value));
-				_userData = value;
-			}
-		}
-		#endregion
+        /// <summary>
+        /// Gets or sets the name of an array that contains custom data.
+        /// </summary>
+        public string UserData
+        {
+            get => _userData;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentNullException(nameof(value));
+                _userData = value;
+            }
+        }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridJsonReader class.
-		/// </summary>
-		public JqGridJsonReader()
-		{
-			PageIndex = JqGridOptionsDefaults.ResponsePageIndex;
-			RecordId = JqGridOptionsDefaults.ResponseRecordId;
-			SubgridReader = new JqGridJsonRecordsReader();
-			TotalPagesCount = JqGridOptionsDefaults.ResponseTotalPagesCount;
-			TotalRecordsCount = JqGridOptionsDefaults.ResponseTotalRecordsCount;
-			UserData = JqGridOptionsDefaults.ResponseUserData;
-		}
-		#endregion
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridJsonReader class.
+        /// </summary>
+        public JqGridJsonReader()
+        {
+            PageIndex = JqGridOptionsDefaults.ResponsePageIndex;
+            RecordId = JqGridOptionsDefaults.ResponseRecordId;
+            SubgridReader = new JqGridJsonRecordsReader();
+            TotalPagesCount = JqGridOptionsDefaults.ResponseTotalPagesCount;
+            TotalRecordsCount = JqGridOptionsDefaults.ResponseTotalRecordsCount;
+            UserData = JqGridOptionsDefaults.ResponseUserData;
+        }
+        #endregion
 
-		#region Methods
-		internal new bool IsDefault()
-		{
-			return base.IsDefault()
-				   && PageIndex == JqGridOptionsDefaults.ResponsePageIndex
-				   && RecordId == JqGridOptionsDefaults.ResponseRecordId
-				   && TotalPagesCount == JqGridOptionsDefaults.ResponseTotalPagesCount
-				   && TotalRecordsCount == JqGridOptionsDefaults.ResponseTotalRecordsCount
-				   && UserData == JqGridOptionsDefaults.ResponseUserData;
-		}
+        #region Methods
+        internal new bool IsDefault()
+        {
+            return base.IsDefault()
+                   && PageIndex == JqGridOptionsDefaults.ResponsePageIndex
+                   && RecordId == JqGridOptionsDefaults.ResponseRecordId
+                   && TotalPagesCount == JqGridOptionsDefaults.ResponseTotalPagesCount
+                   && TotalRecordsCount == JqGridOptionsDefaults.ResponseTotalRecordsCount
+                   && UserData == JqGridOptionsDefaults.ResponseUserData;
+        }
 
-		internal new bool IsGlobal => base.IsGlobal
-								  && PageIndex == JqGridResponse.JsonReader.PageIndex
-								  && RecordId == JqGridResponse.JsonReader.RecordId
-								  && TotalPagesCount == JqGridResponse.JsonReader.TotalPagesCount
-								  && TotalRecordsCount == JqGridResponse.JsonReader.TotalRecordsCount
-								  && UserData == JqGridResponse.JsonReader.UserData;
-		#endregion
+        internal new bool IsGlobal => base.IsGlobal
+                                  && PageIndex == JqGridResponse.JsonReader.PageIndex
+                                  && RecordId == JqGridResponse.JsonReader.RecordId
+                                  && TotalPagesCount == JqGridResponse.JsonReader.TotalPagesCount
+                                  && TotalRecordsCount == JqGridResponse.JsonReader.TotalRecordsCount
+                                  && UserData == JqGridResponse.JsonReader.UserData;
+        #endregion
 
-		#region ICloneable Members
-		/// <summary>
-		/// Creates a new object that is a shallow copy of the current instance.
-		/// </summary>
-		/// <returns>A new object that is a shallow copy of this instance.</returns>
-		public object Clone()
-		{
-			return MemberwiseClone();
-		}
-		#endregion
-	}
+        #region ICloneable Members
+        /// <summary>
+        /// Creates a new object that is a shallow copy of the current instance.
+        /// </summary>
+        /// <returns>A new object that is a shallow copy of this instance.</returns>
+        public object Clone()
+        {
+            return MemberwiseClone();
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridJsonReader.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridJsonReader.cs
@@ -1,192 +1,204 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents JSON reader for jqGrid records.
-    /// </summary>
-    public class JqGridJsonRecordsReader
-    {
-        #region Fields
-        private string _records;
-        private string _recordValues;
-        #endregion
+	/// <summary>
+	/// Class which represents JSON reader for jqGrid records.
+	/// </summary>
+	public class JqGridJsonRecordsReader
+	{
+		#region Fields
+		private string _records;
+		private string _recordValues;
+		#endregion
 
-        #region Properties
-        /// <summary>
-        /// Gets or sets the name of an array that contains the actual data.
-        /// </summary>
-        public string Records
-        {
-            get { return _records; }
-            set
-            {
-                if (String.IsNullOrWhiteSpace(value))
-                    throw new ArgumentNullException("value");
-                _records = value;
-            }
-        }
+		#region Properties
+		/// <summary>
+		/// Gets or sets the name of an array that contains the actual data.
+		/// </summary>
+		public string Records
+		{
+			get => _records;
+			set
+			{
+				if (string.IsNullOrWhiteSpace(value))
+					throw new ArgumentNullException(nameof(value));
+				_records = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the name of an array that contains record values.
-        /// </summary>
-        public string RecordValues
-        {
-            get { return _recordValues; }
-            set { _recordValues = value; }
-        }
+		/// <summary>
+		/// Gets or sets the name of an array that contains record values.
+		/// </summary>
+		public string RecordValues
+		{
+			get => _recordValues;
+			set => _recordValues = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the value indicating if the information for the data in the row is repeatable.
-        /// </summary>
-        public bool RepeatItems { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the value indicating if the information for the data in the row is repeatable.
+		/// </summary>
+		public bool RepeatItems { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridJsonRecordsReader class.
-        /// </summary>
-        public JqGridJsonRecordsReader()
-        {
-            Records = JqGridOptionsDefaults.ResponseRecords;
-            RecordValues = JqGridOptionsDefaults.ResponseRecordValues;
-            RepeatItems = true;
-        }
-        #endregion
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridJsonRecordsReader class.
+		/// </summary>
+		public JqGridJsonRecordsReader()
+		{
+			_records = JqGridOptionsDefaults.ResponseRecords;
+			_recordValues = JqGridOptionsDefaults.ResponseRecordValues;
+			RepeatItems = true;
+		}
+		#endregion
 
-        #region Methods
-        internal virtual bool IsDefault()
-        {
-            return ((Records == JqGridOptionsDefaults.ResponseRecords) && (RecordValues == JqGridOptionsDefaults.ResponseRecordValues) && RepeatItems);
-        }
-        #endregion
-    }
+		#region Methods
+		internal virtual bool IsDefault()
+		{
+			return Records == JqGridOptionsDefaults.ResponseRecords && RecordValues == JqGridOptionsDefaults.ResponseRecordValues && RepeatItems;
+		}
+		internal virtual bool IsGlobal => Records == JqGridResponse.JsonReader.Records
+										 && RecordValues == JqGridResponse.JsonReader.RecordValues
+										 && RepeatItems == JqGridResponse.JsonReader.RepeatItems;
+		#endregion
+	}
 
-    /// <summary>
-    /// Class which represents JSON reader for jqGrid.
-    /// </summary>
-    public class JqGridJsonReader : JqGridJsonRecordsReader, ICloneable
-    {
-        #region Fields
-        private string _pageIndex;
-        private string _recordId;
-        private string _totalPagesCount;
-        private string _totalRecordsCount;
-        private string _userData;
-        #endregion
+	/// <summary>
+	/// Class which represents JSON reader for jqGrid.
+	/// </summary>
+	public class JqGridJsonReader : JqGridJsonRecordsReader, ICloneable
+	{
+		#region Fields
+		private string _pageIndex;
+		private string _recordId;
+		private string _totalPagesCount;
+		private string _totalRecordsCount;
+		private string _userData;
+		#endregion
 
-        #region Properties
-        /// <summary>
-        /// Gets or sets the name of a field that contains the current page index.
-        /// </summary>
-        public string PageIndex
-        {
-            get { return _pageIndex; }
-            set
-            {
-                if (String.IsNullOrWhiteSpace(value))
-                    throw new ArgumentNullException("value");
-                _pageIndex = value;
-            }
-        }
+		#region Properties
+		/// <summary>
+		/// Gets or sets the name of a field that contains the current page index.
+		/// </summary>
+		public string PageIndex
+		{
+			get => _pageIndex;
+			set
+			{
+				if (string.IsNullOrWhiteSpace(value))
+					throw new ArgumentNullException(nameof(value));
+				_pageIndex = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the name of a field that contains record identifier.
-        /// </summary>
-        public string RecordId
-        {
-            get { return _recordId; }
-            set
-            {
-                if (String.IsNullOrWhiteSpace(value))
-                    throw new ArgumentNullException("value");
-                _recordId = value;
-            }
-        }
+		/// <summary>
+		/// Gets or sets the name of a field that contains record identifier.
+		/// </summary>
+		public string RecordId
+		{
+			get => _recordId;
+			set
+			{
+				if (string.IsNullOrWhiteSpace(value))
+					throw new ArgumentNullException(nameof(value));
+				_recordId = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets the settings for jqGrid subgrid JSON reader.
-        /// </summary>
-        public JqGridJsonRecordsReader SubgridReader { get; private set; }
+		/// <summary>
+		/// Gets the settings for jqGrid subgrid JSON reader.
+		/// </summary>
+		public JqGridJsonRecordsReader SubgridReader { get; private set; }
 
-        /// <summary>
-        /// Gets or sets the name of a field that contains total pages count.
-        /// </summary>
-        public string TotalPagesCount
-        {
-            get { return _totalPagesCount; }
-            set
-            {
-                if (String.IsNullOrWhiteSpace(value))
-                    throw new ArgumentNullException("value");
-                _totalPagesCount = value;
-            }
-        }
+		/// <summary>
+		/// Gets or sets the name of a field that contains total pages count.
+		/// </summary>
+		public string TotalPagesCount
+		{
+			get => _totalPagesCount;
+			set
+			{
+				if (string.IsNullOrWhiteSpace(value))
+					throw new ArgumentNullException(nameof(value));
+				_totalPagesCount = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the name of a field that contains total records count.
-        /// </summary>
-        public string TotalRecordsCount
-        {
-            get { return _totalRecordsCount; }
-            set
-            {
-                if (String.IsNullOrWhiteSpace(value))
-                    throw new ArgumentNullException("value");
-                _totalRecordsCount = value;
-            }
-        }
+		/// <summary>
+		/// Gets or sets the name of a field that contains total records count.
+		/// </summary>
+		public string TotalRecordsCount
+		{
+			get => _totalRecordsCount;
+			set
+			{
+				if (string.IsNullOrWhiteSpace(value))
+					throw new ArgumentNullException(nameof(value));
+				_totalRecordsCount = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets the name of an array that contains custom data.
-        /// </summary>
-        public string UserData
-        {
-            get { return _userData; }
-            set
-            {
-                if (String.IsNullOrWhiteSpace(value))
-                    throw new ArgumentNullException("value");
-                _userData = value;
-            }
-        }
-        #endregion
+		/// <summary>
+		/// Gets or sets the name of an array that contains custom data.
+		/// </summary>
+		public string UserData
+		{
+			get => _userData;
+			set
+			{
+				if (string.IsNullOrWhiteSpace(value))
+					throw new ArgumentNullException(nameof(value));
+				_userData = value;
+			}
+		}
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridJsonReader class.
-        /// </summary>
-        public JqGridJsonReader() : base()
-        {
-            PageIndex = JqGridOptionsDefaults.ResponsePageIndex;
-            RecordId = JqGridOptionsDefaults.ResponseRecordId;
-            SubgridReader = new JqGridJsonRecordsReader();
-            TotalPagesCount = JqGridOptionsDefaults.ResponseTotalPagesCount;
-            TotalRecordsCount = JqGridOptionsDefaults.ResponseTotalRecordsCount;
-            UserData = JqGridOptionsDefaults.ResponseUserData;
-        }
-        #endregion
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridJsonReader class.
+		/// </summary>
+		public JqGridJsonReader()
+		{
+			PageIndex = JqGridOptionsDefaults.ResponsePageIndex;
+			RecordId = JqGridOptionsDefaults.ResponseRecordId;
+			SubgridReader = new JqGridJsonRecordsReader();
+			TotalPagesCount = JqGridOptionsDefaults.ResponseTotalPagesCount;
+			TotalRecordsCount = JqGridOptionsDefaults.ResponseTotalRecordsCount;
+			UserData = JqGridOptionsDefaults.ResponseUserData;
+		}
+		#endregion
 
-        #region Methods
-        internal new bool IsDefault()
-        {
-            return (base.IsDefault() && (PageIndex == JqGridOptionsDefaults.ResponsePageIndex) && (RecordId == JqGridOptionsDefaults.ResponseRecordId) && (TotalPagesCount == JqGridOptionsDefaults.ResponseTotalPagesCount) && (TotalRecordsCount == JqGridOptionsDefaults.ResponseTotalRecordsCount) && (UserData == JqGridOptionsDefaults.ResponseUserData));
-        }
-        #endregion
+		#region Methods
+		internal new bool IsDefault()
+		{
+			return base.IsDefault()
+				   && PageIndex == JqGridOptionsDefaults.ResponsePageIndex
+				   && RecordId == JqGridOptionsDefaults.ResponseRecordId
+				   && TotalPagesCount == JqGridOptionsDefaults.ResponseTotalPagesCount
+				   && TotalRecordsCount == JqGridOptionsDefaults.ResponseTotalRecordsCount
+				   && UserData == JqGridOptionsDefaults.ResponseUserData;
+		}
 
-        #region ICloneable Members
-        /// <summary>
-        /// Creates a new object that is a shallow copy of the current instance.
-        /// </summary>
-        /// <returns>A new object that is a shallow copy of this instance.</returns>
-        public object Clone()
-        {
-            return this.MemberwiseClone();
-        }
-        #endregion
-    }
+		internal new bool IsGlobal => base.IsGlobal
+								  && PageIndex == JqGridResponse.JsonReader.PageIndex
+								  && RecordId == JqGridResponse.JsonReader.RecordId
+								  && TotalPagesCount == JqGridResponse.JsonReader.TotalPagesCount
+								  && TotalRecordsCount == JqGridResponse.JsonReader.TotalRecordsCount
+								  && UserData == JqGridResponse.JsonReader.UserData;
+		#endregion
+
+		#region ICloneable Members
+		/// <summary>
+		/// Creates a new object that is a shallow copy of the current instance.
+		/// </summary>
+		/// <returns>A new object that is a shallow copy of this instance.</returns>
+		public object Clone()
+		{
+			return MemberwiseClone();
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridJsonResult.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridJsonResult.cs
@@ -1,56 +1,57 @@
 ﻿using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Script.Serialization;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Represents a class that is used to send object from Lib.Web.Mvc.JQuery.JqGrid namespace as JSON-formatted content to the response, converted the way jqGrid expects it.
-	/// </summary>
-	public class JqGridJsonResult : JsonResult
-	{
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridJsonResult class.
-		/// </summary>
-		public JqGridJsonResult()
-			: base()
-		{ }
-		#endregion
+    /// <summary>
+    /// Represents a class that is used to send object from Lib.Web.Mvc.JQuery.JqGrid namespace as JSON-formatted content to the response, converted the way jqGrid expects it.
+    /// </summary>
+    public class JqGridJsonResult : JsonResult
+    {
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridJsonResult class.
+        /// </summary>
+        public JqGridJsonResult()
+            : base()
+        { }
+        #endregion
 
-		#region JsonResult Members
-		/// <summary>
-		/// When called by the action invoker, writes the JSON formatted result to the response.
-		/// </summary>
-		/// <param name="context">The context that the result is executed in.</param>
-		public override void ExecuteResult(ControllerContext context)
-		{
-			if (context == null)
-				throw new ArgumentNullException(nameof(context));
+        #region JsonResult Members
+        /// <summary>
+        /// When called by the action invoker, writes the JSON formatted result to the response.
+        /// </summary>
+        /// <param name="context">The context that the result is executed in.</param>
+        public override void ExecuteResult(ControllerContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
 
-			if (JsonRequestBehavior == JsonRequestBehavior.DenyGet && string.Equals(context.HttpContext.Request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase))
-				throw new InvalidOperationException("This request has been blocked because sensitive information could be disclosed to third party web sites when this is used in a GET request. To allow GET requests, set JsonRequestBehavior to AllowGet.");
+            if (JsonRequestBehavior == JsonRequestBehavior.DenyGet && string.Equals(context.HttpContext.Request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("This request has been blocked because sensitive information could be disclosed to third party web sites when this is used in a GET request. To allow GET requests, set JsonRequestBehavior to AllowGet.");
 
-			var response = context.HttpContext.Response;
+            HttpResponseBase response = context.HttpContext.Response;
 
-			if (!string.IsNullOrEmpty(ContentType))
-				response.ContentType = ContentType;
-			else
-				response.ContentType = "application/json";
+            if (!string.IsNullOrEmpty(ContentType))
+                response.ContentType = ContentType;
+            else
+                response.ContentType = "application/json";
 
-			if (ContentEncoding != null)
-				response.ContentEncoding = ContentEncoding;
+            if (ContentEncoding != null)
+                response.ContentEncoding = ContentEncoding;
 
-			if (Data != null)
-			{
-				var serializer = new JavaScriptSerializer();
-				serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
-				var data = serializer.Serialize(Data);
+            if (Data != null)
+            {
+                JavaScriptSerializer serializer = new JavaScriptSerializer();
+                serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
+                string data = serializer.Serialize(Data);
 
 
-				response.Write(data);
-			}
-		}
-		#endregion
-	}
+                response.Write(data);
+            }
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridJsonResult.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridJsonResult.cs
@@ -1,56 +1,56 @@
 ﻿using System;
 using System.Web.Mvc;
-using System.Web;
 using System.Web.Script.Serialization;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Represents a class that is used to send object from Lib.Web.Mvc.JQuery.JqGrid namespace as JSON-formatted content to the response, converted the way jqGrid expects it.
-    /// </summary>
-    public class JqGridJsonResult : JsonResult
-    {
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridJsonResult class.
-        /// </summary>
-        public JqGridJsonResult()
-            : base()
-        { }
-        #endregion
+	/// <summary>
+	/// Represents a class that is used to send object from Lib.Web.Mvc.JQuery.JqGrid namespace as JSON-formatted content to the response, converted the way jqGrid expects it.
+	/// </summary>
+	public class JqGridJsonResult : JsonResult
+	{
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridJsonResult class.
+		/// </summary>
+		public JqGridJsonResult()
+			: base()
+		{ }
+		#endregion
 
-        #region JsonResult Members
-        /// <summary>
-        /// When called by the action invoker, writes the JSON formatted result to the response.
-        /// </summary>
-        /// <param name="context">The context that the result is executed in.</param>
-        public override void ExecuteResult(ControllerContext context)
-        {
-            if (context == null)
-                throw new ArgumentNullException("context");
+		#region JsonResult Members
+		/// <summary>
+		/// When called by the action invoker, writes the JSON formatted result to the response.
+		/// </summary>
+		/// <param name="context">The context that the result is executed in.</param>
+		public override void ExecuteResult(ControllerContext context)
+		{
+			if (context == null)
+				throw new ArgumentNullException(nameof(context));
 
-            if (JsonRequestBehavior == JsonRequestBehavior.DenyGet && String.Equals(context.HttpContext.Request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase))
-                throw new InvalidOperationException("This request has been blocked because sensitive information could be disclosed to third party web sites when this is used in a GET request. To allow GET requests, set JsonRequestBehavior to AllowGet.");
+			if (JsonRequestBehavior == JsonRequestBehavior.DenyGet && string.Equals(context.HttpContext.Request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase))
+				throw new InvalidOperationException("This request has been blocked because sensitive information could be disclosed to third party web sites when this is used in a GET request. To allow GET requests, set JsonRequestBehavior to AllowGet.");
 
-            HttpResponseBase response = context.HttpContext.Response;
+			var response = context.HttpContext.Response;
 
-            if (!String.IsNullOrEmpty(ContentType))
-                response.ContentType = ContentType;
-            else
-                response.ContentType = "application/json";
+			if (!string.IsNullOrEmpty(ContentType))
+				response.ContentType = ContentType;
+			else
+				response.ContentType = "application/json";
 
-            if (ContentEncoding != null)
-                response.ContentEncoding = ContentEncoding;
+			if (ContentEncoding != null)
+				response.ContentEncoding = ContentEncoding;
 
-            if (Data != null)
-            {
-                JavaScriptSerializer serializer = new JavaScriptSerializer();
-                serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
+			if (Data != null)
+			{
+				var serializer = new JavaScriptSerializer();
+				serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
+				var data = serializer.Serialize(Data);
 
 
-                response.Write(serializer.Serialize(Data));
-            }
-        }
-        #endregion
-    }
+				response.Write(data);
+			}
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridLanguageDirections.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridLanguageDirections.cs
@@ -1,21 +1,21 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// jqGrid language directions.
-	/// </summary>
-	public enum JqGridLanguageDirections
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Left To Right
-		/// </summary>
-		Ltr,
-		/// <summary>
-		/// Right To Left
-		/// </summary>
-		Rtl
-	}
+    /// <summary>
+    /// jqGrid language directions.
+    /// </summary>
+    public enum JqGridLanguageDirections
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Left To Right
+        /// </summary>
+        Ltr,
+        /// <summary>
+        /// Right To Left
+        /// </summary>
+        Rtl
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridLanguageDirections.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridLanguageDirections.cs
@@ -1,22 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jqGrid language directions.
-    /// </summary>
-    public enum JqGridLanguageDirections
-    {
-        /// <summary>
-        /// Left To Right
-        /// </summary>
-        Ltr,
-        /// <summary>
-        /// Right To Left
-        /// </summary>
-        Rtl
-    }
+	/// <summary>
+	/// jqGrid language directions.
+	/// </summary>
+	public enum JqGridLanguageDirections
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Left To Right
+		/// </summary>
+		Ltr,
+		/// <summary>
+		/// Right To Left
+		/// </summary>
+		Rtl
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridMethodTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridMethodTypes.cs
@@ -1,21 +1,21 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// jgGrid request method types
-	/// </summary>
-	public enum JqGridMethodTypes
-	{
-		/// <summary>
-		/// Use JqGrid defalut value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// GET method
-		/// </summary>
-		Get,
-		/// <summary>
-		/// POST method
-		/// </summary>
-		Post
-	}
+    /// <summary>
+    /// jgGrid request method types
+    /// </summary>
+    public enum JqGridMethodTypes
+    {
+        /// <summary>
+        /// Use JqGrid defalut value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// GET method
+        /// </summary>
+        Get,
+        /// <summary>
+        /// POST method
+        /// </summary>
+        Post
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridMethodTypes.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridMethodTypes.cs
@@ -1,19 +1,21 @@
-﻿using System;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jgGrid request method types
-    /// </summary>
-    public enum JqGridMethodTypes
-    {
-        /// <summary>
-        /// GET method
-        /// </summary>
-        Get,
-        /// <summary>
-        /// POST method
-        /// </summary>
-        Post
-    }
+	/// <summary>
+	/// jgGrid request method types
+	/// </summary>
+	public enum JqGridMethodTypes
+	{
+		/// <summary>
+		/// Use JqGrid defalut value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// GET method
+		/// </summary>
+		Get,
+		/// <summary>
+		/// POST method
+		/// </summary>
+		Post
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridMultiKeys.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridMultiKeys.cs
@@ -1,29 +1,29 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// The possible values for the key which will be pressed when the user makes multiselection.
-	/// </summary>
-	public enum JqGridMultiKeys
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Force disable key
-		/// </summary>
-		Disable,
-		/// <summary>
-		/// The user should press Shift key.
-		/// </summary>
-		Shift,
-		/// <summary>
-		/// The user should press Alt key.
-		/// </summary>
-		Alt,
-		/// <summary>
-		/// The user should press Ctrl key.
-		/// </summary>
-		Ctrl
-	}
+    /// <summary>
+    /// The possible values for the key which will be pressed when the user makes multiselection.
+    /// </summary>
+    public enum JqGridMultiKeys
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Force disable key
+        /// </summary>
+        Disable,
+        /// <summary>
+        /// The user should press Shift key.
+        /// </summary>
+        Shift,
+        /// <summary>
+        /// The user should press Alt key.
+        /// </summary>
+        Alt,
+        /// <summary>
+        /// The user should press Ctrl key.
+        /// </summary>
+        Ctrl
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridMultiKeys.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridMultiKeys.cs
@@ -1,23 +1,29 @@
-﻿using System;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// The possible values for the key which will be pressed when the user makes multiselection.
-    /// </summary>
-    public enum JqGridMultiKeys
-    {
-        /// <summary>
-        /// The user should press Shift key.
-        /// </summary>
-        Shift,
-        /// <summary>
-        /// The user should press Alt key.
-        /// </summary>
-        Alt,
-        /// <summary>
-        /// The user should press Ctrl key.
-        /// </summary>
-        Ctrl
-    }
+	/// <summary>
+	/// The possible values for the key which will be pressed when the user makes multiselection.
+	/// </summary>
+	public enum JqGridMultiKeys
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Force disable key
+		/// </summary>
+		Disable,
+		/// <summary>
+		/// The user should press Shift key.
+		/// </summary>
+		Shift,
+		/// <summary>
+		/// The user should press Alt key.
+		/// </summary>
+		Alt,
+		/// <summary>
+		/// The user should press Ctrl key.
+		/// </summary>
+		Ctrl
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorActionOptions.cs
@@ -1,99 +1,94 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator action.
-    /// </summary>
-    public abstract class JqGridNavigatorActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the initial top position of modal dialog.
-        /// </summary>
-        public int Top { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator action.
+	/// </summary>
+	public abstract class JqGridNavigatorActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the initial top position of modal dialog.
+		/// </summary>
+		public int Top { get; set; }
 
-        /// <summary>
-        /// Gets or sets the initial left position of modal dialog.
-        /// </summary>
-        public int Left { get; set; }
+		/// <summary>
+		/// Gets or sets the initial left position of modal dialog.
+		/// </summary>
+		public int Left { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if dialog is modal (requires jqModal plugin).
-        /// </summary>
-        public bool Modal { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if dialog is modal (requires jqModal plugin).
+		/// </summary>
+		public bool Modal { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if dialog is dragable (requires jqDnR plugin or dragable widget from jQuery UI).
-        /// </summary>
-        public bool Dragable { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if dialog is dragable (requires jqDnR plugin or dragable widget from jQuery UI).
+		/// </summary>
+		public bool Dragable { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if dialog is resizable (requires jqDnR plugin or resizable widget from jQuery UI).
-        /// </summary>
-        public bool Resizable { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if dialog is resizable (requires jqDnR plugin or resizable widget from jQuery UI).
+		/// </summary>
+		public bool Resizable { get; set; }
 
-        /// <summary>
-        /// Gets or sets the width of confirmation dialog in pixels (default 'auto').
-        /// </summary>
-        public int Width { get; set; }
+		/// <summary>
+		/// Gets or sets the width of confirmation dialog in pixels (default 'auto').
+		/// </summary>
+		public int Width { get; set; }
 
-        /// <summary>
-        /// Gets or sets the width of the scrolling content.
-        /// </summary>
-        public int? DataWidth { get; set; }
+		/// <summary>
+		/// Gets or sets the width of the scrolling content.
+		/// </summary>
+		public int? DataWidth { get; set; }
 
-        /// <summary>
-        /// Gets or sets the entry height of confirmation dialog.
-        /// </summary>
-        public int? Height { get; set; }
+		/// <summary>
+		/// Gets or sets the entry height of confirmation dialog.
+		/// </summary>
+		public int? Height { get; set; }
 
-        /// <summary>
-        /// Gets or sets the height of the scrolling content (i.e between the modal header and modal footer).
-        /// </summary>
-        public int? DataHeight { get; set; }
+		/// <summary>
+		/// Gets or sets the height of the scrolling content (i.e between the modal header and modal footer).
+		/// </summary>
+		public int? DataHeight { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if jqModel plugin should be used for creating dialogs otherwise jqGrid uses its internal function.
-        /// </summary>
-        public bool UseJqModal { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if jqModel plugin should be used for creating dialogs otherwise jqGrid uses its internal function.
+		/// </summary>
+		public bool UseJqModal { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if modal window can be closed with ESC key.
-        /// </summary>
-        public bool CloseOnEscape { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if modal window can be closed with ESC key.
+		/// </summary>
+		public bool CloseOnEscape { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised just before closing the form.
-        /// </summary>
-        public string OnClose { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised just before closing the form.
+		/// </summary>
+		public string OnClose { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value controling overlay in the grid.
-        /// </summary>
-        public int Overlay { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the value controling overlay in the grid.
+		/// </summary>
+		public int Overlay { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorActionOptions class.
-        /// </summary>
-        public JqGridNavigatorActionOptions()
-        {
-            Top = 0;
-            Left = 0;
-            Modal = false;
-            Dragable = true;
-            Resizable = true;
-            UseJqModal = true;
-            CloseOnEscape = false;
-            Overlay = 30;
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorActionOptions class.
+		/// </summary>
+		public JqGridNavigatorActionOptions()
+		{
+			Top = 0;
+			Left = 0;
+			Modal = false;
+			Dragable = true;
+			Resizable = true;
+			UseJqModal = true;
+			CloseOnEscape = false;
+			Overlay = 30;
 
-            OnClose = null;
-        }
-        #endregion
-    }
+			OnClose = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorActionOptions.cs
@@ -1,94 +1,94 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator action.
-	/// </summary>
-	public abstract class JqGridNavigatorActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the initial top position of modal dialog.
-		/// </summary>
-		public int Top { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator action.
+    /// </summary>
+    public abstract class JqGridNavigatorActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the initial top position of modal dialog.
+        /// </summary>
+        public int Top { get; set; }
 
-		/// <summary>
-		/// Gets or sets the initial left position of modal dialog.
-		/// </summary>
-		public int Left { get; set; }
+        /// <summary>
+        /// Gets or sets the initial left position of modal dialog.
+        /// </summary>
+        public int Left { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if dialog is modal (requires jqModal plugin).
-		/// </summary>
-		public bool Modal { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if dialog is modal (requires jqModal plugin).
+        /// </summary>
+        public bool Modal { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if dialog is dragable (requires jqDnR plugin or dragable widget from jQuery UI).
-		/// </summary>
-		public bool Dragable { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if dialog is dragable (requires jqDnR plugin or dragable widget from jQuery UI).
+        /// </summary>
+        public bool Dragable { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if dialog is resizable (requires jqDnR plugin or resizable widget from jQuery UI).
-		/// </summary>
-		public bool Resizable { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if dialog is resizable (requires jqDnR plugin or resizable widget from jQuery UI).
+        /// </summary>
+        public bool Resizable { get; set; }
 
-		/// <summary>
-		/// Gets or sets the width of confirmation dialog in pixels (default 'auto').
-		/// </summary>
-		public int Width { get; set; }
+        /// <summary>
+        /// Gets or sets the width of confirmation dialog in pixels (default 'auto').
+        /// </summary>
+        public int Width { get; set; }
 
-		/// <summary>
-		/// Gets or sets the width of the scrolling content.
-		/// </summary>
-		public int? DataWidth { get; set; }
+        /// <summary>
+        /// Gets or sets the width of the scrolling content.
+        /// </summary>
+        public int? DataWidth { get; set; }
 
-		/// <summary>
-		/// Gets or sets the entry height of confirmation dialog.
-		/// </summary>
-		public int? Height { get; set; }
+        /// <summary>
+        /// Gets or sets the entry height of confirmation dialog.
+        /// </summary>
+        public int? Height { get; set; }
 
-		/// <summary>
-		/// Gets or sets the height of the scrolling content (i.e between the modal header and modal footer).
-		/// </summary>
-		public int? DataHeight { get; set; }
+        /// <summary>
+        /// Gets or sets the height of the scrolling content (i.e between the modal header and modal footer).
+        /// </summary>
+        public int? DataHeight { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if jqModel plugin should be used for creating dialogs otherwise jqGrid uses its internal function.
-		/// </summary>
-		public bool UseJqModal { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if jqModel plugin should be used for creating dialogs otherwise jqGrid uses its internal function.
+        /// </summary>
+        public bool UseJqModal { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if modal window can be closed with ESC key.
-		/// </summary>
-		public bool CloseOnEscape { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if modal window can be closed with ESC key.
+        /// </summary>
+        public bool CloseOnEscape { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised just before closing the form.
-		/// </summary>
-		public string OnClose { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised just before closing the form.
+        /// </summary>
+        public string OnClose { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value controling overlay in the grid.
-		/// </summary>
-		public int Overlay { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the value controling overlay in the grid.
+        /// </summary>
+        public int Overlay { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorActionOptions class.
-		/// </summary>
-		public JqGridNavigatorActionOptions()
-		{
-			Top = 0;
-			Left = 0;
-			Modal = false;
-			Dragable = true;
-			Resizable = true;
-			UseJqModal = true;
-			CloseOnEscape = false;
-			Overlay = 30;
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorActionOptions class.
+        /// </summary>
+        public JqGridNavigatorActionOptions()
+        {
+            Top = 0;
+            Left = 0;
+            Modal = false;
+            Dragable = true;
+            Resizable = true;
+            UseJqModal = true;
+            CloseOnEscape = false;
+            Overlay = 30;
 
-			OnClose = null;
-		}
-		#endregion
-	}
+            OnClose = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorButtonOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorButtonOptions.cs
@@ -2,63 +2,63 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator button.
-	/// </summary>
-	public class JqGridNavigatorButtonOptions : JqGridNavigatorControlOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the caption for the button.
-		/// </summary>
-		public string Caption { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator button.
+    /// </summary>
+    public class JqGridNavigatorButtonOptions : JqGridNavigatorControlOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the caption for the button.
+        /// </summary>
+        public string Caption { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for the button. If this property is set to "none" only text will appear.
-		/// </summary>
-		public string Icon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for the button. If this property is set to "none" only text will appear.
+        /// </summary>
+        public string Icon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the id for TD element holding the button (optional).
-		/// </summary>
-		public string Id { get; set; }
+        /// <summary>
+        /// Gets or sets the id for TD element holding the button (optional).
+        /// </summary>
+        public string Id { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for button click action.
-		/// </summary>
-		public string OnClick { get; set; }
+        /// <summary>
+        /// Gets or sets the function for button click action.
+        /// </summary>
+        public string OnClick { get; set; }
 
-		/// <summary>
-		/// Gets or sets the position where the button will be added.
-		/// </summary>
-		public JqGridNavigatorButtonPositions Position { get; set; }
+        /// <summary>
+        /// Gets or sets the position where the button will be added.
+        /// </summary>
+        public JqGridNavigatorButtonPositions Position { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for the button.
-		/// </summary>
-		public string ToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for the button.
+        /// </summary>
+        public string ToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which determines the cursor when user mouseover the button.
-		/// </summary>
-		public string Cursor { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the value which determines the cursor when user mouseover the button.
+        /// </summary>
+        public string Cursor { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorButtonOptions class.
-		/// </summary>
-		public JqGridNavigatorButtonOptions()
-			: base()
-		{
-			Caption = JqGridNavigatorDefaults.ButtonCaption;
-			Icon = JqGridNavigatorDefaults.ButtonIcon;
-			Id = null;
-			OnClick = null;
-			Position = JqGridNavigatorButtonPositions.Last;
-			ToolTip = string.Empty;
-			Cursor = JqGridNavigatorDefaults.ButtonCursor;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorButtonOptions class.
+        /// </summary>
+        public JqGridNavigatorButtonOptions()
+            : base()
+        {
+            Caption = JqGridNavigatorDefaults.ButtonCaption;
+            Icon = JqGridNavigatorDefaults.ButtonIcon;
+            Id = null;
+            OnClick = null;
+            Position = JqGridNavigatorButtonPositions.Last;
+            ToolTip = string.Empty;
+            Cursor = JqGridNavigatorDefaults.ButtonCursor;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorButtonOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorButtonOptions.cs
@@ -1,68 +1,64 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator button.
-    /// </summary>
-    public class JqGridNavigatorButtonOptions : JqGridNavigatorControlOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the caption for the button.
-        /// </summary>
-        public string Caption { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator button.
+	/// </summary>
+	public class JqGridNavigatorButtonOptions : JqGridNavigatorControlOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the caption for the button.
+		/// </summary>
+		public string Caption { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for the button. If this property is set to "none" only text will appear.
-        /// </summary>
-        public string Icon { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for the button. If this property is set to "none" only text will appear.
+		/// </summary>
+		public string Icon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the id for TD element holding the button (optional).
-        /// </summary>
-        public string Id { get; set; }
+		/// <summary>
+		/// Gets or sets the id for TD element holding the button (optional).
+		/// </summary>
+		public string Id { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for button click action.
-        /// </summary>
-        public string OnClick { get; set; }
+		/// <summary>
+		/// Gets or sets the function for button click action.
+		/// </summary>
+		public string OnClick { get; set; }
 
-        /// <summary>
-        /// Gets or sets the position where the button will be added.
-        /// </summary>
-        public JqGridNavigatorButtonPositions Position { get; set; }
+		/// <summary>
+		/// Gets or sets the position where the button will be added.
+		/// </summary>
+		public JqGridNavigatorButtonPositions Position { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for the button.
-        /// </summary>
-        public string ToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for the button.
+		/// </summary>
+		public string ToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which determines the cursor when user mouseover the button.
-        /// </summary>
-        public string Cursor { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the value which determines the cursor when user mouseover the button.
+		/// </summary>
+		public string Cursor { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorButtonOptions class.
-        /// </summary>
-        public JqGridNavigatorButtonOptions()
-            : base()
-        {
-            Caption = JqGridNavigatorDefaults.ButtonCaption;
-            Icon = JqGridNavigatorDefaults.ButtonIcon;
-            Id = null;
-            OnClick = null;
-            Position = JqGridNavigatorButtonPositions.Last;
-            ToolTip = String.Empty;
-            Cursor = JqGridNavigatorDefaults.ButtonCursor;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorButtonOptions class.
+		/// </summary>
+		public JqGridNavigatorButtonOptions()
+			: base()
+		{
+			Caption = JqGridNavigatorDefaults.ButtonCaption;
+			Icon = JqGridNavigatorDefaults.ButtonIcon;
+			Id = null;
+			OnClick = null;
+			Position = JqGridNavigatorButtonPositions.Last;
+			ToolTip = string.Empty;
+			Cursor = JqGridNavigatorDefaults.ButtonCursor;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorButtonPositions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorButtonPositions.cs
@@ -1,17 +1,17 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available positions of jqGrid Navigator button.
-	/// </summary>
-	public enum JqGridNavigatorButtonPositions
-	{
-		/// <summary>
-		/// Before standard buttons.
-		/// </summary>
-		First,
-		/// <summary>
-		/// After standard buttons.
-		/// </summary>
-		Last
-	}
+    /// <summary>
+    /// Defines available positions of jqGrid Navigator button.
+    /// </summary>
+    public enum JqGridNavigatorButtonPositions
+    {
+        /// <summary>
+        /// Before standard buttons.
+        /// </summary>
+        First,
+        /// <summary>
+        /// After standard buttons.
+        /// </summary>
+        Last
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorButtonPositions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorButtonPositions.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available positions of jqGrid Navigator button.
-    /// </summary>
-    public enum JqGridNavigatorButtonPositions
-    {
-        /// <summary>
-        /// Before standard buttons.
-        /// </summary>
-        First,
-        /// <summary>
-        /// After standard buttons.
-        /// </summary>
-        Last
-    }
+	/// <summary>
+	/// Defines available positions of jqGrid Navigator button.
+	/// </summary>
+	public enum JqGridNavigatorButtonPositions
+	{
+		/// <summary>
+		/// Before standard buttons.
+		/// </summary>
+		First,
+		/// <summary>
+		/// After standard buttons.
+		/// </summary>
+		Last
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorControlOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorControlOptions.cs
@@ -1,30 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Base class for classes which represents options for jqGrid Navigator controls
-    /// </summary>
-    public abstract class JqGridNavigatorControlOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the value which defines if the jqGrid Navigator control added to the bottom pager should be coppied to the top pager.
-        /// </summary>
-        public bool CloneToTop { get; set; }
-        #endregion
+	/// <summary>
+	/// Base class for classes which represents options for jqGrid Navigator controls
+	/// </summary>
+	public abstract class JqGridNavigatorControlOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the value which defines if the jqGrid Navigator control added to the bottom pager should be coppied to the top pager.
+		/// </summary>
+		public bool CloneToTop { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorControlOptions class.
-        /// </summary>
-        public JqGridNavigatorControlOptions()
-        {
-            CloneToTop = false;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorControlOptions class.
+		/// </summary>
+		public JqGridNavigatorControlOptions()
+		{
+			CloneToTop = false;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorControlOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorControlOptions.cs
@@ -1,25 +1,25 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Base class for classes which represents options for jqGrid Navigator controls
-	/// </summary>
-	public abstract class JqGridNavigatorControlOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the value which defines if the jqGrid Navigator control added to the bottom pager should be coppied to the top pager.
-		/// </summary>
-		public bool CloneToTop { get; set; }
-		#endregion
+    /// <summary>
+    /// Base class for classes which represents options for jqGrid Navigator controls
+    /// </summary>
+    public abstract class JqGridNavigatorControlOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the value which defines if the jqGrid Navigator control added to the bottom pager should be coppied to the top pager.
+        /// </summary>
+        public bool CloneToTop { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorControlOptions class.
-		/// </summary>
-		public JqGridNavigatorControlOptions()
-		{
-			CloneToTop = false;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorControlOptions class.
+        /// </summary>
+        public JqGridNavigatorControlOptions()
+        {
+            CloneToTop = false;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorDeleteActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorDeleteActionOptions.cs
@@ -1,32 +1,32 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator delete action.
-	/// </summary>
-	public class JqGridNavigatorDeleteActionOptions : JqGridNavigatorModifyActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the icon for the submit button.
-		/// </summary>
-		public JqGridFormButtonIcon DeleteButtonIcon { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator delete action.
+    /// </summary>
+    public class JqGridNavigatorDeleteActionOptions : JqGridNavigatorModifyActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the icon for the submit button.
+        /// </summary>
+        public JqGridFormButtonIcon DeleteButtonIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon for the cancel button.
-		/// </summary>
-		public JqGridFormButtonIcon CancelButtonIcon { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the icon for the cancel button.
+        /// </summary>
+        public JqGridFormButtonIcon CancelButtonIcon { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorDeleteActionOptions class.
-		/// </summary>
-		public JqGridNavigatorDeleteActionOptions()
-		{
-			Width = 240;
-			DeleteButtonIcon = JqGridFormButtonIcon.DeleteIcon;
-			CancelButtonIcon = JqGridFormButtonIcon.CancelIcon;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorDeleteActionOptions class.
+        /// </summary>
+        public JqGridNavigatorDeleteActionOptions()
+        {
+            Width = 240;
+            DeleteButtonIcon = JqGridFormButtonIcon.DeleteIcon;
+            CancelButtonIcon = JqGridFormButtonIcon.CancelIcon;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorDeleteActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorDeleteActionOptions.cs
@@ -1,37 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator delete action.
-    /// </summary>
-    public class JqGridNavigatorDeleteActionOptions : JqGridNavigatorModifyActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the icon for the submit button.
-        /// </summary>
-        public JqGridFormButtonIcon DeleteButtonIcon { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator delete action.
+	/// </summary>
+	public class JqGridNavigatorDeleteActionOptions : JqGridNavigatorModifyActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the icon for the submit button.
+		/// </summary>
+		public JqGridFormButtonIcon DeleteButtonIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon for the cancel button.
-        /// </summary>
-        public JqGridFormButtonIcon CancelButtonIcon { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the icon for the cancel button.
+		/// </summary>
+		public JqGridFormButtonIcon CancelButtonIcon { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorDeleteActionOptions class.
-        /// </summary>
-        public JqGridNavigatorDeleteActionOptions()
-        {
-            Width = 240;
-            DeleteButtonIcon = JqGridFormButtonIcon.DeleteIcon;
-            CancelButtonIcon = JqGridFormButtonIcon.CancelIcon;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorDeleteActionOptions class.
+		/// </summary>
+		public JqGridNavigatorDeleteActionOptions()
+		{
+			Width = 240;
+			DeleteButtonIcon = JqGridFormButtonIcon.DeleteIcon;
+			CancelButtonIcon = JqGridFormButtonIcon.CancelIcon;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorEditActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorEditActionOptions.cs
@@ -1,144 +1,142 @@
-﻿using System;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator edit action.
-    /// </summary>
-    public class JqGridNavigatorEditActionOptions : JqGridNavigatorModifyActionOptions, IJqGridNavigatorPageableFormActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the options for keyboard navigation.
-        /// </summary>
-        public JqGridFormKeyboardNavigation NavigationKeys { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator edit action.
+	/// </summary>
+	public class JqGridNavigatorEditActionOptions : JqGridNavigatorModifyActionOptions, IJqGridNavigatorPageableFormActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the options for keyboard navigation.
+		/// </summary>
+		public JqGridFormKeyboardNavigation NavigationKeys { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the pager buttons should appear on the form.
-        /// </summary>
-        public bool ViewPagerButtons { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the pager buttons should appear on the form.
+		/// </summary>
+		public bool ViewPagerButtons { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
-        /// </summary>
-        public bool RecreateForm { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
+		/// </summary>
+		public bool RecreateForm { get; set; }
 
-        /// <summary>
-        /// Gets or sets value indicating where the row just added should be placed.
-        /// </summary>
-        public JqGridNewRowPositions AddedRowPosition { get; set; }
+		/// <summary>
+		/// Gets or sets value indicating where the row just added should be placed.
+		/// </summary>
+		public JqGridNewRowPositions AddedRowPosition { get; set; }
 
-        /// <summary>
-        /// Gets or sets the information which is placed just after the modal header as additional row.
-        /// </summary>
-        public string TopInfo { get; set; }
+		/// <summary>
+		/// Gets or sets the information which is placed just after the modal header as additional row.
+		/// </summary>
+		public string TopInfo { get; set; }
 
-        /// <summary>
-        /// Gets or sets the information which is placed just after the buttons of the form as additional row.
-        /// </summary>
-        public string BottomInfo { get; set; }
+		/// <summary>
+		/// Gets or sets the information which is placed just after the buttons of the form as additional row.
+		/// </summary>
+		public string BottomInfo { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if add action dialog should be cleared after submiting.
-        /// </summary>
-        public bool ClearAfterAdd { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if add action dialog should be cleared after submiting.
+		/// </summary>
+		public bool ClearAfterAdd { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if add action dialog should be closed after submiting.
-        /// </summary>
-        public bool CloseAfterAdd { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if add action dialog should be closed after submiting.
+		/// </summary>
+		public bool CloseAfterAdd { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if edit action dialog should be closed after submiting.
-        /// </summary>
-        public bool CloseAfterEdit { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if edit action dialog should be closed after submiting.
+		/// </summary>
+		public bool CloseAfterEdit { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the user should confirm the changes uppon saving or cancel them.
-        /// </summary>
-        public bool CheckOnSubmit { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the user should confirm the changes uppon saving or cancel them.
+		/// </summary>
+		public bool CheckOnSubmit { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the user should be prompted when leaving unsaved changes.
-        /// </summary>
-        public bool CheckOnUpdate { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the user should be prompted when leaving unsaved changes.
+		/// </summary>
+		public bool CheckOnUpdate { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the form can be saved by pressing a key.
-        /// </summary>
-        public bool SaveKeyEnabled { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the form can be saved by pressing a key.
+		/// </summary>
+		public bool SaveKeyEnabled { get; set; }
 
-        /// <summary>
-        /// Gets or sets the key for saving.
-        /// </summary>
-        public char SaveKey { get; set; }
+		/// <summary>
+		/// Gets or sets the key for saving.
+		/// </summary>
+		public char SaveKey { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon for the save button.
-        /// </summary>
-        public JqGridFormButtonIcon SaveButtonIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the icon for the save button.
+		/// </summary>
+		public JqGridFormButtonIcon SaveButtonIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon for the close button.
-        /// </summary>
-        public JqGridFormButtonIcon CloseButtonIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the icon for the close button.
+		/// </summary>
+		public JqGridFormButtonIcon CloseButtonIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the data for the new row is loaded from the grid (if navigator buttons are enabled in edit mode).
-        /// </summary>
-        public string AfterClickPgButtons { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the data for the new row is loaded from the grid (if navigator buttons are enabled in edit mode).
+		/// </summary>
+		public string AfterClickPgButtons { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised fires immediately after all actions and events are completed and the row is inserted or updated in the grid.
-        /// </summary>
-        public string AfterComplete { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised fires immediately after all actions and events are completed and the row is inserted or updated in the grid.
+		/// </summary>
+		public string AfterComplete { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised before checking the values (if checking is defined in colModel via editrules option).
-        /// </summary>
-        public string BeforeCheckValues { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before checking the values (if checking is defined in colModel via editrules option).
+		/// </summary>
+		public string BeforeCheckValues { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised immediately after the previous or next button is clicked, before leaving the current row (if navigator buttons are enabled in edit mode).
-        /// </summary>
-        public string OnClickPgButtons { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised immediately after the previous or next button is clicked, before leaving the current row (if navigator buttons are enabled in edit mode).
+		/// </summary>
+		public string OnClickPgButtons { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised only once when creating the form for editing and adding.
-        /// </summary>
-        public string OnInitializeForm { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the function for event which is raised only once when creating the form for editing and adding.
+		/// </summary>
+		public string OnInitializeForm { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorEditActionOptions class.
-        /// </summary>
-        public JqGridNavigatorEditActionOptions()
-        {
-            Width = 300;
-            NavigationKeys = new JqGridFormKeyboardNavigation();
-            ViewPagerButtons = true;
-            RecreateForm = false;
-            AddedRowPosition = JqGridNewRowPositions.First;
-            ClearAfterAdd = true;
-            CloseAfterAdd = false;
-            CloseAfterEdit = false;
-            CheckOnSubmit = false;
-            CheckOnUpdate = false;
-            TopInfo = String.Empty;
-            BottomInfo = String.Empty;
-            SaveKeyEnabled = false;
-            SaveKey = (char)13;
-            SaveButtonIcon = JqGridFormButtonIcon.SaveIcon;
-            CloseButtonIcon = JqGridFormButtonIcon.CloseIcon;
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorEditActionOptions class.
+		/// </summary>
+		public JqGridNavigatorEditActionOptions()
+		{
+			Width = 300;
+			NavigationKeys = new JqGridFormKeyboardNavigation();
+			ViewPagerButtons = true;
+			RecreateForm = false;
+			AddedRowPosition = JqGridNewRowPositions.First;
+			ClearAfterAdd = true;
+			CloseAfterAdd = false;
+			CloseAfterEdit = false;
+			CheckOnSubmit = false;
+			CheckOnUpdate = false;
+			TopInfo = string.Empty;
+			BottomInfo = string.Empty;
+			SaveKeyEnabled = false;
+			SaveKey = (char)13;
+			SaveButtonIcon = JqGridFormButtonIcon.SaveIcon;
+			CloseButtonIcon = JqGridFormButtonIcon.CloseIcon;
 
-            AfterClickPgButtons = null;
-            AfterComplete = null;
-            BeforeCheckValues = null;
-            OnClickPgButtons = null;
-            OnClose = null;
-            OnInitializeForm = null;
-        }
-        #endregion
-    }
+			AfterClickPgButtons = null;
+			AfterComplete = null;
+			BeforeCheckValues = null;
+			OnClickPgButtons = null;
+			OnClose = null;
+			OnInitializeForm = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorEditActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorEditActionOptions.cs
@@ -1,142 +1,142 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator edit action.
-	/// </summary>
-	public class JqGridNavigatorEditActionOptions : JqGridNavigatorModifyActionOptions, IJqGridNavigatorPageableFormActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the options for keyboard navigation.
-		/// </summary>
-		public JqGridFormKeyboardNavigation NavigationKeys { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator edit action.
+    /// </summary>
+    public class JqGridNavigatorEditActionOptions : JqGridNavigatorModifyActionOptions, IJqGridNavigatorPageableFormActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the options for keyboard navigation.
+        /// </summary>
+        public JqGridFormKeyboardNavigation NavigationKeys { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the pager buttons should appear on the form.
-		/// </summary>
-		public bool ViewPagerButtons { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the pager buttons should appear on the form.
+        /// </summary>
+        public bool ViewPagerButtons { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
-		/// </summary>
-		public bool RecreateForm { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
+        /// </summary>
+        public bool RecreateForm { get; set; }
 
-		/// <summary>
-		/// Gets or sets value indicating where the row just added should be placed.
-		/// </summary>
-		public JqGridNewRowPositions AddedRowPosition { get; set; }
+        /// <summary>
+        /// Gets or sets value indicating where the row just added should be placed.
+        /// </summary>
+        public JqGridNewRowPositions AddedRowPosition { get; set; }
 
-		/// <summary>
-		/// Gets or sets the information which is placed just after the modal header as additional row.
-		/// </summary>
-		public string TopInfo { get; set; }
+        /// <summary>
+        /// Gets or sets the information which is placed just after the modal header as additional row.
+        /// </summary>
+        public string TopInfo { get; set; }
 
-		/// <summary>
-		/// Gets or sets the information which is placed just after the buttons of the form as additional row.
-		/// </summary>
-		public string BottomInfo { get; set; }
+        /// <summary>
+        /// Gets or sets the information which is placed just after the buttons of the form as additional row.
+        /// </summary>
+        public string BottomInfo { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if add action dialog should be cleared after submiting.
-		/// </summary>
-		public bool ClearAfterAdd { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if add action dialog should be cleared after submiting.
+        /// </summary>
+        public bool ClearAfterAdd { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if add action dialog should be closed after submiting.
-		/// </summary>
-		public bool CloseAfterAdd { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if add action dialog should be closed after submiting.
+        /// </summary>
+        public bool CloseAfterAdd { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if edit action dialog should be closed after submiting.
-		/// </summary>
-		public bool CloseAfterEdit { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if edit action dialog should be closed after submiting.
+        /// </summary>
+        public bool CloseAfterEdit { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the user should confirm the changes uppon saving or cancel them.
-		/// </summary>
-		public bool CheckOnSubmit { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the user should confirm the changes uppon saving or cancel them.
+        /// </summary>
+        public bool CheckOnSubmit { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the user should be prompted when leaving unsaved changes.
-		/// </summary>
-		public bool CheckOnUpdate { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the user should be prompted when leaving unsaved changes.
+        /// </summary>
+        public bool CheckOnUpdate { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the form can be saved by pressing a key.
-		/// </summary>
-		public bool SaveKeyEnabled { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the form can be saved by pressing a key.
+        /// </summary>
+        public bool SaveKeyEnabled { get; set; }
 
-		/// <summary>
-		/// Gets or sets the key for saving.
-		/// </summary>
-		public char SaveKey { get; set; }
+        /// <summary>
+        /// Gets or sets the key for saving.
+        /// </summary>
+        public char SaveKey { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon for the save button.
-		/// </summary>
-		public JqGridFormButtonIcon SaveButtonIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon for the save button.
+        /// </summary>
+        public JqGridFormButtonIcon SaveButtonIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon for the close button.
-		/// </summary>
-		public JqGridFormButtonIcon CloseButtonIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon for the close button.
+        /// </summary>
+        public JqGridFormButtonIcon CloseButtonIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the data for the new row is loaded from the grid (if navigator buttons are enabled in edit mode).
-		/// </summary>
-		public string AfterClickPgButtons { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the data for the new row is loaded from the grid (if navigator buttons are enabled in edit mode).
+        /// </summary>
+        public string AfterClickPgButtons { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised fires immediately after all actions and events are completed and the row is inserted or updated in the grid.
-		/// </summary>
-		public string AfterComplete { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised fires immediately after all actions and events are completed and the row is inserted or updated in the grid.
+        /// </summary>
+        public string AfterComplete { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised before checking the values (if checking is defined in colModel via editrules option).
-		/// </summary>
-		public string BeforeCheckValues { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before checking the values (if checking is defined in colModel via editrules option).
+        /// </summary>
+        public string BeforeCheckValues { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised immediately after the previous or next button is clicked, before leaving the current row (if navigator buttons are enabled in edit mode).
-		/// </summary>
-		public string OnClickPgButtons { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised immediately after the previous or next button is clicked, before leaving the current row (if navigator buttons are enabled in edit mode).
+        /// </summary>
+        public string OnClickPgButtons { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised only once when creating the form for editing and adding.
-		/// </summary>
-		public string OnInitializeForm { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the function for event which is raised only once when creating the form for editing and adding.
+        /// </summary>
+        public string OnInitializeForm { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorEditActionOptions class.
-		/// </summary>
-		public JqGridNavigatorEditActionOptions()
-		{
-			Width = 300;
-			NavigationKeys = new JqGridFormKeyboardNavigation();
-			ViewPagerButtons = true;
-			RecreateForm = false;
-			AddedRowPosition = JqGridNewRowPositions.First;
-			ClearAfterAdd = true;
-			CloseAfterAdd = false;
-			CloseAfterEdit = false;
-			CheckOnSubmit = false;
-			CheckOnUpdate = false;
-			TopInfo = string.Empty;
-			BottomInfo = string.Empty;
-			SaveKeyEnabled = false;
-			SaveKey = (char)13;
-			SaveButtonIcon = JqGridFormButtonIcon.SaveIcon;
-			CloseButtonIcon = JqGridFormButtonIcon.CloseIcon;
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorEditActionOptions class.
+        /// </summary>
+        public JqGridNavigatorEditActionOptions()
+        {
+            Width = 300;
+            NavigationKeys = new JqGridFormKeyboardNavigation();
+            ViewPagerButtons = true;
+            RecreateForm = false;
+            AddedRowPosition = JqGridNewRowPositions.First;
+            ClearAfterAdd = true;
+            CloseAfterAdd = false;
+            CloseAfterEdit = false;
+            CheckOnSubmit = false;
+            CheckOnUpdate = false;
+            TopInfo = string.Empty;
+            BottomInfo = string.Empty;
+            SaveKeyEnabled = false;
+            SaveKey = (char)13;
+            SaveButtonIcon = JqGridFormButtonIcon.SaveIcon;
+            CloseButtonIcon = JqGridFormButtonIcon.CloseIcon;
 
-			AfterClickPgButtons = null;
-			AfterComplete = null;
-			BeforeCheckValues = null;
-			OnClickPgButtons = null;
-			OnClose = null;
-			OnInitializeForm = null;
-		}
-		#endregion
-	}
+            AfterClickPgButtons = null;
+            AfterComplete = null;
+            BeforeCheckValues = null;
+            OnClickPgButtons = null;
+            OnClose = null;
+            OnInitializeForm = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorFormActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorFormActionOptions.cs
@@ -1,36 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator form editing action.
-    /// </summary>
-    public abstract class JqGridNavigatorFormActionOptions : JqGridNavigatorActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the function for event which is raised before initializing the new form data.
-        /// </summary>
-        public string BeforeInitData { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator form editing action.
+	/// </summary>
+	public abstract class JqGridNavigatorFormActionOptions : JqGridNavigatorActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the function for event which is raised before initializing the new form data.
+		/// </summary>
+		public string BeforeInitData { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised before showing the form with the new data.
-        /// </summary>
-        public string BeforeShowForm { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the function for event which is raised before showing the form with the new data.
+		/// </summary>
+		public string BeforeShowForm { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorFormActionOptions class.
-        /// </summary>
-        public JqGridNavigatorFormActionOptions()
-        {
-            BeforeInitData = null;
-            BeforeShowForm = null;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorFormActionOptions class.
+		/// </summary>
+		public JqGridNavigatorFormActionOptions()
+		{
+			BeforeInitData = null;
+			BeforeShowForm = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorFormActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorFormActionOptions.cs
@@ -1,31 +1,31 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator form editing action.
-	/// </summary>
-	public abstract class JqGridNavigatorFormActionOptions : JqGridNavigatorActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the function for event which is raised before initializing the new form data.
-		/// </summary>
-		public string BeforeInitData { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator form editing action.
+    /// </summary>
+    public abstract class JqGridNavigatorFormActionOptions : JqGridNavigatorActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the function for event which is raised before initializing the new form data.
+        /// </summary>
+        public string BeforeInitData { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised before showing the form with the new data.
-		/// </summary>
-		public string BeforeShowForm { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the function for event which is raised before showing the form with the new data.
+        /// </summary>
+        public string BeforeShowForm { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorFormActionOptions class.
-		/// </summary>
-		public JqGridNavigatorFormActionOptions()
-		{
-			BeforeInitData = null;
-			BeforeShowForm = null;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorFormActionOptions class.
+        /// </summary>
+        public JqGridNavigatorFormActionOptions()
+        {
+            BeforeInitData = null;
+            BeforeShowForm = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorModifyActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorModifyActionOptions.cs
@@ -1,92 +1,92 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator form editing add/edit or delete action.
-    /// </summary>
-    public abstract class JqGridNavigatorModifyActionOptions : JqGridNavigatorFormActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the url for action requests.
-        /// </summary>
-        public string Url { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator form editing add/edit or delete action.
+	/// </summary>
+	public abstract class JqGridNavigatorModifyActionOptions : JqGridNavigatorFormActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the url for action requests.
+		/// </summary>
+		public string Url { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type of request to make when data is sent to the server.
-        /// </summary>
-        public JqGridMethodTypes MethodType { get; set; }
+		/// <summary>
+		/// Gets or sets the type of request to make when data is sent to the server.
+		/// </summary>
+		public JqGridMethodTypes MethodType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if grid should be reloaded after submiting.
-        /// </summary>
-        public bool ReloadAfterSubmit { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if grid should be reloaded after submiting.
+		/// </summary>
+		public bool ReloadAfterSubmit { get; set; }
 
-        /// <summary>
-        /// Gets or sets an object used to add content to the data posted to the server.
-        /// </summary>
-        public object ExtraData { get; set; }
+		/// <summary>
+		/// Gets or sets an object used to add content to the data posted to the server.
+		/// </summary>
+		public object ExtraData { get; set; }
 
-        /// <summary>
-        /// Gets or sets the JavaScript which will dynamically generate the object which will be used to add content to the data posted to the server (this property takes precedence over ExtraData).
-        /// </summary>
-        public string ExtraDataScript { get; set; }
+		/// <summary>
+		/// Gets or sets the JavaScript which will dynamically generate the object which will be used to add content to the data posted to the server (this property takes precedence over ExtraData).
+		/// </summary>
+		public string ExtraDataScript { get; set; }
 
-        /// <summary>
-        /// Gets or sets ajax settings for the request.
-        /// </summary>
-        public object AjaxOptions { get; set; }
+		/// <summary>
+		/// Gets or sets ajax settings for the request.
+		/// </summary>
+		public object AjaxOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised after showing the form.
-        /// </summary>
-        public string AfterShowForm { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after showing the form.
+		/// </summary>
+		public string AfterShowForm { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised after response has been received from server.
-        /// </summary>
-        public string AfterSubmit { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after response has been received from server.
+		/// </summary>
+		public string AfterSubmit { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised before the data is submitted to the server.
-        /// </summary>
-        public string BeforeSubmit { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before the data is submitted to the server.
+		/// </summary>
+		public string BeforeSubmit { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the submit button is clicked and the postdata is constructed.
-        /// </summary>
-        public string OnClickSubmit { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the submit button is clicked and the postdata is constructed.
+		/// </summary>
+		public string OnClickSubmit { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which can serialize the data passed to the ajax request from the form.
-        /// </summary>
-        public string SerializeData { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which can serialize the data passed to the ajax request from the form.
+		/// </summary>
+		public string SerializeData { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised when error occurs from the ajax call and can be used for better formatting of the error messages.
-        /// </summary>
-        public string ErrorTextFormat { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the function for event which is raised when error occurs from the ajax call and can be used for better formatting of the error messages.
+		/// </summary>
+		public string ErrorTextFormat { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorModifyActionOptions class.
-        /// </summary>
-        public JqGridNavigatorModifyActionOptions()
-        {
-            Url = null;
-            MethodType = JqGridMethodTypes.Post;
-            ReloadAfterSubmit = true;
-            ExtraData = null;
-            ExtraDataScript = null;
-            AjaxOptions = null;
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorModifyActionOptions class.
+		/// </summary>
+		public JqGridNavigatorModifyActionOptions()
+		{
+			Url = null;
+			MethodType = JqGridMethodTypes.Post;
+			ReloadAfterSubmit = true;
+			ExtraData = null;
+			ExtraDataScript = null;
+			AjaxOptions = null;
 
-            AfterShowForm = null;
-            AfterSubmit = null;
-            BeforeSubmit = null;
-            OnClickSubmit = null;
-            SerializeData = null;
-            ErrorTextFormat = null;
-        }
-        #endregion
-    }
+			AfterShowForm = null;
+			AfterSubmit = null;
+			BeforeSubmit = null;
+			OnClickSubmit = null;
+			SerializeData = null;
+			ErrorTextFormat = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorModifyActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorModifyActionOptions.cs
@@ -1,92 +1,92 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator form editing add/edit or delete action.
-	/// </summary>
-	public abstract class JqGridNavigatorModifyActionOptions : JqGridNavigatorFormActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the url for action requests.
-		/// </summary>
-		public string Url { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator form editing add/edit or delete action.
+    /// </summary>
+    public abstract class JqGridNavigatorModifyActionOptions : JqGridNavigatorFormActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the url for action requests.
+        /// </summary>
+        public string Url { get; set; }
 
-		/// <summary>
-		/// Gets or sets the type of request to make when data is sent to the server.
-		/// </summary>
-		public JqGridMethodTypes MethodType { get; set; }
+        /// <summary>
+        /// Gets or sets the type of request to make when data is sent to the server.
+        /// </summary>
+        public JqGridMethodTypes MethodType { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if grid should be reloaded after submiting.
-		/// </summary>
-		public bool ReloadAfterSubmit { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if grid should be reloaded after submiting.
+        /// </summary>
+        public bool ReloadAfterSubmit { get; set; }
 
-		/// <summary>
-		/// Gets or sets an object used to add content to the data posted to the server.
-		/// </summary>
-		public object ExtraData { get; set; }
+        /// <summary>
+        /// Gets or sets an object used to add content to the data posted to the server.
+        /// </summary>
+        public object ExtraData { get; set; }
 
-		/// <summary>
-		/// Gets or sets the JavaScript which will dynamically generate the object which will be used to add content to the data posted to the server (this property takes precedence over ExtraData).
-		/// </summary>
-		public string ExtraDataScript { get; set; }
+        /// <summary>
+        /// Gets or sets the JavaScript which will dynamically generate the object which will be used to add content to the data posted to the server (this property takes precedence over ExtraData).
+        /// </summary>
+        public string ExtraDataScript { get; set; }
 
-		/// <summary>
-		/// Gets or sets ajax settings for the request.
-		/// </summary>
-		public object AjaxOptions { get; set; }
+        /// <summary>
+        /// Gets or sets ajax settings for the request.
+        /// </summary>
+        public object AjaxOptions { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised after showing the form.
-		/// </summary>
-		public string AfterShowForm { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after showing the form.
+        /// </summary>
+        public string AfterShowForm { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised after response has been received from server.
-		/// </summary>
-		public string AfterSubmit { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after response has been received from server.
+        /// </summary>
+        public string AfterSubmit { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised before the data is submitted to the server.
-		/// </summary>
-		public string BeforeSubmit { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before the data is submitted to the server.
+        /// </summary>
+        public string BeforeSubmit { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the submit button is clicked and the postdata is constructed.
-		/// </summary>
-		public string OnClickSubmit { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the submit button is clicked and the postdata is constructed.
+        /// </summary>
+        public string OnClickSubmit { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which can serialize the data passed to the ajax request from the form.
-		/// </summary>
-		public string SerializeData { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which can serialize the data passed to the ajax request from the form.
+        /// </summary>
+        public string SerializeData { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised when error occurs from the ajax call and can be used for better formatting of the error messages.
-		/// </summary>
-		public string ErrorTextFormat { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the function for event which is raised when error occurs from the ajax call and can be used for better formatting of the error messages.
+        /// </summary>
+        public string ErrorTextFormat { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorModifyActionOptions class.
-		/// </summary>
-		public JqGridNavigatorModifyActionOptions()
-		{
-			Url = null;
-			MethodType = JqGridMethodTypes.Post;
-			ReloadAfterSubmit = true;
-			ExtraData = null;
-			ExtraDataScript = null;
-			AjaxOptions = null;
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorModifyActionOptions class.
+        /// </summary>
+        public JqGridNavigatorModifyActionOptions()
+        {
+            Url = null;
+            MethodType = JqGridMethodTypes.Post;
+            ReloadAfterSubmit = true;
+            ExtraData = null;
+            ExtraDataScript = null;
+            AjaxOptions = null;
 
-			AfterShowForm = null;
-			AfterSubmit = null;
-			BeforeSubmit = null;
-			OnClickSubmit = null;
-			SerializeData = null;
-			ErrorTextFormat = null;
-		}
-		#endregion
-	}
+            AfterShowForm = null;
+            AfterSubmit = null;
+            BeforeSubmit = null;
+            OnClickSubmit = null;
+            SerializeData = null;
+            ErrorTextFormat = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorOptions.cs
@@ -2,183 +2,183 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator.
-	/// </summary>
-	public class JqGridNavigatorOptions : JqGridNavigatorOptionsBase
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the pager to which the Navigator should be attached to (jqGrid can have only one Navigator).
-		/// </summary>
-		public JqGridNavigatorPagers Pager { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator.
+    /// </summary>
+    public class JqGridNavigatorOptions : JqGridNavigatorOptionsBase
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the pager to which the Navigator should be attached to (jqGrid can have only one Navigator).
+        /// </summary>
+        public JqGridNavigatorPagers Pager { get; set; }
 
-		/// <summary>
-		/// Gets or sets the caption for warning which appears when user try to edit, delete or view a row without selecting it.
-		/// </summary>
-		public string AlertCaption { get; set; }
+        /// <summary>
+        /// Gets or sets the caption for warning which appears when user try to edit, delete or view a row without selecting it.
+        /// </summary>
+        public string AlertCaption { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for warning which appears when user try to edit, delete or view a row without selecting it.
-		/// </summary>
-		public string AlertText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for warning which appears when user try to edit, delete or view a row without selecting it.
+        /// </summary>
+        public string AlertText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if all the actions from the bottom pager should be coppied to the top pager.
-		/// </summary>
-		public bool CloneToTop { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if all the actions from the bottom pager should be coppied to the top pager.
+        /// </summary>
+        public bool CloneToTop { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines if the warning dialog can be closed with ESC key.
-		/// </summary>
-		public bool CloseOnEscape { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines if the warning dialog can be closed with ESC key.
+        /// </summary>
+        public bool CloseOnEscape { get; set; }
 
-		/// <summary>
-		/// Gets or set the value which defines if delete action is enabled (default true).
-		/// </summary>
-		public bool Delete { get; set; }
+        /// <summary>
+        /// Gets or set the value which defines if delete action is enabled (default true).
+        /// </summary>
+        public bool Delete { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for delete action.
-		/// </summary>
-		public string DeleteIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for delete action.
+        /// </summary>
+        public string DeleteIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for delete action.
-		/// </summary>
-		public string DeleteText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for delete action.
+        /// </summary>
+        public string DeleteText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for delete action.
-		/// </summary>
-		public string DeleteToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for delete action.
+        /// </summary>
+        public string DeleteToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or set the value which defines if refresh action is enabled (default true).
-		/// </summary>
-		public bool Refresh { get; set; }
+        /// <summary>
+        /// Gets or set the value which defines if refresh action is enabled (default true).
+        /// </summary>
+        public bool Refresh { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for refresh action.
-		/// </summary>
-		public string RefreshIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for refresh action.
+        /// </summary>
+        public string RefreshIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for refresh action.
-		/// </summary>
-		public string RefreshText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for refresh action.
+        /// </summary>
+        public string RefreshText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for refresh action.
-		/// </summary>
-		public string RefreshToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for refresh action.
+        /// </summary>
+        public string RefreshToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or sets the mode for refresh action.
-		/// </summary>
-		public JqGridRefreshModes RefreshMode { get; set; }
+        /// <summary>
+        /// Gets or sets the mode for refresh action.
+        /// </summary>
+        public JqGridRefreshModes RefreshMode { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the refresh button is clicked.
-		/// </summary>
-		public string AfterRefresh { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the refresh button is clicked.
+        /// </summary>
+        public string AfterRefresh { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised before the refresh button is clicked.
-		/// </summary>
-		public string BeforeRefresh { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before the refresh button is clicked.
+        /// </summary>
+        public string BeforeRefresh { get; set; }
 
-		/// <summary>
-		/// Gets or set the value which defines if search action is enabled (default true).
-		/// </summary>
-		public bool Search { get; set; }
+        /// <summary>
+        /// Gets or set the value which defines if search action is enabled (default true).
+        /// </summary>
+        public bool Search { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for search action.
-		/// </summary>
-		public string SearchIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for search action.
+        /// </summary>
+        public string SearchIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for search action.
-		/// </summary>
-		public string SearchText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for search action.
+        /// </summary>
+        public string SearchText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for search action.
-		/// </summary>
-		public string SearchToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for search action.
+        /// </summary>
+        public string SearchToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or set the value which defines if view action is enabled (default true).
-		/// </summary>
-		public bool View { get; set; }
+        /// <summary>
+        /// Gets or set the value which defines if view action is enabled (default true).
+        /// </summary>
+        public bool View { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for view action.
-		/// </summary>
-		public string ViewIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for view action.
+        /// </summary>
+        public string ViewIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for view action.
-		/// </summary>
-		public string ViewText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for view action.
+        /// </summary>
+        public string ViewText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for view action.
-		/// </summary>
-		public string ViewToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for view action.
+        /// </summary>
+        public string ViewToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or sets the custom function to replace the build in add function.
-		/// </summary>
-		public string AddFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the custom function to replace the build in add function.
+        /// </summary>
+        public string AddFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets the custom function to replace the build in edit function.
-		/// </summary>
-		public string EditFunction { get; set; }
+        /// <summary>
+        /// Gets or sets the custom function to replace the build in edit function.
+        /// </summary>
+        public string EditFunction { get; set; }
 
-		/// <summary>
-		/// Gets or sets the custom function to replace the build in delete function.
-		/// </summary>
-		public string DeleteFunction { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the custom function to replace the build in delete function.
+        /// </summary>
+        public string DeleteFunction { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorOptions class.
-		/// </summary>
-		public JqGridNavigatorOptions()
-			: base()
-		{
-			Pager = JqGridNavigatorPagers.Standard;
-			AlertCaption = JqGridNavigatorDefaults.AlertCaption;
-			AlertText = JqGridNavigatorDefaults.AlertText;
-			CloneToTop = false;
-			CloseOnEscape = true;
-			Delete = true;
-			DeleteIcon = JqGridNavigatorDefaults.DeleteIcon;
-			DeleteText = string.Empty;
-			DeleteToolTip = JqGridNavigatorDefaults.DeleteToolTip;
-			Refresh = true;
-			RefreshIcon = JqGridNavigatorDefaults.RefreshIcon;
-			RefreshText = string.Empty;
-			RefreshToolTip = JqGridNavigatorDefaults.RefreshToolTip;
-			RefreshMode = JqGridRefreshModes.FirstPage;
-			AfterRefresh = null;
-			BeforeRefresh = null;
-			Search = true;
-			SearchIcon = JqGridNavigatorDefaults.SearchIcon;
-			SearchText = string.Empty;
-			SearchToolTip = JqGridNavigatorDefaults.SearchToolTip;
-			View = false;
-			ViewIcon = JqGridNavigatorDefaults.ViewIcon;
-			ViewText = string.Empty;
-			ViewToolTip = JqGridNavigatorDefaults.ViewToolTip;
-			AddFunction = null;
-			EditFunction = null;
-			DeleteFunction = null;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorOptions class.
+        /// </summary>
+        public JqGridNavigatorOptions()
+            : base()
+        {
+            Pager = JqGridNavigatorPagers.Standard;
+            AlertCaption = JqGridNavigatorDefaults.AlertCaption;
+            AlertText = JqGridNavigatorDefaults.AlertText;
+            CloneToTop = false;
+            CloseOnEscape = true;
+            Delete = true;
+            DeleteIcon = JqGridNavigatorDefaults.DeleteIcon;
+            DeleteText = string.Empty;
+            DeleteToolTip = JqGridNavigatorDefaults.DeleteToolTip;
+            Refresh = true;
+            RefreshIcon = JqGridNavigatorDefaults.RefreshIcon;
+            RefreshText = string.Empty;
+            RefreshToolTip = JqGridNavigatorDefaults.RefreshToolTip;
+            RefreshMode = JqGridRefreshModes.FirstPage;
+            AfterRefresh = null;
+            BeforeRefresh = null;
+            Search = true;
+            SearchIcon = JqGridNavigatorDefaults.SearchIcon;
+            SearchText = string.Empty;
+            SearchToolTip = JqGridNavigatorDefaults.SearchToolTip;
+            View = false;
+            ViewIcon = JqGridNavigatorDefaults.ViewIcon;
+            ViewText = string.Empty;
+            ViewToolTip = JqGridNavigatorDefaults.ViewToolTip;
+            AddFunction = null;
+            EditFunction = null;
+            DeleteFunction = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorOptions.cs
@@ -1,188 +1,184 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator.
-    /// </summary>
-    public class JqGridNavigatorOptions : JqGridNavigatorOptionsBase
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the pager to which the Navigator should be attached to (jqGrid can have only one Navigator).
-        /// </summary>
-        public JqGridNavigatorPagers Pager { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator.
+	/// </summary>
+	public class JqGridNavigatorOptions : JqGridNavigatorOptionsBase
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the pager to which the Navigator should be attached to (jqGrid can have only one Navigator).
+		/// </summary>
+		public JqGridNavigatorPagers Pager { get; set; }
 
-        /// <summary>
-        /// Gets or sets the caption for warning which appears when user try to edit, delete or view a row without selecting it.
-        /// </summary>
-        public string AlertCaption { get; set; }
+		/// <summary>
+		/// Gets or sets the caption for warning which appears when user try to edit, delete or view a row without selecting it.
+		/// </summary>
+		public string AlertCaption { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for warning which appears when user try to edit, delete or view a row without selecting it.
-        /// </summary>
-        public string AlertText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for warning which appears when user try to edit, delete or view a row without selecting it.
+		/// </summary>
+		public string AlertText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if all the actions from the bottom pager should be coppied to the top pager.
-        /// </summary>
-        public bool CloneToTop { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if all the actions from the bottom pager should be coppied to the top pager.
+		/// </summary>
+		public bool CloneToTop { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines if the warning dialog can be closed with ESC key.
-        /// </summary>
-        public bool CloseOnEscape { get; set; }
-        
-        /// <summary>
-        /// Gets or set the value which defines if delete action is enabled (default true).
-        /// </summary>
-        public bool Delete { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines if the warning dialog can be closed with ESC key.
+		/// </summary>
+		public bool CloseOnEscape { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for delete action.
-        /// </summary>
-        public string DeleteIcon { get; set; }
+		/// <summary>
+		/// Gets or set the value which defines if delete action is enabled (default true).
+		/// </summary>
+		public bool Delete { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for delete action.
-        /// </summary>
-        public string DeleteText { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for delete action.
+		/// </summary>
+		public string DeleteIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for delete action.
-        /// </summary>
-        public string DeleteToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the text for delete action.
+		/// </summary>
+		public string DeleteText { get; set; }
 
-        /// <summary>
-        /// Gets or set the value which defines if refresh action is enabled (default true).
-        /// </summary>
-        public bool Refresh { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for delete action.
+		/// </summary>
+		public string DeleteToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for refresh action.
-        /// </summary>
-        public string RefreshIcon { get; set; }
+		/// <summary>
+		/// Gets or set the value which defines if refresh action is enabled (default true).
+		/// </summary>
+		public bool Refresh { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for refresh action.
-        /// </summary>
-        public string RefreshText { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for refresh action.
+		/// </summary>
+		public string RefreshIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for refresh action.
-        /// </summary>
-        public string RefreshToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the text for refresh action.
+		/// </summary>
+		public string RefreshText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the mode for refresh action.
-        /// </summary>
-        public JqGridRefreshModes RefreshMode { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for refresh action.
+		/// </summary>
+		public string RefreshToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the refresh button is clicked.
-        /// </summary>
-        public string AfterRefresh { get; set; }
+		/// <summary>
+		/// Gets or sets the mode for refresh action.
+		/// </summary>
+		public JqGridRefreshModes RefreshMode { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised before the refresh button is clicked.
-        /// </summary>
-        public string BeforeRefresh { get; set; } 
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the refresh button is clicked.
+		/// </summary>
+		public string AfterRefresh { get; set; }
 
-        /// <summary>
-        /// Gets or set the value which defines if search action is enabled (default true).
-        /// </summary>
-        public bool Search { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before the refresh button is clicked.
+		/// </summary>
+		public string BeforeRefresh { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for search action.
-        /// </summary>
-        public string SearchIcon { get; set; }
+		/// <summary>
+		/// Gets or set the value which defines if search action is enabled (default true).
+		/// </summary>
+		public bool Search { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for search action.
-        /// </summary>
-        public string SearchText { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for search action.
+		/// </summary>
+		public string SearchIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for search action.
-        /// </summary>
-        public string SearchToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the text for search action.
+		/// </summary>
+		public string SearchText { get; set; }
 
-        /// <summary>
-        /// Gets or set the value which defines if view action is enabled (default true).
-        /// </summary>
-        public bool View { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for search action.
+		/// </summary>
+		public string SearchToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for view action.
-        /// </summary>
-        public string ViewIcon { get; set; }
+		/// <summary>
+		/// Gets or set the value which defines if view action is enabled (default true).
+		/// </summary>
+		public bool View { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for view action.
-        /// </summary>
-        public string ViewText { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for view action.
+		/// </summary>
+		public string ViewIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for view action.
-        /// </summary>
-        public string ViewToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the text for view action.
+		/// </summary>
+		public string ViewText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the custom function to replace the build in add function.
-        /// </summary>
-        public string AddFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for view action.
+		/// </summary>
+		public string ViewToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or sets the custom function to replace the build in edit function.
-        /// </summary>
-        public string EditFunction { get; set; }
+		/// <summary>
+		/// Gets or sets the custom function to replace the build in add function.
+		/// </summary>
+		public string AddFunction { get; set; }
 
-        /// <summary>
-        /// Gets or sets the custom function to replace the build in delete function.
-        /// </summary>
-        public string DeleteFunction { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the custom function to replace the build in edit function.
+		/// </summary>
+		public string EditFunction { get; set; }
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorOptions class.
-        /// </summary>
-        public JqGridNavigatorOptions()
-            : base()
-        {
-            Pager = JqGridNavigatorPagers.Standard;
-            AlertCaption = JqGridNavigatorDefaults.AlertCaption;
-            AlertText = JqGridNavigatorDefaults.AlertText;
-            CloneToTop = false;
-            CloseOnEscape = true;
-            Delete = true;
-            DeleteIcon = JqGridNavigatorDefaults.DeleteIcon;
-            DeleteText = String.Empty;
-            DeleteToolTip = JqGridNavigatorDefaults.DeleteToolTip;
-            Refresh = true;
-            RefreshIcon = JqGridNavigatorDefaults.RefreshIcon;
-            RefreshText = String.Empty;
-            RefreshToolTip = JqGridNavigatorDefaults.RefreshToolTip;
-            RefreshMode = JqGridRefreshModes.FirstPage;
-            AfterRefresh = null;
-            BeforeRefresh = null;
-            Search = true;
-            SearchIcon = JqGridNavigatorDefaults.SearchIcon;
-            SearchText = String.Empty;
-            SearchToolTip = JqGridNavigatorDefaults.SearchToolTip;
-            View = false;
-            ViewIcon = JqGridNavigatorDefaults.ViewIcon;
-            ViewText = String.Empty;
-            ViewToolTip = JqGridNavigatorDefaults.ViewToolTip;
-            AddFunction = null;
-            EditFunction = null;
-            DeleteFunction = null;
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Gets or sets the custom function to replace the build in delete function.
+		/// </summary>
+		public string DeleteFunction { get; set; }
+		#endregion
+
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorOptions class.
+		/// </summary>
+		public JqGridNavigatorOptions()
+			: base()
+		{
+			Pager = JqGridNavigatorPagers.Standard;
+			AlertCaption = JqGridNavigatorDefaults.AlertCaption;
+			AlertText = JqGridNavigatorDefaults.AlertText;
+			CloneToTop = false;
+			CloseOnEscape = true;
+			Delete = true;
+			DeleteIcon = JqGridNavigatorDefaults.DeleteIcon;
+			DeleteText = string.Empty;
+			DeleteToolTip = JqGridNavigatorDefaults.DeleteToolTip;
+			Refresh = true;
+			RefreshIcon = JqGridNavigatorDefaults.RefreshIcon;
+			RefreshText = string.Empty;
+			RefreshToolTip = JqGridNavigatorDefaults.RefreshToolTip;
+			RefreshMode = JqGridRefreshModes.FirstPage;
+			AfterRefresh = null;
+			BeforeRefresh = null;
+			Search = true;
+			SearchIcon = JqGridNavigatorDefaults.SearchIcon;
+			SearchText = string.Empty;
+			SearchToolTip = JqGridNavigatorDefaults.SearchToolTip;
+			View = false;
+			ViewIcon = JqGridNavigatorDefaults.ViewIcon;
+			ViewText = string.Empty;
+			ViewToolTip = JqGridNavigatorDefaults.ViewToolTip;
+			AddFunction = null;
+			EditFunction = null;
+			DeleteFunction = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorOptionsBase.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorOptionsBase.cs
@@ -3,74 +3,74 @@ using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents base options for jqGrid navigators.
-	/// </summary>
-	public abstract class JqGridNavigatorOptionsBase
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or set the value which defines if add action is enabled (default true).
-		/// </summary>
-		public bool Add { get; set; }
+    /// <summary>
+    /// Class which represents base options for jqGrid navigators.
+    /// </summary>
+    public abstract class JqGridNavigatorOptionsBase
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or set the value which defines if add action is enabled (default true).
+        /// </summary>
+        public bool Add { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for add action.
-		/// </summary>
-		public string AddIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for add action.
+        /// </summary>
+        public string AddIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for add action.
-		/// </summary>
-		public string AddText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for add action.
+        /// </summary>
+        public string AddText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for add action.
-		/// </summary>
-		public string AddToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for add action.
+        /// </summary>
+        public string AddToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or set the value which defines if edit action is enabled (default true).
-		/// </summary>
-		public bool Edit { get; set; }
+        /// <summary>
+        /// Gets or set the value which defines if edit action is enabled (default true).
+        /// </summary>
+        public bool Edit { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon (form UI theme images) for edit action.
-		/// </summary>
-		public string EditIcon { get; set; }
+        /// <summary>
+        /// Gets or sets the icon (form UI theme images) for edit action.
+        /// </summary>
+        public string EditIcon { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for edit action.
-		/// </summary>
-		public string EditText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for edit action.
+        /// </summary>
+        public string EditText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the tooltip for edit action.
-		/// </summary>
-		public string EditToolTip { get; set; }
+        /// <summary>
+        /// Gets or sets the tooltip for edit action.
+        /// </summary>
+        public string EditToolTip { get; set; }
 
-		/// <summary>
-		/// Gets or sets the position of the Navigator buttons in the pager.
-		/// </summary>
-		public JqGridAlignments Position { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the position of the Navigator buttons in the pager.
+        /// </summary>
+        public JqGridAlignments Position { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorOptionsBase class.
-		/// </summary>
-		public JqGridNavigatorOptionsBase()
-		{
-			Add = true;
-			AddIcon = JqGridNavigatorDefaults.AddIcon;
-			AddText = String.Empty;
-			AddToolTip = JqGridNavigatorDefaults.AddToolTip;
-			Edit = true;
-			EditIcon = JqGridNavigatorDefaults.EditIcon;
-			EditText = String.Empty;
-			EditToolTip = JqGridNavigatorDefaults.EditToolTip;
-			Position = JqGridAlignments.Left;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorOptionsBase class.
+        /// </summary>
+        public JqGridNavigatorOptionsBase()
+        {
+            Add = true;
+            AddIcon = JqGridNavigatorDefaults.AddIcon;
+            AddText = String.Empty;
+            AddToolTip = JqGridNavigatorDefaults.AddToolTip;
+            Edit = true;
+            EditIcon = JqGridNavigatorDefaults.EditIcon;
+            EditText = String.Empty;
+            EditToolTip = JqGridNavigatorDefaults.EditToolTip;
+            Position = JqGridAlignments.Left;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorOptionsBase.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorOptionsBase.cs
@@ -1,79 +1,76 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents base options for jqGrid navigators.
-    /// </summary>
-    public abstract class JqGridNavigatorOptionsBase
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or set the value which defines if add action is enabled (default true).
-        /// </summary>
-        public bool Add { get; set; }
+	/// <summary>
+	/// Class which represents base options for jqGrid navigators.
+	/// </summary>
+	public abstract class JqGridNavigatorOptionsBase
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or set the value which defines if add action is enabled (default true).
+		/// </summary>
+		public bool Add { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for add action.
-        /// </summary>
-        public string AddIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for add action.
+		/// </summary>
+		public string AddIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for add action.
-        /// </summary>
-        public string AddText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for add action.
+		/// </summary>
+		public string AddText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for add action.
-        /// </summary>
-        public string AddToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for add action.
+		/// </summary>
+		public string AddToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or set the value which defines if edit action is enabled (default true).
-        /// </summary>
-        public bool Edit { get; set; }
+		/// <summary>
+		/// Gets or set the value which defines if edit action is enabled (default true).
+		/// </summary>
+		public bool Edit { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon (form UI theme images) for edit action.
-        /// </summary>
-        public string EditIcon { get; set; }
+		/// <summary>
+		/// Gets or sets the icon (form UI theme images) for edit action.
+		/// </summary>
+		public string EditIcon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for edit action.
-        /// </summary>
-        public string EditText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for edit action.
+		/// </summary>
+		public string EditText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tooltip for edit action.
-        /// </summary>
-        public string EditToolTip { get; set; }
+		/// <summary>
+		/// Gets or sets the tooltip for edit action.
+		/// </summary>
+		public string EditToolTip { get; set; }
 
-        /// <summary>
-        /// Gets or sets the position of the Navigator buttons in the pager.
-        /// </summary>
-        public JqGridAlignments Position { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the position of the Navigator buttons in the pager.
+		/// </summary>
+		public JqGridAlignments Position { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorOptionsBase class.
-        /// </summary>
-        public JqGridNavigatorOptionsBase()
-        {
-            Add = true;
-            AddIcon = JqGridNavigatorDefaults.AddIcon;
-            AddText = String.Empty;
-            AddToolTip = JqGridNavigatorDefaults.AddToolTip;
-            Edit = true;
-            EditIcon = JqGridNavigatorDefaults.EditIcon;
-            EditText = String.Empty;
-            EditToolTip = JqGridNavigatorDefaults.EditToolTip;
-            Position = JqGridAlignments.Left;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorOptionsBase class.
+		/// </summary>
+		public JqGridNavigatorOptionsBase()
+		{
+			Add = true;
+			AddIcon = JqGridNavigatorDefaults.AddIcon;
+			AddText = String.Empty;
+			AddToolTip = JqGridNavigatorDefaults.AddToolTip;
+			Edit = true;
+			EditIcon = JqGridNavigatorDefaults.EditIcon;
+			EditText = String.Empty;
+			EditToolTip = JqGridNavigatorDefaults.EditToolTip;
+			Position = JqGridAlignments.Left;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorPagers.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorPagers.cs
@@ -1,17 +1,17 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available pagers that jqGrid Navigator can be attached to.
-	/// </summary>
-	public enum JqGridNavigatorPagers
-	{
-		/// <summary>
-		/// Standard pager.
-		/// </summary>
-		Standard,
-		/// <summary>
-		/// Top pager.
-		/// </summary>
-		Top
-	}
+    /// <summary>
+    /// Defines available pagers that jqGrid Navigator can be attached to.
+    /// </summary>
+    public enum JqGridNavigatorPagers
+    {
+        /// <summary>
+        /// Standard pager.
+        /// </summary>
+        Standard,
+        /// <summary>
+        /// Top pager.
+        /// </summary>
+        Top
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorPagers.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorPagers.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available pagers that jqGrid Navigator can be attached to.
-    /// </summary>
-    public enum JqGridNavigatorPagers
-    {
-        /// <summary>
-        /// Standard pager.
-        /// </summary>
-        Standard,
-        /// <summary>
-        /// Top pager.
-        /// </summary>
-        Top
-    }
+	/// <summary>
+	/// Defines available pagers that jqGrid Navigator can be attached to.
+	/// </summary>
+	public enum JqGridNavigatorPagers
+	{
+		/// <summary>
+		/// Standard pager.
+		/// </summary>
+		Standard,
+		/// <summary>
+		/// Top pager.
+		/// </summary>
+		Top
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorSearchActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorSearchActionOptions.cs
@@ -1,152 +1,149 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator search action.
-    /// </summary>
-    public class JqGridNavigatorSearchActionOptions : JqGridNavigatorActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the function for event which is raised every time the filter is redrawed .
-        /// </summary>
-        public string AfterRedraw { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator search action.
+	/// </summary>
+	public class JqGridNavigatorSearchActionOptions : JqGridNavigatorActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the function for event which is raised every time the filter is redrawed .
+		/// </summary>
+		public string AfterRedraw { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised every time after the search dialog is shown.
-        /// </summary>
-        public string AfterShowSearch { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised every time after the search dialog is shown.
+		/// </summary>
+		public string AfterShowSearch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised every time before the search dialog is shown.
-        /// </summary>
-        public string BeforeShowSearch { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised every time before the search dialog is shown.
+		/// </summary>
+		public string BeforeShowSearch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the caption for the dialog.
-        /// </summary>
-        public string Caption { get; set; }
+		/// <summary>
+		/// Gets or sets the caption for the dialog.
+		/// </summary>
+		public string Caption { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if search action dialog should be closed after searching.
-        /// </summary>
-        public bool CloseAfterSearch { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if search action dialog should be closed after searching.
+		/// </summary>
+		public bool CloseAfterSearch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if search action dialog should be closed after reseting.
-        /// </summary>
-        public bool CloseAfterReset { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if search action dialog should be closed after reseting.
+		/// </summary>
+		public bool CloseAfterReset { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the SearchRules should be validated.
-        /// </summary>
-        public bool ErrorCheck { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the SearchRules should be validated.
+		/// </summary>
+		public bool ErrorCheck { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for search button.
-        /// </summary>
-        public string SearchText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for search button.
+		/// </summary>
+		public string SearchText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if advanced searching is enabled.
-        /// </summary>
-        public bool AdvancedSearching { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if advanced searching is enabled.
+		/// </summary>
+		public bool AdvancedSearching { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if advanced searching with a possibilities to define a complex condfitions is enabled.
-        /// </summary>
-        public bool AdvancedSearchingWithGroups { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if advanced searching with a possibilities to define a complex condfitions is enabled.
+		/// </summary>
+		public bool AdvancedSearchingWithGroups { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if added row (in advanced searching) should be copied from previous row.
-        /// </summary>
-        public bool CloneSearchRowOnAdd { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if added row (in advanced searching) should be copied from previous row.
+		/// </summary>
+		public bool CloneSearchRowOnAdd { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised once when the dialog is created.
-        /// </summary>
-        public string OnInitializeSearch { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised once when the dialog is created.
+		/// </summary>
+		public string OnInitializeSearch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised when the reset button is activated.
-        /// </summary>
-        public string OnReset { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when the reset button is activated.
+		/// </summary>
+		public string OnReset { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function for event which is raised when the search button is activated.
-        /// </summary>
-        public string OnSearch { get; set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when the search button is activated.
+		/// </summary>
+		public string OnSearch { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the entry filter should be destroyed unbinding all the events and then constructed again.
-        /// </summary>
-        public bool RecreateFilter { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the entry filter should be destroyed unbinding all the events and then constructed again.
+		/// </summary>
+		public bool RecreateFilter { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text for reset button.
-        /// </summary>
-        public string ResetText { get; set; }
+		/// <summary>
+		/// Gets or sets the text for reset button.
+		/// </summary>
+		public string ResetText { get; set; }
 
-        /// <summary>
-        /// Gets or sets the available search operators for the searching (if not defined on column).
-        /// </summary>
-        public JqGridSearchOperators? SearchOperators { get; set; }
+		/// <summary>
+		/// Gets or sets the available search operators for the searching (if not defined on column).
+		/// </summary>
+		public JqGridSearchOperators? SearchOperators { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the dialog should appear automatically when the grid is constructed for first time.
-        /// </summary>
-        public bool ShowOnLoad { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the dialog should appear automatically when the grid is constructed for first time.
+		/// </summary>
+		public bool ShowOnLoad { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the query which is generated when the user defines the conditions for the search should be shown.
-        /// </summary>
-        public bool ShowQuery { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the query which is generated when the user defines the conditions for the search should be shown.
+		/// </summary>
+		public bool ShowQuery { get; set; }
 
-        /// <summary>
-        /// Gets or sets the filters templates for advanced searching and avanced searching with groups.
-        /// </summary>
-        public IDictionary<string, JqGridRequestSearchingFilters> Templates { get; set; }
+		/// <summary>
+		/// Gets or sets the filters templates for advanced searching and avanced searching with groups.
+		/// </summary>
+		public IDictionary<string, JqGridRequestSearchingFilters> Templates { get; set; }
 
-        /// <summary>
-        /// Gets or sets the valid DOM id of the element into which the filter is inserted as child.
-        /// </summary>
-        public string Layer { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the valid DOM id of the element into which the filter is inserted as child.
+		/// </summary>
+		public string Layer { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorSearchActionOptions class.
-        /// </summary>
-        public JqGridNavigatorSearchActionOptions()
-            : base()
-        {
-            Width = 450;
-            AfterRedraw = null;
-            AfterShowSearch = null;
-            BeforeShowSearch = null;
-            Caption = null;
-            CloseAfterSearch = false;
-            CloseAfterReset = false;
-            ErrorCheck = true;
-            SearchText = null;
-            AdvancedSearching = false;
-            AdvancedSearchingWithGroups = false;
-            CloneSearchRowOnAdd = true;
-            OnInitializeSearch = null;
-            OnReset = null;
-            OnSearch = null;
-            RecreateFilter = false;
-            ResetText = null;
-            SearchOperators = null;
-            ShowOnLoad = false;
-            ShowQuery = false;
-            Templates = null;
-            Layer = null;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorSearchActionOptions class.
+		/// </summary>
+		public JqGridNavigatorSearchActionOptions()
+			: base()
+		{
+			Width = 450;
+			AfterRedraw = null;
+			AfterShowSearch = null;
+			BeforeShowSearch = null;
+			Caption = null;
+			CloseAfterSearch = false;
+			CloseAfterReset = false;
+			ErrorCheck = true;
+			SearchText = null;
+			AdvancedSearching = false;
+			AdvancedSearchingWithGroups = false;
+			CloneSearchRowOnAdd = true;
+			OnInitializeSearch = null;
+			OnReset = null;
+			OnSearch = null;
+			RecreateFilter = false;
+			ResetText = null;
+			SearchOperators = null;
+			ShowOnLoad = false;
+			ShowQuery = false;
+			Templates = null;
+			Layer = null;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorSearchActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorSearchActionOptions.cs
@@ -2,148 +2,148 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator search action.
-	/// </summary>
-	public class JqGridNavigatorSearchActionOptions : JqGridNavigatorActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the function for event which is raised every time the filter is redrawed .
-		/// </summary>
-		public string AfterRedraw { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator search action.
+    /// </summary>
+    public class JqGridNavigatorSearchActionOptions : JqGridNavigatorActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the function for event which is raised every time the filter is redrawed .
+        /// </summary>
+        public string AfterRedraw { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised every time after the search dialog is shown.
-		/// </summary>
-		public string AfterShowSearch { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised every time after the search dialog is shown.
+        /// </summary>
+        public string AfterShowSearch { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised every time before the search dialog is shown.
-		/// </summary>
-		public string BeforeShowSearch { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised every time before the search dialog is shown.
+        /// </summary>
+        public string BeforeShowSearch { get; set; }
 
-		/// <summary>
-		/// Gets or sets the caption for the dialog.
-		/// </summary>
-		public string Caption { get; set; }
+        /// <summary>
+        /// Gets or sets the caption for the dialog.
+        /// </summary>
+        public string Caption { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if search action dialog should be closed after searching.
-		/// </summary>
-		public bool CloseAfterSearch { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if search action dialog should be closed after searching.
+        /// </summary>
+        public bool CloseAfterSearch { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if search action dialog should be closed after reseting.
-		/// </summary>
-		public bool CloseAfterReset { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if search action dialog should be closed after reseting.
+        /// </summary>
+        public bool CloseAfterReset { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the SearchRules should be validated.
-		/// </summary>
-		public bool ErrorCheck { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the SearchRules should be validated.
+        /// </summary>
+        public bool ErrorCheck { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for search button.
-		/// </summary>
-		public string SearchText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for search button.
+        /// </summary>
+        public string SearchText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if advanced searching is enabled.
-		/// </summary>
-		public bool AdvancedSearching { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if advanced searching is enabled.
+        /// </summary>
+        public bool AdvancedSearching { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if advanced searching with a possibilities to define a complex condfitions is enabled.
-		/// </summary>
-		public bool AdvancedSearchingWithGroups { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if advanced searching with a possibilities to define a complex condfitions is enabled.
+        /// </summary>
+        public bool AdvancedSearchingWithGroups { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if added row (in advanced searching) should be copied from previous row.
-		/// </summary>
-		public bool CloneSearchRowOnAdd { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if added row (in advanced searching) should be copied from previous row.
+        /// </summary>
+        public bool CloneSearchRowOnAdd { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised once when the dialog is created.
-		/// </summary>
-		public string OnInitializeSearch { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised once when the dialog is created.
+        /// </summary>
+        public string OnInitializeSearch { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised when the reset button is activated.
-		/// </summary>
-		public string OnReset { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when the reset button is activated.
+        /// </summary>
+        public string OnReset { get; set; }
 
-		/// <summary>
-		/// Gets or sets the function for event which is raised when the search button is activated.
-		/// </summary>
-		public string OnSearch { get; set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when the search button is activated.
+        /// </summary>
+        public string OnSearch { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the entry filter should be destroyed unbinding all the events and then constructed again.
-		/// </summary>
-		public bool RecreateFilter { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the entry filter should be destroyed unbinding all the events and then constructed again.
+        /// </summary>
+        public bool RecreateFilter { get; set; }
 
-		/// <summary>
-		/// Gets or sets the text for reset button.
-		/// </summary>
-		public string ResetText { get; set; }
+        /// <summary>
+        /// Gets or sets the text for reset button.
+        /// </summary>
+        public string ResetText { get; set; }
 
-		/// <summary>
-		/// Gets or sets the available search operators for the searching (if not defined on column).
-		/// </summary>
-		public JqGridSearchOperators? SearchOperators { get; set; }
+        /// <summary>
+        /// Gets or sets the available search operators for the searching (if not defined on column).
+        /// </summary>
+        public JqGridSearchOperators? SearchOperators { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the dialog should appear automatically when the grid is constructed for first time.
-		/// </summary>
-		public bool ShowOnLoad { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the dialog should appear automatically when the grid is constructed for first time.
+        /// </summary>
+        public bool ShowOnLoad { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the query which is generated when the user defines the conditions for the search should be shown.
-		/// </summary>
-		public bool ShowQuery { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the query which is generated when the user defines the conditions for the search should be shown.
+        /// </summary>
+        public bool ShowQuery { get; set; }
 
-		/// <summary>
-		/// Gets or sets the filters templates for advanced searching and avanced searching with groups.
-		/// </summary>
-		public IDictionary<string, JqGridRequestSearchingFilters> Templates { get; set; }
+        /// <summary>
+        /// Gets or sets the filters templates for advanced searching and avanced searching with groups.
+        /// </summary>
+        public IDictionary<string, JqGridRequestSearchingFilters> Templates { get; set; }
 
-		/// <summary>
-		/// Gets or sets the valid DOM id of the element into which the filter is inserted as child.
-		/// </summary>
-		public string Layer { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the valid DOM id of the element into which the filter is inserted as child.
+        /// </summary>
+        public string Layer { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorSearchActionOptions class.
-		/// </summary>
-		public JqGridNavigatorSearchActionOptions()
-			: base()
-		{
-			Width = 450;
-			AfterRedraw = null;
-			AfterShowSearch = null;
-			BeforeShowSearch = null;
-			Caption = null;
-			CloseAfterSearch = false;
-			CloseAfterReset = false;
-			ErrorCheck = true;
-			SearchText = null;
-			AdvancedSearching = false;
-			AdvancedSearchingWithGroups = false;
-			CloneSearchRowOnAdd = true;
-			OnInitializeSearch = null;
-			OnReset = null;
-			OnSearch = null;
-			RecreateFilter = false;
-			ResetText = null;
-			SearchOperators = null;
-			ShowOnLoad = false;
-			ShowQuery = false;
-			Templates = null;
-			Layer = null;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorSearchActionOptions class.
+        /// </summary>
+        public JqGridNavigatorSearchActionOptions()
+            : base()
+        {
+            Width = 450;
+            AfterRedraw = null;
+            AfterShowSearch = null;
+            BeforeShowSearch = null;
+            Caption = null;
+            CloseAfterSearch = false;
+            CloseAfterReset = false;
+            ErrorCheck = true;
+            SearchText = null;
+            AdvancedSearching = false;
+            AdvancedSearchingWithGroups = false;
+            CloneSearchRowOnAdd = true;
+            OnInitializeSearch = null;
+            OnReset = null;
+            OnSearch = null;
+            RecreateFilter = false;
+            ResetText = null;
+            SearchOperators = null;
+            ShowOnLoad = false;
+            ShowQuery = false;
+            Templates = null;
+            Layer = null;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorSeparatorOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorSeparatorOptions.cs
@@ -2,32 +2,32 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator separator.
-	/// </summary>
-	public class JqGridNavigatorSeparatorOptions : JqGridNavigatorControlOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the class for the separator.
-		/// </summary>
-		public string Class { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator separator.
+    /// </summary>
+    public class JqGridNavigatorSeparatorOptions : JqGridNavigatorControlOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the class for the separator.
+        /// </summary>
+        public string Class { get; set; }
 
-		/// <summary>
-		/// Gets or sets the content for the separator.
-		/// </summary>
-		public string Content { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the content for the separator.
+        /// </summary>
+        public string Content { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorSeparatorOptions class.
-		/// </summary>
-		public JqGridNavigatorSeparatorOptions()
-		{
-			Class = JqGridNavigatorDefaults.SeparatorClass;
-			Content = string.Empty;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorSeparatorOptions class.
+        /// </summary>
+        public JqGridNavigatorSeparatorOptions()
+        {
+            Class = JqGridNavigatorDefaults.SeparatorClass;
+            Content = string.Empty;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorSeparatorOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorSeparatorOptions.cs
@@ -1,38 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator separator.
-    /// </summary>
-    public class JqGridNavigatorSeparatorOptions : JqGridNavigatorControlOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the class for the separator.
-        /// </summary>
-        public string Class { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator separator.
+	/// </summary>
+	public class JqGridNavigatorSeparatorOptions : JqGridNavigatorControlOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the class for the separator.
+		/// </summary>
+		public string Class { get; set; }
 
-        /// <summary>
-        /// Gets or sets the content for the separator.
-        /// </summary>
-        public string Content { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the content for the separator.
+		/// </summary>
+		public string Content { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorSeparatorOptions class.
-        /// </summary>
-        public JqGridNavigatorSeparatorOptions()
-            : base()
-        {
-            Class = JqGridNavigatorDefaults.SeparatorClass;
-            Content = String.Empty;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorSeparatorOptions class.
+		/// </summary>
+		public JqGridNavigatorSeparatorOptions()
+		{
+			Class = JqGridNavigatorDefaults.SeparatorClass;
+			Content = string.Empty;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorViewActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorViewActionOptions.cs
@@ -1,50 +1,50 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents options for jqGrid Navigator view action.
-	/// </summary>
-	public class JqGridNavigatorViewActionOptions : JqGridNavigatorFormActionOptions, IJqGridNavigatorPageableFormActionOptions
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the options for keyboard navigation.
-		/// </summary>
-		public JqGridFormKeyboardNavigation NavigationKeys { get; set; }
+    /// <summary>
+    /// Class which represents options for jqGrid Navigator view action.
+    /// </summary>
+    public class JqGridNavigatorViewActionOptions : JqGridNavigatorFormActionOptions, IJqGridNavigatorPageableFormActionOptions
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the options for keyboard navigation.
+        /// </summary>
+        public JqGridFormKeyboardNavigation NavigationKeys { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the pager buttons should appear on the form.
-		/// </summary>
-		public bool ViewPagerButtons { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the pager buttons should appear on the form.
+        /// </summary>
+        public bool ViewPagerButtons { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
-		/// </summary>
-		public bool RecreateForm { get; set; }
+        /// <summary>
+        /// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
+        /// </summary>
+        public bool RecreateForm { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines how much width is needed for the labels.
-		/// </summary>
-		public string LabelsWidth { get; set; }
+        /// <summary>
+        /// Gets or sets the value which defines how much width is needed for the labels.
+        /// </summary>
+        public string LabelsWidth { get; set; }
 
-		/// <summary>
-		/// Gets or sets the icon for the close button.
-		/// </summary>
-		public JqGridFormButtonIcon CloseButtonIcon { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the icon for the close button.
+        /// </summary>
+        public JqGridFormButtonIcon CloseButtonIcon { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNavigatorViewActionOptions class.
-		/// </summary>
-		public JqGridNavigatorViewActionOptions()
-		{
-			Width = 0;
-			NavigationKeys = new JqGridFormKeyboardNavigation();
-			ViewPagerButtons = true;
-			RecreateForm = false;
-			LabelsWidth = "30%";
-			CloseButtonIcon = JqGridFormButtonIcon.CloseIcon;
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNavigatorViewActionOptions class.
+        /// </summary>
+        public JqGridNavigatorViewActionOptions()
+        {
+            Width = 0;
+            NavigationKeys = new JqGridFormKeyboardNavigation();
+            ViewPagerButtons = true;
+            RecreateForm = false;
+            LabelsWidth = "30%";
+            CloseButtonIcon = JqGridFormButtonIcon.CloseIcon;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorViewActionOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNavigatorViewActionOptions.cs
@@ -1,55 +1,50 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents options for jqGrid Navigator view action.
-    /// </summary>
-    public class JqGridNavigatorViewActionOptions : JqGridNavigatorFormActionOptions, IJqGridNavigatorPageableFormActionOptions
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the options for keyboard navigation.
-        /// </summary>
-        public JqGridFormKeyboardNavigation NavigationKeys { get; set; }
+	/// <summary>
+	/// Class which represents options for jqGrid Navigator view action.
+	/// </summary>
+	public class JqGridNavigatorViewActionOptions : JqGridNavigatorFormActionOptions, IJqGridNavigatorPageableFormActionOptions
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the options for keyboard navigation.
+		/// </summary>
+		public JqGridFormKeyboardNavigation NavigationKeys { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the pager buttons should appear on the form.
-        /// </summary>
-        public bool ViewPagerButtons { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the pager buttons should appear on the form.
+		/// </summary>
+		public bool ViewPagerButtons { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
-        /// </summary>
-        public bool RecreateForm { get; set; }
+		/// <summary>
+		/// Gets or sets the value indicating if the form should be recreated every time the dialog is activeted with the new options from colModel (if they are changed).
+		/// </summary>
+		public bool RecreateForm { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines how much width is needed for the labels.
-        /// </summary>
-        public string LabelsWidth { get; set; }
+		/// <summary>
+		/// Gets or sets the value which defines how much width is needed for the labels.
+		/// </summary>
+		public string LabelsWidth { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon for the close button.
-        /// </summary>
-        public JqGridFormButtonIcon CloseButtonIcon { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the icon for the close button.
+		/// </summary>
+		public JqGridFormButtonIcon CloseButtonIcon { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNavigatorViewActionOptions class.
-        /// </summary>
-        public JqGridNavigatorViewActionOptions()
-        {
-            Width = 0;
-            NavigationKeys = new JqGridFormKeyboardNavigation();
-            ViewPagerButtons = true;
-            RecreateForm = false;
-            LabelsWidth = "30%";
-            CloseButtonIcon = JqGridFormButtonIcon.CloseIcon;
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNavigatorViewActionOptions class.
+		/// </summary>
+		public JqGridNavigatorViewActionOptions()
+		{
+			Width = 0;
+			NavigationKeys = new JqGridFormKeyboardNavigation();
+			ViewPagerButtons = true;
+			RecreateForm = false;
+			LabelsWidth = "30%";
+			CloseButtonIcon = JqGridFormButtonIcon.CloseIcon;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNestedSetTreeRecord.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNestedSetTreeRecord.cs
@@ -1,57 +1,54 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents TreeGrid record for jqGrid in nested set model.
-    /// </summary>
-    public class JqGridNestedSetTreeRecord : JqGridTreeRecord
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the rowid of the record to the left.
-        /// </summary>
-        public int LeftField { get; private set; }
+	/// <summary>
+	/// Class which represents TreeGrid record for jqGrid in nested set model.
+	/// </summary>
+	public class JqGridNestedSetTreeRecord : JqGridTreeRecord
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the rowid of the record to the left.
+		/// </summary>
+		public int LeftField { get; private set; }
 
-        /// <summary>
-        /// Gets the rowid of the record to the right.
-        /// </summary>
-        public int RightField { get; private set; }
-        #endregion
+		/// <summary>
+		/// Gets the rowid of the record to the right.
+		/// </summary>
+		public int RightField { get; private set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNestedSetTreeRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="values">The record cells values.</param>
-        /// <param name="level">The level of the record in the hierarchy.</param>
-        /// <param name="leftField">The rowid of the record to the left.</param>
-        /// <param name="rightField">The rowid of the record to the right.</param>
-        public JqGridNestedSetTreeRecord(string id, List<object> values, int level, int leftField, int rightField)
-            : base(id, values, level)
-        {
-            LeftField = leftField;
-            RightField = rightField;
-        }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNestedSetTreeRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="values">The record cells values.</param>
+		/// <param name="level">The level of the record in the hierarchy.</param>
+		/// <param name="leftField">The rowid of the record to the left.</param>
+		/// <param name="rightField">The rowid of the record to the right.</param>
+		public JqGridNestedSetTreeRecord(string id, List<object> values, int level, int leftField, int rightField)
+			: base(id, values, level)
+		{
+			LeftField = leftField;
+			RightField = rightField;
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridNestedSetTreeRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="value">The record value.</param>
-        /// <param name="level">The level of the record in the hierarchy.</param>
-        /// <param name="leftField">The rowid of the record to the left.</param>
-        /// <param name="rightField">The rowid of the record to the right.</param>
-        public JqGridNestedSetTreeRecord(string id, object value, int level, int leftField, int rightField)
-            : base(id, value, level)
-        {
-            LeftField = leftField;
-            RightField = rightField;
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Initializes a new instance of the JqGridNestedSetTreeRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="value">The record value.</param>
+		/// <param name="level">The level of the record in the hierarchy.</param>
+		/// <param name="leftField">The rowid of the record to the left.</param>
+		/// <param name="rightField">The rowid of the record to the right.</param>
+		public JqGridNestedSetTreeRecord(string id, object value, int level, int leftField, int rightField)
+			: base(id, value, level)
+		{
+			LeftField = leftField;
+			RightField = rightField;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNestedSetTreeRecord.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNestedSetTreeRecord.cs
@@ -2,53 +2,53 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents TreeGrid record for jqGrid in nested set model.
-	/// </summary>
-	public class JqGridNestedSetTreeRecord : JqGridTreeRecord
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the rowid of the record to the left.
-		/// </summary>
-		public int LeftField { get; private set; }
+    /// <summary>
+    /// Class which represents TreeGrid record for jqGrid in nested set model.
+    /// </summary>
+    public class JqGridNestedSetTreeRecord : JqGridTreeRecord
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the rowid of the record to the left.
+        /// </summary>
+        public int LeftField { get; private set; }
 
-		/// <summary>
-		/// Gets the rowid of the record to the right.
-		/// </summary>
-		public int RightField { get; private set; }
-		#endregion
+        /// <summary>
+        /// Gets the rowid of the record to the right.
+        /// </summary>
+        public int RightField { get; private set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNestedSetTreeRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="values">The record cells values.</param>
-		/// <param name="level">The level of the record in the hierarchy.</param>
-		/// <param name="leftField">The rowid of the record to the left.</param>
-		/// <param name="rightField">The rowid of the record to the right.</param>
-		public JqGridNestedSetTreeRecord(string id, List<object> values, int level, int leftField, int rightField)
-			: base(id, values, level)
-		{
-			LeftField = leftField;
-			RightField = rightField;
-		}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNestedSetTreeRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="values">The record cells values.</param>
+        /// <param name="level">The level of the record in the hierarchy.</param>
+        /// <param name="leftField">The rowid of the record to the left.</param>
+        /// <param name="rightField">The rowid of the record to the right.</param>
+        public JqGridNestedSetTreeRecord(string id, List<object> values, int level, int leftField, int rightField)
+            : base(id, values, level)
+        {
+            LeftField = leftField;
+            RightField = rightField;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridNestedSetTreeRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="value">The record value.</param>
-		/// <param name="level">The level of the record in the hierarchy.</param>
-		/// <param name="leftField">The rowid of the record to the left.</param>
-		/// <param name="rightField">The rowid of the record to the right.</param>
-		public JqGridNestedSetTreeRecord(string id, object value, int level, int leftField, int rightField)
-			: base(id, value, level)
-		{
-			LeftField = leftField;
-			RightField = rightField;
-		}
-		#endregion
-	}
+        /// <summary>
+        /// Initializes a new instance of the JqGridNestedSetTreeRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="value">The record value.</param>
+        /// <param name="level">The level of the record in the hierarchy.</param>
+        /// <param name="leftField">The rowid of the record to the left.</param>
+        /// <param name="rightField">The rowid of the record to the right.</param>
+        public JqGridNestedSetTreeRecord(string id, object value, int level, int leftField, int rightField)
+            : base(id, value, level)
+        {
+            LeftField = leftField;
+            RightField = rightField;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNestedSetTreeRecord`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNestedSetTreeRecord`1.cs
@@ -1,28 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents TreeGrid record for jqGrid in nested set model.
-    /// </summary>
-    /// <typeparam name="TModel">Type of model for this grid</typeparam>
-    public class JqGridNestedSetTreeRecord<TModel> : JqGridNestedSetTreeRecord
-    {
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridNestedSetTreeRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="value">The record value.</param>
-        /// <param name="level">The level of the record in the hierarchy.</param>
-        /// <param name="leftField">The rowid of the record to the left.</param>
-        /// <param name="rightField">The rowid of the record to the right.</param>
-        public JqGridNestedSetTreeRecord(string id, TModel value, int level, int leftField, int rightField)
-            : base(id, value, level, leftField, rightField)
-        { }
-        #endregion
-    }
+	/// <summary>
+	/// Class which represents TreeGrid record for jqGrid in nested set model.
+	/// </summary>
+	/// <typeparam name="TModel">Type of model for this grid</typeparam>
+	public class JqGridNestedSetTreeRecord<TModel> : JqGridNestedSetTreeRecord
+	{
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridNestedSetTreeRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="value">The record value.</param>
+		/// <param name="level">The level of the record in the hierarchy.</param>
+		/// <param name="leftField">The rowid of the record to the left.</param>
+		/// <param name="rightField">The rowid of the record to the right.</param>
+		public JqGridNestedSetTreeRecord(string id, TModel value, int level, int leftField, int rightField)
+			: base(id, value, level, leftField, rightField)
+		{ }
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNestedSetTreeRecord`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNestedSetTreeRecord`1.cs
@@ -1,23 +1,23 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents TreeGrid record for jqGrid in nested set model.
-	/// </summary>
-	/// <typeparam name="TModel">Type of model for this grid</typeparam>
-	public class JqGridNestedSetTreeRecord<TModel> : JqGridNestedSetTreeRecord
-	{
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridNestedSetTreeRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="value">The record value.</param>
-		/// <param name="level">The level of the record in the hierarchy.</param>
-		/// <param name="leftField">The rowid of the record to the left.</param>
-		/// <param name="rightField">The rowid of the record to the right.</param>
-		public JqGridNestedSetTreeRecord(string id, TModel value, int level, int leftField, int rightField)
-			: base(id, value, level, leftField, rightField)
-		{ }
-		#endregion
-	}
+    /// <summary>
+    /// Class which represents TreeGrid record for jqGrid in nested set model.
+    /// </summary>
+    /// <typeparam name="TModel">Type of model for this grid</typeparam>
+    public class JqGridNestedSetTreeRecord<TModel> : JqGridNestedSetTreeRecord
+    {
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridNestedSetTreeRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="value">The record value.</param>
+        /// <param name="level">The level of the record in the hierarchy.</param>
+        /// <param name="leftField">The rowid of the record to the left.</param>
+        /// <param name="rightField">The rowid of the record to the right.</param>
+        public JqGridNestedSetTreeRecord(string id, TModel value, int level, int leftField, int rightField)
+            : base(id, value, level, leftField, rightField)
+        { }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNewRowPositions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNewRowPositions.cs
@@ -1,22 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available position for new row (inline editing)
-    /// </summary>
-    public enum JqGridNewRowPositions
-    {
-        /// <summary>
-        /// Add new row as first.
-        /// </summary>
-        First,
-        /// <summary>
-        /// Add new row as last.
-        /// </summary>
-        Last
-    }
+	/// <summary>
+	/// Defines available position for new row (inline editing)
+	/// </summary>
+	public enum JqGridNewRowPositions
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Add new row as first.
+		/// </summary>
+		First,
+		/// <summary>
+		/// Add new row as last.
+		/// </summary>
+		Last
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridNewRowPositions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridNewRowPositions.cs
@@ -1,21 +1,21 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available position for new row (inline editing)
-	/// </summary>
-	public enum JqGridNewRowPositions
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Add new row as first.
-		/// </summary>
-		First,
-		/// <summary>
-		/// Add new row as last.
-		/// </summary>
-		Last
-	}
+    /// <summary>
+    /// Defines available position for new row (inline editing)
+    /// </summary>
+    public enum JqGridNewRowPositions
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Add new row as first.
+        /// </summary>
+        First,
+        /// <summary>
+        /// Add new row as last.
+        /// </summary>
+        Last
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridOptions.cs
@@ -6,1074 +6,1074 @@ using System.Web.UI.WebControls.WebParts;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Options passed to helper's constructor
-	/// </summary>
-	public class JqGridOptions
-	{
-		#region Fields
-		private string _afterInsertRow;
-		private string _afterEditCell;
-		private string _afterRestoreCell;
-		private string _afterSaveCell;
-		private string _afterSubmitCell;
-		private string _altClass;
-		private string _beforeRequest;
-		private string _beforeSelectRow;
-		private string _beforeEditCell;
-		private string _beforeSaveCell;
-		private string _beforeSubmitCell;
-		private string _beforeProcessing;
-		private string _caption;
-		private string _cellEditingUrl;
-		private string _editingUrl;
-		private string _emptyRecords;
-		private string _expandColumn;
-		private string _errorCell;
-		private string _formatCell;
-		private string _gridComplete;
-		private string _loadBeforeSend;
-		private string _loadComplete;
-		private string _loadError;
-		private string _onCellSelect;
-		private string _onDoubleClickRow;
-		private string _onHeaderClick;
-		private string _onInitGrid;
-		private string _onPaging;
-		private string _onRightClickRow;
-		private string _onSelectAll;
-		private string _onSelectCell;
-		private string _onSelectRow;
-		private string _onSortCol;
-		private object _postData;
-		private string _postDataScript;
-		private string _resizeStart;
-		private string _resizeStop;
-		private string _rowAttributes;
-		private string _serializeCellData;
-		private string _serializeGridData;
-		private string _serializeSubGridData;
-		private string _sortingName;
-		private string _subgridUrl;
-		private string _subGridBeforeExpand;
-		private string _subGridRowExpanded;
-		private string _subGridRowColapsed;
-		private string _url;
-
-		#endregion
-
-		#region Properties
-
-		/// <summary>
-		/// Gets the grid identifier which will be used for table (id='{0}'), pager div (id='{0}Pager') and in JavaScript.
-		/// </summary>
-		public string Id { get; }
-
-		/// <summary>
-		/// Gets the list of columns parameters descriptions.
-		/// </summary>
-		public List<JqGridColumnModel> ColumnsModels { get; private set; }
-
-		/// <summary>
-		/// Gets the list of columns names.
-		/// </summary>
-		public List<string> ColumnsNames { get; private set; }
-
-		/// <summary>
-		/// Gets or sets the list of columns indexes for remaping (default null).
-		/// </summary>
-		public List<int> ColumnsRemaping { get; set; }
-
-		/// <summary>
-		/// Gets or sets default compatibility mode
-		/// </summary>
-		public static JqGridCompatibilityModes DefaultCompatibilityMode { get; set; } = JqGridCompatibilityModes.JqGrid;
-
-		/// <summary>
-		/// Gets or sets the jqGrid compatibility mode.
-		/// </summary>
-		public JqGridCompatibilityModes CompatibilityMode { get; set; } = DefaultCompatibilityMode;
-
-		internal bool IsAfterInsertRowSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after every inserted row.
-		/// </summary>
-		public string AfterInsertRow
-		{
-			get => _afterInsertRow;
-			set
-			{
-				_afterInsertRow = value;
-				IsAfterInsertRowSetted = true;
-			}
-		}
-
-		internal bool IsAfterEditCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the edited cell is edited.
-		/// </summary>
-		public string AfterEditCell
-		{
-			get => _afterEditCell;
-			set
-			{
-				_afterEditCell = value;
-				IsAfterInsertRowSetted = true;
-			}
-		}
-
-		internal bool IsAfterRestoreCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after calling the method restoreCell or the user press ESC leaving the changes.
-		/// </summary>
-		public string AfterRestoreCell
-		{
-			get => _afterRestoreCell;
-			set
-			{
-				_afterRestoreCell = value;
-				IsAfterRestoreCellSetted = true;
-			}
-		}
-
-		internal bool IsAfterSaveCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the cell has been successfully saved.
-		/// </summary>
-		public string AfterSaveCell
-		{
-			get => _afterSaveCell;
-			set
-			{
-				_afterSaveCell = value;
-				IsAfterSaveCellSetted = true;
-			}
-		}
-
-		internal bool IsAfterSumbitCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the cell and other data is posted to the server.
-		/// </summary>
-		public string AfterSubmitCell
-		{
-			get => _afterSubmitCell;
-			set
-			{
-				_afterSubmitCell = value;
-				IsAfterSumbitCellSetted = true;
-			}
-		}
-
-		internal bool IsAltClassSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the class that is used for alternate rows.
-		/// </summary>
-		/// <remarks>In Guriddo JqGrid this options is deprecated as of version 5.2</remarks>
-		public string AltClass
-		{
-			get => _altClass;
-			set
-			{
-				_altClass = value;
-				IsAltClassSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the grid should be "zebra-striped".
-		/// </summary>
-		public bool? AltRows { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the grid should auto encode/decode the data.
-		/// </summary>
-		public bool? AutoEncode { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the grid width will be recalculated automatically to the width of the parent element.
-		/// </summary>
-		public bool? AutoWidth { get; set; }
-
-		internal bool IsBeforeRequestSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised before requesting any data.
-		/// </summary>
-		public string BeforeRequest
-		{
-			get => _beforeRequest;
-			set
-			{
-				_beforeRequest = value;
-				IsBeforeRequestSetted = true;
-			}
-		}
-
-		internal bool IsBeforeSelectRowSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised when the user click on the row, but before selecting it.
-		/// </summary>
-		public string BeforeSelectRow
-		{
-			get => _beforeSelectRow;
-			set
-			{
-				_beforeSelectRow = value;
-				IsBeforeSelectRowSetted = true;
-			}
-		}
-
-		internal bool IsBeforeEditCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised before editing the cell.
-		/// </summary>
-		public string BeforeEditCell
-		{
-			get => _beforeEditCell;
-			set
-			{
-				_beforeEditCell = value;
-				IsBeforeEditCellSetted = true;
-			}
-		}
-
-		internal bool IsBeforeSaveCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised before validation of values if any.
-		/// </summary>
-		public string BeforeSaveCell
-		{
-			get => _beforeSaveCell;
-			set
-			{
-				_beforeSaveCell = value;
-				IsBeforeSaveCellSetted = true;
-			}
-		}
-
-		internal bool IsBeforeSubmitCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised before submit the cell content to the server.
-		/// </summary>
-		public string BeforeSubmitCell
-		{
-			get => _beforeSubmitCell;
-			set
-			{
-				_beforeSubmitCell = value;
-				IsBeforeSubmitCellSetted = true;
-			}
-		}
-
-		internal bool IsBeforeProcessingSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised before responce of the server is processed.
-		/// </summary>
-		public string BeforeProcessing
-		{
-			get => _beforeProcessing;
-			set
-			{
-				_beforeProcessing = value;
-				IsBeforeProcessingSetted = true;
-			}
-		}
-
-		internal bool IsCaptionSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the caption for the grid.
-		/// </summary>
-		public string Caption
-		{
-			get => _caption;
-			set
-			{
-				_caption = value;
-				IsCaptionSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the padding plus border width of the cell.
-		/// </summary>
-		public int? CellLayout { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if cell editing is enabled
-		/// </summary>
-		public bool? CellEditingEnabled { get; set; }
-
-		/// <summary>
-		/// Gets or sets the cell editing submit mode
-		/// </summary>
-		public JqGridCellEditingSubmitModes CellEditingSubmitMode { get; set; } = JqGridCellEditingSubmitModes.Default;
-
-		internal bool IsCellEditingUrlSetted { get; private set; }
-		/// <summary>
-		/// Gets or set the URL for cell editing submit
-		/// </summary>
-		public string CellEditingUrl
-		{
-			get => _cellEditingUrl;
-			set
-			{
-				_cellEditingUrl = value;
-				IsCellEditingUrlSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the string of data which will be used when DataType is set to JqGridDataTypes.XmlString or JqGridDataTypes.JsonString (default null).
-		/// </summary>
-		public string DataString { get; set; }
-
-		/// <summary>
-		/// Gets or sets the type of information to expect to represent data in the grid (default JqGridDataTypes.Xml).
-		/// </summary>
-		public JqGridDataTypes DataType { get; set; } = JqGridDataTypes.Default;
-
-		/// <summary>
-		/// Gets or sets the value indicating if jqGrid should be using jQuery.empty for the the row and all its children elements.
-		/// </summary>
-		public bool? DeepEmpty { get; set; }
-
-		/// <summary>
-		/// Gets or sets the language direction in grid.
-		/// </summary>
-		public JqGridLanguageDirections Direction { get; set; } = JqGridLanguageDirections.Default;
-
-		/// <summary>
-		/// Gets or sets the value which defines if dynamic scrolling is enabled.
-		/// </summary>
-		public JqGridDynamicScrollingModes DynamicScrollingMode { get; set; } = JqGridDynamicScrollingModes.Default;
-
-		/// <summary>
-		/// Gets or sets the timeout (in miliseconds) if DynamicScrollingMode is set to JqGridDynamicScrollingModes.HoldVisibleRows
-		/// </summary>
-		public int? DynamicScrollingTimeout { get; set; }
-
-		internal bool IsEditingUrlSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the url for inline and form editing.
-		/// </summary>
-		public string EditingUrl
-		{
-			get => _editingUrl;
-			set
-			{
-				_editingUrl = value;
-				IsEditingUrlSetted = true;
-			}
-		}
-
-		internal bool IsEmptyRecordsSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the information to be displayed when the returned (or the current) number of records is zero.
-		/// </summary>
-		public string EmptyRecords
-		{
-			get => _emptyRecords;
-			set
-			{
-				_emptyRecords = value;
-				IsEmptyRecordsSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the tree is expanded and/or collapsed when user clicks on the text of the expanded column, not only on the image.
-		/// </summary>
-		public bool? ExpandColumnClick { get; set; }
-
-		internal bool IsExpandColumnSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the name of column which should be used to expand the tree grid.
-		/// </summary>
-		public string ExpandColumn
-		{
-			get => _expandColumn;
-			set
-			{
-				_expandColumn = value;
-				IsExpandColumnSetted = true;
-			}
-		}
-
-		internal bool IsErrorCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised when there is a server error while saving cell.
-		/// </summary>
-		public string ErrorCell
-		{
-			get => _errorCell;
-			set
-			{
-				_errorCell = value;
-				IsErrorCellSetted = true;
-			}
-		}
-
-		internal bool IsFormatCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which allows formatting the cell content before editing.
-		/// </summary>
-		public string FormatCell
-		{
-			get => _formatCell;
-			set
-			{
-				_formatCell = value;
-				IsFormatCellSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the footer table (with one row) will be placed below the grid records and above the pager. The number of columns equal of these from ColumnsModels.
-		/// </summary>
-		public bool? FooterEnabled { get; set; }
-
-		internal bool IsGridCompleteSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after all the data is loaded into the grid and all other processes are complete.
-		/// </summary>
-		public string GridComplete
-		{
-			get => _gridComplete;
-			set
-			{
-				_gridComplete = value;
-				IsGridCompleteSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if all the data should be inserted into DOM with one jQuery call (5 to 10 times faster).
-		/// </summary>
-		/// <remarks>Following features can not be used when this option is enabled:
-		/// <list type="bullet">
-		/// <item><description>TreeGrid</description></item>
-		/// <item><description>SubGrid</description></item>
-		/// <item><description>AfterInsertRow event.</description></item>
-		/// </list>
-		/// </remarks>
-		public bool? GridView { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the grouping is enabled.
-		/// </summary>
-		public bool? GroupingEnabled { get; set; }
-
-		/// <summary>
-		/// Gets or sets the grouping view options.
-		/// </summary>
-		public JqGridGroupingView GroupingView { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value indicating if the title attribute is added to the column headers.
-		/// </summary>
-		public bool? HeaderTitles { get; set; }
-
-		/// <summary>
-		/// Gets or sets the height of the grid in pixels (default 'auto').
-		/// </summary>
-		public int? Height { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the grid is initialy hidden (no data loaded, only caption layer is shown).
-		/// Takes effect only if the Caption property is not empty string and HiddenEnabled is set to true.
-		/// </summary>
-		public bool? Hidden { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the show/hide grid button is enabled.
-		/// Takes effect only if the Caption property is not empty string.
-		/// </summary>
-		public bool? HiddenEnabled { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value which defines whether mouse hovering over the grid data rows is enabled.
-		/// </summary>
-		public bool? HoverRows { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the local searching is case-sensitive.
-		/// </summary>
-		public bool? IgnoreCase { get; set; }
-
-		/// <summary>
-		/// Gets or sets the JSON reader for the grid, set this if you want to change JsonReader for this grid
-		/// </summary>
-		public JqGridJsonReader JsonReader { get; set; }
-
-		internal bool IsLoadBeforeSendSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for pre-callback to modify the XMLHttpRequest object before it is sent.
-		/// </summary>
-		public string LoadBeforeSend
-		{
-			get => _loadBeforeSend;
-			set
-			{
-				_loadBeforeSend = value;
-				IsLoadBeforeSendSetted = true;
-			}
-		}
-
-		internal bool IsLoadCompleteSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised immediately after every server request.
-		/// </summary>
-		public string LoadComplete
-		{
-			get => _loadComplete;
-			set
-			{
-				_loadComplete = value;
-				IsLoadCompleteSetted = true;
-			}
-		}
-
-		internal bool IsLoadErrorSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the request fails.
-		/// </summary>
-		public string LoadError
-		{
-			get => _loadError;
-			set
-			{
-				_loadError = value;
-				IsLoadErrorSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the grid should load the data only once and all further manipulationsshould be done on the client side.
-		/// </summary>
-		public bool? LoadOnce { get; set; }
-
-		/// <summary>
-		/// Gets or sets the type of request to make (default JqGridMethodTypes.Get).
-		/// </summary>
-		public JqGridMethodTypes MethodType { get; set; } = JqGridMethodTypes.Default;
-
-		/// <summary>
-		/// Gets or sets the key which should be pressed when the user makes multiselection.
-		/// </summary>
-		public JqGridMultiKeys MultiKey { get; set; } = JqGridMultiKeys.Default;
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the multiselection is done only when the checkbox is clicked.
-		/// </summary>
-		public bool? MultiBoxOnly { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the multiselection is enabled.
-		/// </summary>
-		public bool? MultiSelect { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the sorting by multiple columns is enabled.
-		/// </summary>
-		public bool? MultiSort { get; set; }
-
-		/// <summary>
-		/// Gets or sets the width of the multiselect colum.
-		/// </summary>
-		public int? MultiSelectWidth { get; set; }
-
-		internal bool IsOnCellSelectSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised when user clicks on particular cell in the grid.
-		/// </summary>
-		public string OnCellSelect
-		{
-			get => _onCellSelect;
-			set
-			{
-				_onCellSelect = value;
-				IsOnCellSelectSetted = true;
-			}
-		}
-
-		internal bool IsOnDoubleClickRowSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised immediately after row was double clicked.
-		/// </summary>
-		public string OnDoubleClickRow
-		{
-			get => _onDoubleClickRow;
-			set
-			{
-				_onDoubleClickRow = value;
-				IsOnDoubleClickRowSetted = true;
-			}
-		}
-
-		internal bool IsOnHeaderClickSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after clicking to hide or show grid.
-		/// </summary>
-		public string OnHeaderClick
-		{
-			get => _onHeaderClick;
-			set
-			{
-				_onHeaderClick = value;
-				IsOnHeaderClickSetted = true;
-			}
-		}
-
-		internal bool IsOnInitGridSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised only once before populating the data.
-		/// </summary>
-		public string OnInitGrid
-		{
-			get => _onInitGrid;
-			set
-			{
-				_onInitGrid = value;
-				IsOnInitGridSetted = true;
-			}
-		}
-
-		internal bool IsOnPagingSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised before populating the data after page index/size change.
-		/// </summary>
-		public string OnPaging
-		{
-			get => _onPaging;
-			set
-			{
-				_onPaging = value;
-				IsOnPagingSetted = true;
-			}
-		}
-
-		internal bool IsOnRightClickRowSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised immediately after row was right clicked.
-		/// </summary>
-		public string OnRightClickRow
-		{
-			get => _onRightClickRow;
-			set
-			{
-				_onRightClickRow = value;
-				IsOnRightClickRowSetted = true;
-			}
-		}
-
-		internal bool IsOnSelectAllSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised when MultipleSelect option is true and user clicks on the header checkbox.
-		/// </summary>
-		public string OnSelectAll
-		{
-			get => _onSelectAll;
-			set
-			{
-				_onSelectAll = value;
-				IsOnSelectAllSetted = true;
-			}
-		}
-
-		internal bool IsOnSelectCellSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the cell is selected for editing.
-		/// </summary>
-		public string OnSelectCell
-		{
-			get => _onSelectCell;
-			set
-			{
-				_onSelectCell = value;
-				IsOnSelectCellSetted = true;
-			}
-		}
-
-		internal bool IsOnSelectRowSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised immediately after row was clicked.
-		/// </summary>
-		public string OnSelectRow
-		{
-			get => _onSelectRow;
-			set
-			{
-				_onSelectRow = value;
-				IsOnSelectRowSetted = true;
-			}
-		}
-
-		internal bool IsOnSortColSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised immediately after sortable column was clicked and before sorting the data.
-		/// </summary>
-		public string OnSortCol
-		{
-			get => _onSortCol;
-			set
-			{
-				_onSortCol = value;
-				IsOnSortColSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets if grid should use a pager bar to navigate through the records (default: false).
-		/// </summary>
-		public bool Pager { get; set; }
-
-		internal bool IsPostDataSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the additional data which will be added to the request.
-		/// </summary>
-		public object PostData
-		{
-			get => _postData;
-			set
-			{
-				_postData = value;
-				IsPostDataSetted = true;
-			}
-		}
-
-		internal bool IsPostDataScriptSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the request (this property takes precedence over PostData).
-		/// </summary>
-		public string PostDataScript
-		{
-			get => _postDataScript;
-			set
-			{
-				_postDataScript = value;
-				IsPostDataScriptSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets customized names for jqGrid request parameters. Set this if you want redefine ParametersNames for this grid.
-		/// </summary>
-		public JqGridParametersNames ParametersNames { get; set; }
-
-		internal bool IsResizeStartSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised when user starts resizing a column.
-		/// </summary>
-		public string ResizeStart
-		{
-			get => _resizeStart;
-			set
-			{
-				_resizeStart = value;
-				IsResizeStartSetted = true;
-			}
-		}
-
-		internal bool IsResizeStopSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised after the column is resized.
-		/// </summary>
-		public string ResizeStop
-		{
-			get => _resizeStop;
-			set
-			{
-				_resizeStop = value;
-				IsResizeStopSetted = true;
-			}
-		}
-
-		internal bool IsRowAttributesSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function which can add attributes to the row during the creation of the data (dynamically).
-		/// </summary>
-		public string RowAttributes
-		{
-			get => _rowAttributes;
-			set
-			{
-				_rowAttributes = value;
-				IsRowAttributesSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets an array to construct a select box element in the pager in which user can change the number of the visible rows.
-		/// </summary>
-		public IEnumerable<int> RowsList { get; set; }
-
-		/// <summary>
-		/// Gets or sets how many records should be displayed in the grid (default 20).
-		/// </summary>
-		public int? RowsNumber { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines whether a new column, which purpose is to count the number of available rows, should be added at left of the grid.
-		/// </summary>
-		public bool? RowsNumbers { get; set; }
-
-		/// <summary>
-		/// Gets or sets the width of the row number column.
-		/// </summary>
-		public int? RowsNumbersWidth { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the columns width should be recalculated to fit the width of the grid.
-		/// </summary>
-		public bool? ShrinkToFit { get; set; }
-
-		/// <summary>
-		/// Gets or sets the width of vertical scrollbar
-		/// </summary>
-		public int? ScrollOffset { get; set; }
-
-		internal bool IsSerializeCellDataSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which can serialize the data passed to the ajax request when the cell is being saved.
-		/// </summary>
-		public string SerializeCellData
-		{
-			get => _serializeCellData;
-			set
-			{
-				_serializeCellData = value;
-				IsSerializeCellDataSetted = true;
-			}
-		}
-
-		internal bool IsSerializeGridDataSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which can serialize the data passed to the ajax request.
-		/// </summary>
-		public string SerializeGridData
-		{
-			get => _serializeGridData;
-			set
-			{
-				_serializeGridData = value;
-				IsSerializeGridDataSetted = true;
-			}
-		}
-
-		internal bool IsSerializeSubGridDataSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which can serialize the data passed to the subgrid ajax request.
-		/// </summary>
-		public string SerializeSubGridData
-		{
-			get => _serializeSubGridData;
-			set
-			{
-				_serializeSubGridData = value;
-				IsSerializeSubGridDataSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value which defines whether the columns can be reordered by dragging and dropping them with the mouse.
-		/// </summary>
-		/// <remarks>This option requires the jQuery UI sortable widget and the jQuery UI Addons module.</remarks>
-		public bool? Sortable { get; set; }
-
-		internal bool IsSortingNameSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the initial sorting column index, when  using data returned from server (default: String.Empty)
-		/// </summary>
-		public string SortingName
-		{
-			get => _sortingName;
-			set
-			{
-				_sortingName = value;
-				IsSortingNameSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the initial sorting order, when  using data returned from server (default JqGridSortingOrders.Asc)
-		/// </summary>
-		public JqGridSortingOrders SortingOrder { get; set; } = JqGridSortingOrders.Default;
-
-		/// <summary>
-		/// Gets or set the CSS framework  
-		/// </summary>
-		/// <remarks>
-		/// Available since Guriddo jqGrid 5.0
-		/// </remarks>
-		public JqGridStyleUIOptions StyleUI { get; set; } = JqGridStyleUIOptions.Default;
-
-		/// <summary>
-		/// Gets or set the icon set for Bootstrap 4 style UI
-		/// </summary>
-		/// <remarks>Available since Gurido JqGrid 5.3.0</remarks>
-		public JqGridBootstrap4IconSet IconSet { get; set; } = JqGridBootstrap4IconSet.Default;
-
-		/// <summary>
-		/// Gets or sets the value which defines if subgrid is enabled.
-		/// </summary>
-		public bool? SubgridEnabled { get; set; }
-
-		/// <summary>
-		/// Gets or sets the subgrid model.
-		/// </summary>
-		public JqGridSubgridModel SubgridModel { get; set; }
-
-		internal bool IsSubgridUrlSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the url for subgrid data requests.
-		/// </summary>
-		public string SubgridUrl
-		{
-			get => _subgridUrl;
-			set
-			{
-				_subgridUrl = value;
-				IsSubgridUrlSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the width of subgrid expand/colapse column.
-		/// </summary>
-		public int? SubgridColumnWidth { get; set; }
-
-		internal bool IsSubGridBeforeExpandSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised just before expanding the subgrid.
-		/// </summary>
-		public string SubGridBeforeExpand
-		{
-			get => _subGridBeforeExpand;
-			set
-			{
-				_subGridBeforeExpand = value;
-				IsSubGridBeforeExpandSetted = true;
-			}
-		}
-
-		internal bool IsSubGridRowExpandedSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised when the user clicks on the plus icon of the grid.
-		/// </summary>
-		public string SubGridRowExpanded
-		{
-			get => _subGridRowExpanded;
-			set
-			{
-				_subGridRowExpanded = value;
-				IsSubGridRowExpandedSetted = true;
-			}
-		}
-
-		internal bool IsSubGridRowColapsedSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the function for event which is raised when the user clicks on the minus icon of the grid.
-		/// </summary>
-		public string SubGridRowColapsed
-		{
-			get => _subGridRowColapsed;
-			set
-			{
-				_subGridRowColapsed = value;
-				IsSubGridRowColapsedSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if jqGrid should place a pager element at top of the grid below the caption (if available).
-		/// </summary>
-		public bool? TopPager { get; set; }
-
-		/// <summary>
-		/// Gets or sets the value which defines if TreeGrid is enabled.
-		/// </summary>
-		public bool? TreeGridEnabled { get; set; }
-
-		/// <summary>
-		/// Gets or sets the model for TreeGrid.
-		/// </summary>
-		public JqGridTreeGridModels TreeGridModel { get; set; }
-
-		internal bool IsUrlSetted { get; private set; }
-		/// <summary>
-		/// Gets or sets the url for data requests (default null)
-		/// </summary>
-		public string Url
-		{
-			get => _url;
-			set
-			{
-				_url = value;
-				IsUrlSetted = true;
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets the value indicating if the values from user data should be placed on footer.
-		/// </summary>
-		public bool? UserDataOnFooter { get; set; }
-
-		/// <summary>
-		/// Gets or sets if grid should display the beginning and ending record number out of the total number of records in the query (default: false)
-		/// </summary>
-		public bool? ViewRecords { get; set; }
-
-		/// <summary>
-		/// Gets or sets the width of the grid in pixels (default 'auto').
-		/// </summary>
-		public int? Width { get; set; }
-
-		internal bool IsUsedDataString => DataType == JqGridDataTypes.JsonString || DataType == JqGridDataTypes.XmlString;
-
-		#endregion
-
-		#region Constructors
-		/// <summary>
-		/// Initialize new instant of JqGridOptions.
-		/// </summary>
-		/// <param name="id">Id of Grid</param>
-		public JqGridOptions(string id)
-		{
-			Id = id;
-			ColumnsModels = new List<JqGridColumnModel>();
-			ColumnsNames = new List<string>();
-		}
-
-		/// <summary>
-		/// Initialize new instant of JqGridOptions.
-		/// </summary>
-		/// <param name="id">Id of Grid</param>
-		/// <param name="modelType">Type of used model</param>
-		public JqGridOptions(string id, Type modelType)
-			: this(id)
-		{
-			SetModel(modelType);
-		}
-
-		#endregion
-
-		#region Methods
-		/// <summary>
-		/// Sets the grid columns models
-		/// </summary>
-		/// <param name="modelType"></param>
-		public void SetModel(Type modelType)
-		{
-			ColumnsModels = new List<JqGridColumnModel>();
-			ColumnsNames = new List<string>();
-			var jqGridModelMetadata = ModelMetadataProviders.Current.GetMetadataForType(null, modelType);
-			foreach (var propertyMetadata in jqGridModelMetadata.Properties.Where(p => p.IsValidForColumn()))
-			{
-				var columnModel = new JqGridColumnModel(propertyMetadata);
-				ColumnsModels.Add(columnModel);
-				ColumnsNames.Add(propertyMetadata.GetDisplayName());
-			}
-		}
-
-		#endregion
-	}
+    /// <summary>
+    /// Options passed to helper's constructor
+    /// </summary>
+    public class JqGridOptions
+    {
+        #region Fields
+        private string _afterInsertRow;
+        private string _afterEditCell;
+        private string _afterRestoreCell;
+        private string _afterSaveCell;
+        private string _afterSubmitCell;
+        private string _altClass;
+        private string _beforeRequest;
+        private string _beforeSelectRow;
+        private string _beforeEditCell;
+        private string _beforeSaveCell;
+        private string _beforeSubmitCell;
+        private string _beforeProcessing;
+        private string _caption;
+        private string _cellEditingUrl;
+        private string _editingUrl;
+        private string _emptyRecords;
+        private string _expandColumn;
+        private string _errorCell;
+        private string _formatCell;
+        private string _gridComplete;
+        private string _loadBeforeSend;
+        private string _loadComplete;
+        private string _loadError;
+        private string _onCellSelect;
+        private string _onDoubleClickRow;
+        private string _onHeaderClick;
+        private string _onInitGrid;
+        private string _onPaging;
+        private string _onRightClickRow;
+        private string _onSelectAll;
+        private string _onSelectCell;
+        private string _onSelectRow;
+        private string _onSortCol;
+        private object _postData;
+        private string _postDataScript;
+        private string _resizeStart;
+        private string _resizeStop;
+        private string _rowAttributes;
+        private string _serializeCellData;
+        private string _serializeGridData;
+        private string _serializeSubGridData;
+        private string _sortingName;
+        private string _subgridUrl;
+        private string _subGridBeforeExpand;
+        private string _subGridRowExpanded;
+        private string _subGridRowColapsed;
+        private string _url;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the grid identifier which will be used for table (id='{0}'), pager div (id='{0}Pager') and in JavaScript.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// Gets the list of columns parameters descriptions.
+        /// </summary>
+        public List<JqGridColumnModel> ColumnsModels { get; private set; }
+
+        /// <summary>
+        /// Gets the list of columns names.
+        /// </summary>
+        public List<string> ColumnsNames { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the list of columns indexes for remaping (default null).
+        /// </summary>
+        public List<int> ColumnsRemaping { get; set; }
+
+        /// <summary>
+        /// Gets or sets default compatibility mode
+        /// </summary>
+        public static JqGridCompatibilityModes DefaultCompatibilityMode { get; set; } = JqGridCompatibilityModes.JqGrid;
+
+        /// <summary>
+        /// Gets or sets the jqGrid compatibility mode.
+        /// </summary>
+        public JqGridCompatibilityModes CompatibilityMode { get; set; } = DefaultCompatibilityMode;
+
+        internal bool IsAfterInsertRowSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after every inserted row.
+        /// </summary>
+        public string AfterInsertRow
+        {
+            get => _afterInsertRow;
+            set
+            {
+                _afterInsertRow = value;
+                IsAfterInsertRowSetted = true;
+            }
+        }
+
+        internal bool IsAfterEditCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the edited cell is edited.
+        /// </summary>
+        public string AfterEditCell
+        {
+            get => _afterEditCell;
+            set
+            {
+                _afterEditCell = value;
+                IsAfterInsertRowSetted = true;
+            }
+        }
+
+        internal bool IsAfterRestoreCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after calling the method restoreCell or the user press ESC leaving the changes.
+        /// </summary>
+        public string AfterRestoreCell
+        {
+            get => _afterRestoreCell;
+            set
+            {
+                _afterRestoreCell = value;
+                IsAfterRestoreCellSetted = true;
+            }
+        }
+
+        internal bool IsAfterSaveCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the cell has been successfully saved.
+        /// </summary>
+        public string AfterSaveCell
+        {
+            get => _afterSaveCell;
+            set
+            {
+                _afterSaveCell = value;
+                IsAfterSaveCellSetted = true;
+            }
+        }
+
+        internal bool IsAfterSumbitCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the cell and other data is posted to the server.
+        /// </summary>
+        public string AfterSubmitCell
+        {
+            get => _afterSubmitCell;
+            set
+            {
+                _afterSubmitCell = value;
+                IsAfterSumbitCellSetted = true;
+            }
+        }
+
+        internal bool IsAltClassSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the class that is used for alternate rows.
+        /// </summary>
+        /// <remarks>In Guriddo JqGrid this options is deprecated as of version 5.2</remarks>
+        public string AltClass
+        {
+            get => _altClass;
+            set
+            {
+                _altClass = value;
+                IsAltClassSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the grid should be "zebra-striped".
+        /// </summary>
+        public bool? AltRows { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the grid should auto encode/decode the data.
+        /// </summary>
+        public bool? AutoEncode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the grid width will be recalculated automatically to the width of the parent element.
+        /// </summary>
+        public bool? AutoWidth { get; set; }
+
+        internal bool IsBeforeRequestSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before requesting any data.
+        /// </summary>
+        public string BeforeRequest
+        {
+            get => _beforeRequest;
+            set
+            {
+                _beforeRequest = value;
+                IsBeforeRequestSetted = true;
+            }
+        }
+
+        internal bool IsBeforeSelectRowSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when the user click on the row, but before selecting it.
+        /// </summary>
+        public string BeforeSelectRow
+        {
+            get => _beforeSelectRow;
+            set
+            {
+                _beforeSelectRow = value;
+                IsBeforeSelectRowSetted = true;
+            }
+        }
+
+        internal bool IsBeforeEditCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before editing the cell.
+        /// </summary>
+        public string BeforeEditCell
+        {
+            get => _beforeEditCell;
+            set
+            {
+                _beforeEditCell = value;
+                IsBeforeEditCellSetted = true;
+            }
+        }
+
+        internal bool IsBeforeSaveCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before validation of values if any.
+        /// </summary>
+        public string BeforeSaveCell
+        {
+            get => _beforeSaveCell;
+            set
+            {
+                _beforeSaveCell = value;
+                IsBeforeSaveCellSetted = true;
+            }
+        }
+
+        internal bool IsBeforeSubmitCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before submit the cell content to the server.
+        /// </summary>
+        public string BeforeSubmitCell
+        {
+            get => _beforeSubmitCell;
+            set
+            {
+                _beforeSubmitCell = value;
+                IsBeforeSubmitCellSetted = true;
+            }
+        }
+
+        internal bool IsBeforeProcessingSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before responce of the server is processed.
+        /// </summary>
+        public string BeforeProcessing
+        {
+            get => _beforeProcessing;
+            set
+            {
+                _beforeProcessing = value;
+                IsBeforeProcessingSetted = true;
+            }
+        }
+
+        internal bool IsCaptionSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the caption for the grid.
+        /// </summary>
+        public string Caption
+        {
+            get => _caption;
+            set
+            {
+                _caption = value;
+                IsCaptionSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the padding plus border width of the cell.
+        /// </summary>
+        public int? CellLayout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if cell editing is enabled
+        /// </summary>
+        public bool? CellEditingEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the cell editing submit mode
+        /// </summary>
+        public JqGridCellEditingSubmitModes CellEditingSubmitMode { get; set; } = JqGridCellEditingSubmitModes.Default;
+
+        internal bool IsCellEditingUrlSetted { get; private set; }
+        /// <summary>
+        /// Gets or set the URL for cell editing submit
+        /// </summary>
+        public string CellEditingUrl
+        {
+            get => _cellEditingUrl;
+            set
+            {
+                _cellEditingUrl = value;
+                IsCellEditingUrlSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the string of data which will be used when DataType is set to JqGridDataTypes.XmlString or JqGridDataTypes.JsonString (default null).
+        /// </summary>
+        public string DataString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of information to expect to represent data in the grid (default JqGridDataTypes.Xml).
+        /// </summary>
+        public JqGridDataTypes DataType { get; set; } = JqGridDataTypes.Default;
+
+        /// <summary>
+        /// Gets or sets the value indicating if jqGrid should be using jQuery.empty for the the row and all its children elements.
+        /// </summary>
+        public bool? DeepEmpty { get; set; }
+
+        /// <summary>
+        /// Gets or sets the language direction in grid.
+        /// </summary>
+        public JqGridLanguageDirections Direction { get; set; } = JqGridLanguageDirections.Default;
+
+        /// <summary>
+        /// Gets or sets the value which defines if dynamic scrolling is enabled.
+        /// </summary>
+        public JqGridDynamicScrollingModes DynamicScrollingMode { get; set; } = JqGridDynamicScrollingModes.Default;
+
+        /// <summary>
+        /// Gets or sets the timeout (in miliseconds) if DynamicScrollingMode is set to JqGridDynamicScrollingModes.HoldVisibleRows
+        /// </summary>
+        public int? DynamicScrollingTimeout { get; set; }
+
+        internal bool IsEditingUrlSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the url for inline and form editing.
+        /// </summary>
+        public string EditingUrl
+        {
+            get => _editingUrl;
+            set
+            {
+                _editingUrl = value;
+                IsEditingUrlSetted = true;
+            }
+        }
+
+        internal bool IsEmptyRecordsSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the information to be displayed when the returned (or the current) number of records is zero.
+        /// </summary>
+        public string EmptyRecords
+        {
+            get => _emptyRecords;
+            set
+            {
+                _emptyRecords = value;
+                IsEmptyRecordsSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the tree is expanded and/or collapsed when user clicks on the text of the expanded column, not only on the image.
+        /// </summary>
+        public bool? ExpandColumnClick { get; set; }
+
+        internal bool IsExpandColumnSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the name of column which should be used to expand the tree grid.
+        /// </summary>
+        public string ExpandColumn
+        {
+            get => _expandColumn;
+            set
+            {
+                _expandColumn = value;
+                IsExpandColumnSetted = true;
+            }
+        }
+
+        internal bool IsErrorCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when there is a server error while saving cell.
+        /// </summary>
+        public string ErrorCell
+        {
+            get => _errorCell;
+            set
+            {
+                _errorCell = value;
+                IsErrorCellSetted = true;
+            }
+        }
+
+        internal bool IsFormatCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which allows formatting the cell content before editing.
+        /// </summary>
+        public string FormatCell
+        {
+            get => _formatCell;
+            set
+            {
+                _formatCell = value;
+                IsFormatCellSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the footer table (with one row) will be placed below the grid records and above the pager. The number of columns equal of these from ColumnsModels.
+        /// </summary>
+        public bool? FooterEnabled { get; set; }
+
+        internal bool IsGridCompleteSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after all the data is loaded into the grid and all other processes are complete.
+        /// </summary>
+        public string GridComplete
+        {
+            get => _gridComplete;
+            set
+            {
+                _gridComplete = value;
+                IsGridCompleteSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if all the data should be inserted into DOM with one jQuery call (5 to 10 times faster).
+        /// </summary>
+        /// <remarks>Following features can not be used when this option is enabled:
+        /// <list type="bullet">
+        /// <item><description>TreeGrid</description></item>
+        /// <item><description>SubGrid</description></item>
+        /// <item><description>AfterInsertRow event.</description></item>
+        /// </list>
+        /// </remarks>
+        public bool? GridView { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the grouping is enabled.
+        /// </summary>
+        public bool? GroupingEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the grouping view options.
+        /// </summary>
+        public JqGridGroupingView GroupingView { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the title attribute is added to the column headers.
+        /// </summary>
+        public bool? HeaderTitles { get; set; }
+
+        /// <summary>
+        /// Gets or sets the height of the grid in pixels (default 'auto').
+        /// </summary>
+        public int? Height { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the grid is initialy hidden (no data loaded, only caption layer is shown).
+        /// Takes effect only if the Caption property is not empty string and HiddenEnabled is set to true.
+        /// </summary>
+        public bool? Hidden { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the show/hide grid button is enabled.
+        /// Takes effect only if the Caption property is not empty string.
+        /// </summary>
+        public bool? HiddenEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value which defines whether mouse hovering over the grid data rows is enabled.
+        /// </summary>
+        public bool? HoverRows { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the local searching is case-sensitive.
+        /// </summary>
+        public bool? IgnoreCase { get; set; }
+
+        /// <summary>
+        /// Gets or sets the JSON reader for the grid, set this if you want to change JsonReader for this grid
+        /// </summary>
+        public JqGridJsonReader JsonReader { get; set; }
+
+        internal bool IsLoadBeforeSendSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for pre-callback to modify the XMLHttpRequest object before it is sent.
+        /// </summary>
+        public string LoadBeforeSend
+        {
+            get => _loadBeforeSend;
+            set
+            {
+                _loadBeforeSend = value;
+                IsLoadBeforeSendSetted = true;
+            }
+        }
+
+        internal bool IsLoadCompleteSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised immediately after every server request.
+        /// </summary>
+        public string LoadComplete
+        {
+            get => _loadComplete;
+            set
+            {
+                _loadComplete = value;
+                IsLoadCompleteSetted = true;
+            }
+        }
+
+        internal bool IsLoadErrorSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the request fails.
+        /// </summary>
+        public string LoadError
+        {
+            get => _loadError;
+            set
+            {
+                _loadError = value;
+                IsLoadErrorSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the grid should load the data only once and all further manipulationsshould be done on the client side.
+        /// </summary>
+        public bool? LoadOnce { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of request to make (default JqGridMethodTypes.Get).
+        /// </summary>
+        public JqGridMethodTypes MethodType { get; set; } = JqGridMethodTypes.Default;
+
+        /// <summary>
+        /// Gets or sets the key which should be pressed when the user makes multiselection.
+        /// </summary>
+        public JqGridMultiKeys MultiKey { get; set; } = JqGridMultiKeys.Default;
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the multiselection is done only when the checkbox is clicked.
+        /// </summary>
+        public bool? MultiBoxOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the multiselection is enabled.
+        /// </summary>
+        public bool? MultiSelect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the sorting by multiple columns is enabled.
+        /// </summary>
+        public bool? MultiSort { get; set; }
+
+        /// <summary>
+        /// Gets or sets the width of the multiselect colum.
+        /// </summary>
+        public int? MultiSelectWidth { get; set; }
+
+        internal bool IsOnCellSelectSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when user clicks on particular cell in the grid.
+        /// </summary>
+        public string OnCellSelect
+        {
+            get => _onCellSelect;
+            set
+            {
+                _onCellSelect = value;
+                IsOnCellSelectSetted = true;
+            }
+        }
+
+        internal bool IsOnDoubleClickRowSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised immediately after row was double clicked.
+        /// </summary>
+        public string OnDoubleClickRow
+        {
+            get => _onDoubleClickRow;
+            set
+            {
+                _onDoubleClickRow = value;
+                IsOnDoubleClickRowSetted = true;
+            }
+        }
+
+        internal bool IsOnHeaderClickSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after clicking to hide or show grid.
+        /// </summary>
+        public string OnHeaderClick
+        {
+            get => _onHeaderClick;
+            set
+            {
+                _onHeaderClick = value;
+                IsOnHeaderClickSetted = true;
+            }
+        }
+
+        internal bool IsOnInitGridSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised only once before populating the data.
+        /// </summary>
+        public string OnInitGrid
+        {
+            get => _onInitGrid;
+            set
+            {
+                _onInitGrid = value;
+                IsOnInitGridSetted = true;
+            }
+        }
+
+        internal bool IsOnPagingSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised before populating the data after page index/size change.
+        /// </summary>
+        public string OnPaging
+        {
+            get => _onPaging;
+            set
+            {
+                _onPaging = value;
+                IsOnPagingSetted = true;
+            }
+        }
+
+        internal bool IsOnRightClickRowSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised immediately after row was right clicked.
+        /// </summary>
+        public string OnRightClickRow
+        {
+            get => _onRightClickRow;
+            set
+            {
+                _onRightClickRow = value;
+                IsOnRightClickRowSetted = true;
+            }
+        }
+
+        internal bool IsOnSelectAllSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when MultipleSelect option is true and user clicks on the header checkbox.
+        /// </summary>
+        public string OnSelectAll
+        {
+            get => _onSelectAll;
+            set
+            {
+                _onSelectAll = value;
+                IsOnSelectAllSetted = true;
+            }
+        }
+
+        internal bool IsOnSelectCellSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the cell is selected for editing.
+        /// </summary>
+        public string OnSelectCell
+        {
+            get => _onSelectCell;
+            set
+            {
+                _onSelectCell = value;
+                IsOnSelectCellSetted = true;
+            }
+        }
+
+        internal bool IsOnSelectRowSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised immediately after row was clicked.
+        /// </summary>
+        public string OnSelectRow
+        {
+            get => _onSelectRow;
+            set
+            {
+                _onSelectRow = value;
+                IsOnSelectRowSetted = true;
+            }
+        }
+
+        internal bool IsOnSortColSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised immediately after sortable column was clicked and before sorting the data.
+        /// </summary>
+        public string OnSortCol
+        {
+            get => _onSortCol;
+            set
+            {
+                _onSortCol = value;
+                IsOnSortColSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets if grid should use a pager bar to navigate through the records (default: false).
+        /// </summary>
+        public bool Pager { get; set; }
+
+        internal bool IsPostDataSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the additional data which will be added to the request.
+        /// </summary>
+        public object PostData
+        {
+            get => _postData;
+            set
+            {
+                _postData = value;
+                IsPostDataSetted = true;
+            }
+        }
+
+        internal bool IsPostDataScriptSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the request (this property takes precedence over PostData).
+        /// </summary>
+        public string PostDataScript
+        {
+            get => _postDataScript;
+            set
+            {
+                _postDataScript = value;
+                IsPostDataScriptSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets customized names for jqGrid request parameters. Set this if you want redefine ParametersNames for this grid.
+        /// </summary>
+        public JqGridParametersNames ParametersNames { get; set; }
+
+        internal bool IsResizeStartSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when user starts resizing a column.
+        /// </summary>
+        public string ResizeStart
+        {
+            get => _resizeStart;
+            set
+            {
+                _resizeStart = value;
+                IsResizeStartSetted = true;
+            }
+        }
+
+        internal bool IsResizeStopSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised after the column is resized.
+        /// </summary>
+        public string ResizeStop
+        {
+            get => _resizeStop;
+            set
+            {
+                _resizeStop = value;
+                IsResizeStopSetted = true;
+            }
+        }
+
+        internal bool IsRowAttributesSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function which can add attributes to the row during the creation of the data (dynamically).
+        /// </summary>
+        public string RowAttributes
+        {
+            get => _rowAttributes;
+            set
+            {
+                _rowAttributes = value;
+                IsRowAttributesSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets an array to construct a select box element in the pager in which user can change the number of the visible rows.
+        /// </summary>
+        public IEnumerable<int> RowsList { get; set; }
+
+        /// <summary>
+        /// Gets or sets how many records should be displayed in the grid (default 20).
+        /// </summary>
+        public int? RowsNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether a new column, which purpose is to count the number of available rows, should be added at left of the grid.
+        /// </summary>
+        public bool? RowsNumbers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the width of the row number column.
+        /// </summary>
+        public int? RowsNumbersWidth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the columns width should be recalculated to fit the width of the grid.
+        /// </summary>
+        public bool? ShrinkToFit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the width of vertical scrollbar
+        /// </summary>
+        public int? ScrollOffset { get; set; }
+
+        internal bool IsSerializeCellDataSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which can serialize the data passed to the ajax request when the cell is being saved.
+        /// </summary>
+        public string SerializeCellData
+        {
+            get => _serializeCellData;
+            set
+            {
+                _serializeCellData = value;
+                IsSerializeCellDataSetted = true;
+            }
+        }
+
+        internal bool IsSerializeGridDataSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which can serialize the data passed to the ajax request.
+        /// </summary>
+        public string SerializeGridData
+        {
+            get => _serializeGridData;
+            set
+            {
+                _serializeGridData = value;
+                IsSerializeGridDataSetted = true;
+            }
+        }
+
+        internal bool IsSerializeSubGridDataSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which can serialize the data passed to the subgrid ajax request.
+        /// </summary>
+        public string SerializeSubGridData
+        {
+            get => _serializeSubGridData;
+            set
+            {
+                _serializeSubGridData = value;
+                IsSerializeSubGridDataSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value which defines whether the columns can be reordered by dragging and dropping them with the mouse.
+        /// </summary>
+        /// <remarks>This option requires the jQuery UI sortable widget and the jQuery UI Addons module.</remarks>
+        public bool? Sortable { get; set; }
+
+        internal bool IsSortingNameSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the initial sorting column index, when  using data returned from server (default: String.Empty)
+        /// </summary>
+        public string SortingName
+        {
+            get => _sortingName;
+            set
+            {
+                _sortingName = value;
+                IsSortingNameSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the initial sorting order, when  using data returned from server (default JqGridSortingOrders.Asc)
+        /// </summary>
+        public JqGridSortingOrders SortingOrder { get; set; } = JqGridSortingOrders.Default;
+
+        /// <summary>
+        /// Gets or set the CSS framework  
+        /// </summary>
+        /// <remarks>
+        /// Available since Guriddo jqGrid 5.0
+        /// </remarks>
+        public JqGridStyleUIOptions StyleUI { get; set; } = JqGridStyleUIOptions.Default;
+
+        /// <summary>
+        /// Gets or set the icon set for Bootstrap 4 style UI
+        /// </summary>
+        /// <remarks>Available since Gurido JqGrid 5.3.0</remarks>
+        public JqGridBootstrap4IconSet IconSet { get; set; } = JqGridBootstrap4IconSet.Default;
+
+        /// <summary>
+        /// Gets or sets the value which defines if subgrid is enabled.
+        /// </summary>
+        public bool? SubgridEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subgrid model.
+        /// </summary>
+        public JqGridSubgridModel SubgridModel { get; set; }
+
+        internal bool IsSubgridUrlSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the url for subgrid data requests.
+        /// </summary>
+        public string SubgridUrl
+        {
+            get => _subgridUrl;
+            set
+            {
+                _subgridUrl = value;
+                IsSubgridUrlSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the width of subgrid expand/colapse column.
+        /// </summary>
+        public int? SubgridColumnWidth { get; set; }
+
+        internal bool IsSubGridBeforeExpandSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised just before expanding the subgrid.
+        /// </summary>
+        public string SubGridBeforeExpand
+        {
+            get => _subGridBeforeExpand;
+            set
+            {
+                _subGridBeforeExpand = value;
+                IsSubGridBeforeExpandSetted = true;
+            }
+        }
+
+        internal bool IsSubGridRowExpandedSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when the user clicks on the plus icon of the grid.
+        /// </summary>
+        public string SubGridRowExpanded
+        {
+            get => _subGridRowExpanded;
+            set
+            {
+                _subGridRowExpanded = value;
+                IsSubGridRowExpandedSetted = true;
+            }
+        }
+
+        internal bool IsSubGridRowColapsedSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the function for event which is raised when the user clicks on the minus icon of the grid.
+        /// </summary>
+        public string SubGridRowColapsed
+        {
+            get => _subGridRowColapsed;
+            set
+            {
+                _subGridRowColapsed = value;
+                IsSubGridRowColapsedSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if jqGrid should place a pager element at top of the grid below the caption (if available).
+        /// </summary>
+        public bool? TopPager { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which defines if TreeGrid is enabled.
+        /// </summary>
+        public bool? TreeGridEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the model for TreeGrid.
+        /// </summary>
+        public JqGridTreeGridModels TreeGridModel { get; set; }
+
+        internal bool IsUrlSetted { get; private set; }
+        /// <summary>
+        /// Gets or sets the url for data requests (default null)
+        /// </summary>
+        public string Url
+        {
+            get => _url;
+            set
+            {
+                _url = value;
+                IsUrlSetted = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the values from user data should be placed on footer.
+        /// </summary>
+        public bool? UserDataOnFooter { get; set; }
+
+        /// <summary>
+        /// Gets or sets if grid should display the beginning and ending record number out of the total number of records in the query (default: false)
+        /// </summary>
+        public bool? ViewRecords { get; set; }
+
+        /// <summary>
+        /// Gets or sets the width of the grid in pixels (default 'auto').
+        /// </summary>
+        public int? Width { get; set; }
+
+        internal bool IsUsedDataString => DataType == JqGridDataTypes.JsonString || DataType == JqGridDataTypes.XmlString;
+
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initialize new instant of JqGridOptions.
+        /// </summary>
+        /// <param name="id">Id of Grid</param>
+        public JqGridOptions(string id)
+        {
+            Id = id;
+            ColumnsModels = new List<JqGridColumnModel>();
+            ColumnsNames = new List<string>();
+        }
+
+        /// <summary>
+        /// Initialize new instant of JqGridOptions.
+        /// </summary>
+        /// <param name="id">Id of Grid</param>
+        /// <param name="modelType">Type of used model</param>
+        public JqGridOptions(string id, Type modelType)
+            : this(id)
+        {
+            SetModel(modelType);
+        }
+
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Sets the grid columns models
+        /// </summary>
+        /// <param name="modelType"></param>
+        public void SetModel(Type modelType)
+        {
+            ColumnsModels = new List<JqGridColumnModel>();
+            ColumnsNames = new List<string>();
+            ModelMetadata jqGridModelMetadata = ModelMetadataProviders.Current.GetMetadataForType(null, modelType);
+            foreach (ModelMetadata propertyMetadata in jqGridModelMetadata.Properties.Where(p => p.IsValidForColumn()))
+            {
+                JqGridColumnModel columnModel = new JqGridColumnModel(propertyMetadata);
+                ColumnsModels.Add(columnModel);
+                ColumnsNames.Add(propertyMetadata.GetDisplayName());
+            }
+        }
+
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridOptions.cs
@@ -1,663 +1,1079 @@
 ﻿using System;
 using System.Collections.Generic;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+using System.Linq;
+using System.Web.Mvc;
+using System.Web.UI.WebControls.WebParts;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jqGrid options
-    /// </summary>
-    public class JqGridOptions
-    {
-        #region Fields
-        private List<JqGridColumnModel> _columnsModel;
-        private List<string> _columnsNames;
-        #endregion
-
-        #region Properties
-        /// <summary>
-        /// Gets or sets the jqGrid compatibility mode.
-        /// </summary>
-        public JqGridCompatibilityModes CompatibilityMode { get; set; }
-
-        /// <summary>
-        /// Gets the grid identifier which will be used for table (id='{0}'), pager div (id='{0}Pager') and in JavaScript.
-        /// </summary>
-        public string Id { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after every inserted row.
-        /// </summary>
-        public string AfterInsertRow { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the edited cell is edited.
-        /// </summary>
-        public string AfterEditCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after calling the method restoreCell or the user press ESC leaving the changes.
-        /// </summary>
-        public string AfterRestoreCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the cell has been successfully saved.
-        /// </summary>
-        public string AfterSaveCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the cell and other data is posted to the server.
-        /// </summary>
-        public string AfterSubmitCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the class that is used for alternate rows.
-        /// </summary>
-        public string AltClass { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the grid should be "zebra-striped".
-        /// </summary>
-        public bool AltRows { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the grid should auto encode/decode the data.
-        /// </summary>
-        public bool AutoEncode { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the grid width will be recalculated automatically to the width of the parent element.
-        /// </summary>
-        public bool AutoWidth { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised before requesting any data.
-        /// </summary>
-        public string BeforeRequest { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised when the user click on the row, but before selecting it.
-        /// </summary>
-        public string BeforeSelectRow { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised before editing the cell.
-        /// </summary>
-        public string BeforeEditCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised before validation of values if any.
-        /// </summary>
-        public string BeforeSaveCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised before submit the cell content to the server.
-        /// </summary>
-        public string BeforeSubmitCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised before responce of the server is processed.
-        /// </summary>
-        public string BeforeProcessing { get; set; }
-
-        /// <summary>
-        /// Gets or sets the caption for the grid.
-        /// </summary>
-        public string Caption { get; set; }
-
-        /// <summary>
-        /// Gets or sets the padding plus border width of the cell.
-        /// </summary>
-        public int CellLayout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if cell editing is enabled
-        /// </summary>
-        public bool CellEditingEnabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets the cell editing submit mode
-        /// </summary>
-        public JqGridCellEditingSubmitModes CellEditingSubmitMode { get; set; }
-
-        /// <summary>
-        /// Gets or set the URL for cell editing submit
-        /// </summary>
-        public string CellEditingUrl { get; set; }
-
-        /// <summary>
-        /// Gets the list of columns parameters descriptions.
-        /// </summary>
-        public List<JqGridColumnModel> ColumnsModels { get { return _columnsModel; } }
-
-        /// <summary>
-        /// Gets the list of columns names.
-        /// </summary>
-        public List<string> ColumnsNames { get { return _columnsNames; } }
-
-        /// <summary>
-        /// Gets or sets the list of columns indexes for remaping (default null).
-        /// </summary>
-        public List<int> ColumnsRemaping { get; set;  }
-
-        /// <summary>
-        /// Gets or sets the string of data which will be used when DataType is set to JqGridDataTypes.XmlString or JqGridDataTypes.JsonString (default null).
-        /// </summary>
-        public string DataString { get; set; }
-
-        /// <summary>
-        /// Gets or sets the type of information to expect to represent data in the grid (default JqGridDataTypes.Xml).
-        /// </summary>
-        public JqGridDataTypes DataType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if jqGrid should be using jQuery.empty for the the row and all its children elements.
-        /// </summary>
-        public bool DeepEmpty { get; set; }
-
-        /// <summary>
-        /// Gets or sets the language direction in grid.
-        /// </summary>
-        public JqGridLanguageDirections Direction { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines if dynamic scrolling is enabled.
-        /// </summary>
-        public JqGridDynamicScrollingModes DynamicScrollingMode { get; set; }
-
-        /// <summary>
-        /// Gets or sets the timeout (in miliseconds) if DynamicScrollingMode is set to JqGridDynamicScrollingModes.HoldVisibleRows
-        /// </summary>
-        public int DynamicScrollingTimeout { get; set; }
-
-        /// <summary>
-        /// Gets or sets the url for inline and form editing.
-        /// </summary>
-        public string EditingUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the information to be displayed when the returned (or the current) number of records is zero.
-        /// </summary>
-        public string EmptyRecords { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the tree is expanded and/or collapsed when user clicks on the text of the expanded column, not only on the image.
-        /// </summary>
-        public bool ExpandColumnClick { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name of column which should be used to expand the tree grid.
-        /// </summary>
-        public string ExpandColumn { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised when there is a server error while saving cell.
-        /// </summary>
-        public string ErrorCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which allows formatting the cell content before editing.
-        /// </summary>
-        public string FormatCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the footer table (with one row) will be placed below the grid records and above the pager. The number of columns equal of these from ColumnsModels.
-        /// </summary>
-        public bool FooterEnabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after all the data is loaded into the grid and all other processes are complete.
-        /// </summary>
-        public string GridComplete { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if all the data should be inserted into DOM with one jQuery call (5 to 10 times faster).
-        /// </summary>
-        /// <remarks>Following features can not be used when this option is enabled:
-        /// <list type="bullet">
-        /// <item><description>TreeGrid</description></item>
-        /// <item><description>SubGrid</description></item>
-        /// <item><description>AfterInsertRow event.</description></item>
-        /// </list>
-        /// </remarks>
-        public bool GridView { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the grouping is enabled.
-        /// </summary>
-        public bool GroupingEnabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets the grouping view options.
-        /// </summary>
-        public JqGridGroupingView GroupingView { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the title attribute is added to the column headers.
-        /// </summary>
-        public bool HeaderTitles { get; set; }
-
-        /// <summary>
-        /// Gets or sets the height of the grid in pixels (default 'auto').
-        /// </summary>
-        public int? Height { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the grid is initialy hidden (no data loaded, only caption layer is shown).
-        /// Takes effect only if the Caption property is not empty string and HiddenEnabled is set to true.
-        /// </summary>
-        public bool Hidden { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the show/hide grid button is enabled.
-        /// Takes effect only if the Caption property is not empty string.
-        /// </summary>
-        public bool HiddenEnabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value which defines whether mouse hovering over the grid data rows is enabled.
-        /// </summary>
-        public bool HoverRows { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the local searching is case-sensitive.
-        /// </summary>
-        public bool IgnoreCase { get; set; }
-
-        /// <summary>
-        /// Gets or sets the JSON reader for the grid.
-        /// </summary>
-        public JqGridJsonReader JsonReader { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for pre-callback to modify the XMLHttpRequest object before it is sent.
-        /// </summary>
-        public string LoadBeforeSend { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised immediately after every server request.
-        /// </summary>
-        public string LoadComplete { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the request fails.
-        /// </summary>
-        public string LoadError { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the grid should load the data only once and all further manipulationsshould be done on the client side.
-        /// </summary>
-        public bool LoadOnce { get; set; }
-
-        /// <summary>
-        /// Gets or sets the type of request to make (default JqGridMethodTypes.Get).
-        /// </summary>
-        public JqGridMethodTypes MethodType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the key which should be pressed when the user makes multiselection.
-        /// </summary>
-        public JqGridMultiKeys? MultiKey { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the multiselection is done only when the checkbox is clicked.
-        /// </summary>
-        public bool MultiBoxOnly { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the multiselection is enabled.
-        /// </summary>
-        public bool MultiSelect { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the sorting by multiple columns is enabled.
-        /// </summary>
-        public bool MultiSort { get; set; }
-
-        /// <summary>
-        /// Gets or sets the width of the multiselect colum.
-        /// </summary>
-        public int MultiSelectWidth { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised when user clicks on particular cell in the grid.
-        /// </summary>
-        public string OnCellSelect { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised immediately after row was double clicked.
-        /// </summary>
-        public string OnDoubleClickRow { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after clicking to hide or show grid.
-        /// </summary>
-        public string OnHeaderClick { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised only once before populating the data.
-        /// </summary>
-        public string OnInitGrid { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised before populating the data after page index/size change.
-        /// </summary>
-        public string OnPaging { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised immediately after row was right clicked.
-        /// </summary>
-        public string OnRightClickRow { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised when MultipleSelect option is true and user clicks on the header checkbox.
-        /// </summary>
-        public string OnSelectAll { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the cell is selected for editing.
-        /// </summary>
-        public string OnSelectCell { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised immediately after row was clicked.
-        /// </summary>
-        public string OnSelectRow { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised immediately after sortable column was clicked and before sorting the data.
-        /// </summary>
-        public string OnSortCol { get; set; }
-
-        /// <summary>
-        /// Gets or sets if grid should use a pager bar to navigate through the records (default: false).
-        /// </summary>
-        public bool Pager { get; set; }
-
-        /// <summary>
-        /// Gets or sets the additional data which will be added to the request.
-        /// </summary>
-        public object PostData { get; set; }
-
-        /// <summary>
-        /// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the request (this property takes precedence over PostData).
-        /// </summary>
-        public string PostDataScript { get; set; }
-
-        /// <summary>
-        /// Gets or sets customized names for jqGrid request parameters.
-        /// </summary>
-        public JqGridParametersNames ParametersNames { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised when user starts resizing a column.
-        /// </summary>
-        public string ResizeStart { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised after the column is resized.
-        /// </summary>
-        public string ResizeStop { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function which can add attributes to the row during the creation of the data (dynamically).
-        /// </summary>
-        public string RowAttributes { get; set; }
-
-        /// <summary>
-        /// Gets or sets an array to construct a select box element in the pager in which user can change the number of the visible rows.
-        /// </summary>
-        public List<int> RowsList { get; set; }
-
-        /// <summary>
-        /// Gets or sets how many records should be displayed in the grid (default 20).
-        /// </summary>
-        public int RowsNumber { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether a new column, which purpose is to count the number of available rows, should be added at left of the grid.
-        /// </summary>
-        public bool RowsNumbers { get; set; }
-
-        /// <summary>
-        /// Gets or sets the width of the row number column.
-        /// </summary>
-        public int RowsNumbersWidth { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the columns width should be recalculated to fit the width of the grid.
-        /// </summary>
-        public bool ShrinkToFit { get; set; }
-
-        /// <summary>
-        /// Gets or sets the width of vertical scrollbar
-        /// </summary>
-        public int ScrollOffset { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which can serialize the data passed to the ajax request when the cell is being saved.
-        /// </summary>
-        public string SerializeCellData { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which can serialize the data passed to the ajax request.
-        /// </summary>
-        public string SerializeGridData { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which can serialize the data passed to the subgrid ajax request.
-        /// </summary>
-        public string SerializeSubGridData { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines whether the columns can be reordered by dragging and dropping them with the mouse.
-        /// </summary>
-        /// <remarks>This option requires the jQuery UI sortable widget and the jQuery UI Addons module.</remarks>
-        public bool Sortable { get; set; }
-
-        /// <summary>
-        /// Gets or sets the initial sorting column index, when  using data returned from server (default: String.Empty)
-        /// </summary>
-        public string SortingName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the initial sorting order, when  using data returned from server (default JqGridSortingOrders.Asc)
-        /// </summary>
-        public JqGridSortingOrders SortingOrder { get; set; }
-
-        /// <summary>
-        /// Gets or set the CSS framework  
-        /// </summary>
-        /// <remarks>
-        /// Available since Guriddo jqGrid 5.0
-        /// </remarks>
-        public JqGridStyleUIOptions StyleUI { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines if subgrid is enabled.
-        /// </summary>
-        public bool SubgridEnabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets the subgrid model.
-        /// </summary>
-        public JqGridSubgridModel SubgridModel { get; set; }
-
-        /// <summary>
-        /// Gets or sets the url for subgrid data requests.
-        /// </summary>
-        public string SubgridUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the width of subgrid expand/colapse column.
-        /// </summary>
-        public int SubgridColumnWidth { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised just before expanding the subgrid.
-        /// </summary>
-        public string SubGridBeforeExpand { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised when the user clicks on the plus icon of the grid.
-        /// </summary>
-        public string SubGridRowExpanded { get; set; }
-
-        /// <summary>
-        /// Gets or sets the function for event which is raised when the user clicks on the minus icon of the grid.
-        /// </summary>
-        public string SubGridRowColapsed { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if jqGrid should place a pager element at top of the grid below the caption (if available).
-        /// </summary>
-        public bool TopPager { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value which defines if TreeGrid is enabled.
-        /// </summary>
-        public bool TreeGridEnabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets the model for TreeGrid.
-        /// </summary>
-        public JqGridTreeGridModels TreeGridModel { get; set; }
-
-        /// <summary>
-        /// Gets or sets the url for data requests (default null)
-        /// </summary>
-        public string Url { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating if the values from user data should be placed on footer.
-        /// </summary>
-        public bool UserDataOnFooter { get; set; }
-
-        /// <summary>
-        /// Gets or sets if grid should display the beginning and ending record number out of the total number of records in the query (default: false)
-        /// </summary>
-        public bool ViewRecords { get; set; }
-
-        /// <summary>
-        /// Gets or sets the width of the grid in pixels (default 'auto').
-        /// </summary>
-        public int? Width { get; set; }
-        #endregion
-
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridOptions class.
-        /// </summary>
-        /// <param name="id">Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div (id='{0}Search') and in JavaScript.</param>
-        public JqGridOptions(string id)
-        {
-            CompatibilityMode = JqGridCompatibilityModes.JqGrid;
-            Id = id;
-            _columnsModel = new List<JqGridColumnModel>();
-            _columnsNames = new List<string>();
-
-            AfterInsertRow = null;
-            AfterEditCell = null;
-            AfterRestoreCell = null;
-            AfterSaveCell = null;
-            AfterSubmitCell = null;
-            AltClass = JqGridOptionsDefaults.AltClass;
-            AltRows = false;
-            AutoEncode = false;
-            AutoWidth = false;
-            BeforeRequest = null;
-            BeforeSelectRow = null;
-            BeforeEditCell = null;
-            BeforeSaveCell = null;
-            BeforeSubmitCell = null;
-            Caption = String.Empty;
-            CellLayout = JqGridOptionsDefaults.CellLayout;
-            CellEditingEnabled = false;
-            CellEditingSubmitMode = JqGridCellEditingSubmitModes.Remote;
-            CellEditingUrl = null;
-            ColumnsRemaping = null;
-            DataString = null;
-            DataType = JqGridDataTypes.Xml;
-            DeepEmpty = false;
-            Direction = JqGridLanguageDirections.Ltr;
-            DynamicScrollingMode = JqGridDynamicScrollingModes.Disabled;
-            DynamicScrollingTimeout = 200;
-            EditingUrl = null;
-            EmptyRecords = JqGridOptionsDefaults.EmptyRecords;
-            ExpandColumn = null;
-            ExpandColumnClick = true;
-            ErrorCell = null;
-            FormatCell = null;
-            FooterEnabled = false;
-            GridComplete = null;
-            GridView = false;
-            GroupingEnabled = false;
-            GroupingView = null;
-            HeaderTitles = false;
-            Height = null;
-            Hidden = false;
-            HiddenEnabled = true;
-            HoverRows = true;
-            IgnoreCase = false;
-            JsonReader = JqGridResponse.JsonReader;
-            LoadBeforeSend = null;
-            LoadComplete = null;
-            LoadError = null;
-            LoadOnce = false;
-            MethodType = JqGridMethodTypes.Get;
-            MultiBoxOnly = false;
-            MultiKey = null;
-            MultiSelect = false;
-            MultiSelectWidth = 20;
-            MultiSort = false;
-            OnCellSelect = null;
-            OnDoubleClickRow = null;
-            OnHeaderClick = null;
-            OnPaging = null;
-            OnRightClickRow = null;
-            OnSelectAll = null;
-            OnSelectCell = null;
-            OnSelectRow = null;
-            OnSortCol = null;
-            Pager = false;
-            ParametersNames = JqGridRequest.ParameterNames;
-            ResizeStart = null;
-            ResizeStop = null;
-            RowsList = null;
-            RowsNumber = 20;
-            RowsNumbers = false;
-            RowsNumbersWidth = 25;
-            ScrollOffset = 18;
-            ShrinkToFit = true;
-            SerializeCellData = null;
-            SerializeGridData = null;
-            SerializeSubGridData = null;
-            Sortable = false;
-            SortingName = String.Empty;
-            SortingOrder = JqGridSortingOrders.Asc;
-            StyleUI = JqGridStyleUIOptions.jQueryUI;
-            SubgridColumnWidth = 20;
-            SubgridEnabled = false;
-            SubgridModel = null;
-            SubgridUrl = String.Empty;
-            SubGridBeforeExpand = null;
-            SubGridRowColapsed = null;
-            SubGridRowExpanded = null;
-            TopPager = false;
-            TreeGridEnabled = false;
-            TreeGridModel = JqGridTreeGridModels.Nested;
-            Url = null;
-            UserDataOnFooter = false;
-            ViewRecords = false;
-            Width = null;
-        }
-        #endregion
-
-        #region Methods
-        internal bool UseDataString()
-        {
-            return (this.DataType == JqGridDataTypes.JsonString || this.DataType == JqGridDataTypes.XmlString);
-        }
-        #endregion
-    }
+	/// <summary>
+	/// Options passed to helper's constructor
+	/// </summary>
+	public class JqGridOptions
+	{
+		#region Fields
+		private string _afterInsertRow;
+		private string _afterEditCell;
+		private string _afterRestoreCell;
+		private string _afterSaveCell;
+		private string _afterSubmitCell;
+		private string _altClass;
+		private string _beforeRequest;
+		private string _beforeSelectRow;
+		private string _beforeEditCell;
+		private string _beforeSaveCell;
+		private string _beforeSubmitCell;
+		private string _beforeProcessing;
+		private string _caption;
+		private string _cellEditingUrl;
+		private string _editingUrl;
+		private string _emptyRecords;
+		private string _expandColumn;
+		private string _errorCell;
+		private string _formatCell;
+		private string _gridComplete;
+		private string _loadBeforeSend;
+		private string _loadComplete;
+		private string _loadError;
+		private string _onCellSelect;
+		private string _onDoubleClickRow;
+		private string _onHeaderClick;
+		private string _onInitGrid;
+		private string _onPaging;
+		private string _onRightClickRow;
+		private string _onSelectAll;
+		private string _onSelectCell;
+		private string _onSelectRow;
+		private string _onSortCol;
+		private object _postData;
+		private string _postDataScript;
+		private string _resizeStart;
+		private string _resizeStop;
+		private string _rowAttributes;
+		private string _serializeCellData;
+		private string _serializeGridData;
+		private string _serializeSubGridData;
+		private string _sortingName;
+		private string _subgridUrl;
+		private string _subGridBeforeExpand;
+		private string _subGridRowExpanded;
+		private string _subGridRowColapsed;
+		private string _url;
+
+		#endregion
+
+		#region Properties
+
+		/// <summary>
+		/// Gets the grid identifier which will be used for table (id='{0}'), pager div (id='{0}Pager') and in JavaScript.
+		/// </summary>
+		public string Id { get; }
+
+		/// <summary>
+		/// Gets the list of columns parameters descriptions.
+		/// </summary>
+		public List<JqGridColumnModel> ColumnsModels { get; private set; }
+
+		/// <summary>
+		/// Gets the list of columns names.
+		/// </summary>
+		public List<string> ColumnsNames { get; private set; }
+
+		/// <summary>
+		/// Gets or sets the list of columns indexes for remaping (default null).
+		/// </summary>
+		public List<int> ColumnsRemaping { get; set; }
+
+		/// <summary>
+		/// Gets or sets default compatibility mode
+		/// </summary>
+		public static JqGridCompatibilityModes DefaultCompatibilityMode { get; set; } = JqGridCompatibilityModes.JqGrid;
+
+		/// <summary>
+		/// Gets or sets the jqGrid compatibility mode.
+		/// </summary>
+		public JqGridCompatibilityModes CompatibilityMode { get; set; } = DefaultCompatibilityMode;
+
+		internal bool IsAfterInsertRowSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after every inserted row.
+		/// </summary>
+		public string AfterInsertRow
+		{
+			get => _afterInsertRow;
+			set
+			{
+				_afterInsertRow = value;
+				IsAfterInsertRowSetted = true;
+			}
+		}
+
+		internal bool IsAfterEditCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the edited cell is edited.
+		/// </summary>
+		public string AfterEditCell
+		{
+			get => _afterEditCell;
+			set
+			{
+				_afterEditCell = value;
+				IsAfterInsertRowSetted = true;
+			}
+		}
+
+		internal bool IsAfterRestoreCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after calling the method restoreCell or the user press ESC leaving the changes.
+		/// </summary>
+		public string AfterRestoreCell
+		{
+			get => _afterRestoreCell;
+			set
+			{
+				_afterRestoreCell = value;
+				IsAfterRestoreCellSetted = true;
+			}
+		}
+
+		internal bool IsAfterSaveCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the cell has been successfully saved.
+		/// </summary>
+		public string AfterSaveCell
+		{
+			get => _afterSaveCell;
+			set
+			{
+				_afterSaveCell = value;
+				IsAfterSaveCellSetted = true;
+			}
+		}
+
+		internal bool IsAfterSumbitCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the cell and other data is posted to the server.
+		/// </summary>
+		public string AfterSubmitCell
+		{
+			get => _afterSubmitCell;
+			set
+			{
+				_afterSubmitCell = value;
+				IsAfterSumbitCellSetted = true;
+			}
+		}
+
+		internal bool IsAltClassSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the class that is used for alternate rows.
+		/// </summary>
+		/// <remarks>In Guriddo JqGrid this options is deprecated as of version 5.2</remarks>
+		public string AltClass
+		{
+			get => _altClass;
+			set
+			{
+				_altClass = value;
+				IsAltClassSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value indicating if the grid should be "zebra-striped".
+		/// </summary>
+		public bool? AltRows { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the grid should auto encode/decode the data.
+		/// </summary>
+		public bool? AutoEncode { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the grid width will be recalculated automatically to the width of the parent element.
+		/// </summary>
+		public bool? AutoWidth { get; set; }
+
+		internal bool IsBeforeRequestSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before requesting any data.
+		/// </summary>
+		public string BeforeRequest
+		{
+			get => _beforeRequest;
+			set
+			{
+				_beforeRequest = value;
+				IsBeforeRequestSetted = true;
+			}
+		}
+
+		internal bool IsBeforeSelectRowSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when the user click on the row, but before selecting it.
+		/// </summary>
+		public string BeforeSelectRow
+		{
+			get => _beforeSelectRow;
+			set
+			{
+				_beforeSelectRow = value;
+				IsBeforeSelectRowSetted = true;
+			}
+		}
+
+		internal bool IsBeforeEditCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before editing the cell.
+		/// </summary>
+		public string BeforeEditCell
+		{
+			get => _beforeEditCell;
+			set
+			{
+				_beforeEditCell = value;
+				IsBeforeEditCellSetted = true;
+			}
+		}
+
+		internal bool IsBeforeSaveCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before validation of values if any.
+		/// </summary>
+		public string BeforeSaveCell
+		{
+			get => _beforeSaveCell;
+			set
+			{
+				_beforeSaveCell = value;
+				IsBeforeSaveCellSetted = true;
+			}
+		}
+
+		internal bool IsBeforeSubmitCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before submit the cell content to the server.
+		/// </summary>
+		public string BeforeSubmitCell
+		{
+			get => _beforeSubmitCell;
+			set
+			{
+				_beforeSubmitCell = value;
+				IsBeforeSubmitCellSetted = true;
+			}
+		}
+
+		internal bool IsBeforeProcessingSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before responce of the server is processed.
+		/// </summary>
+		public string BeforeProcessing
+		{
+			get => _beforeProcessing;
+			set
+			{
+				_beforeProcessing = value;
+				IsBeforeProcessingSetted = true;
+			}
+		}
+
+		internal bool IsCaptionSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the caption for the grid.
+		/// </summary>
+		public string Caption
+		{
+			get => _caption;
+			set
+			{
+				_caption = value;
+				IsCaptionSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the padding plus border width of the cell.
+		/// </summary>
+		public int? CellLayout { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if cell editing is enabled
+		/// </summary>
+		public bool? CellEditingEnabled { get; set; }
+
+		/// <summary>
+		/// Gets or sets the cell editing submit mode
+		/// </summary>
+		public JqGridCellEditingSubmitModes CellEditingSubmitMode { get; set; } = JqGridCellEditingSubmitModes.Default;
+
+		internal bool IsCellEditingUrlSetted { get; private set; }
+		/// <summary>
+		/// Gets or set the URL for cell editing submit
+		/// </summary>
+		public string CellEditingUrl
+		{
+			get => _cellEditingUrl;
+			set
+			{
+				_cellEditingUrl = value;
+				IsCellEditingUrlSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the string of data which will be used when DataType is set to JqGridDataTypes.XmlString or JqGridDataTypes.JsonString (default null).
+		/// </summary>
+		public string DataString { get; set; }
+
+		/// <summary>
+		/// Gets or sets the type of information to expect to represent data in the grid (default JqGridDataTypes.Xml).
+		/// </summary>
+		public JqGridDataTypes DataType { get; set; } = JqGridDataTypes.Default;
+
+		/// <summary>
+		/// Gets or sets the value indicating if jqGrid should be using jQuery.empty for the the row and all its children elements.
+		/// </summary>
+		public bool? DeepEmpty { get; set; }
+
+		/// <summary>
+		/// Gets or sets the language direction in grid.
+		/// </summary>
+		public JqGridLanguageDirections Direction { get; set; } = JqGridLanguageDirections.Default;
+
+		/// <summary>
+		/// Gets or sets the value which defines if dynamic scrolling is enabled.
+		/// </summary>
+		public JqGridDynamicScrollingModes DynamicScrollingMode { get; set; } = JqGridDynamicScrollingModes.Default;
+
+		/// <summary>
+		/// Gets or sets the timeout (in miliseconds) if DynamicScrollingMode is set to JqGridDynamicScrollingModes.HoldVisibleRows
+		/// </summary>
+		public int? DynamicScrollingTimeout { get; set; }
+
+		internal bool IsEditingUrlSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the url for inline and form editing.
+		/// </summary>
+		public string EditingUrl
+		{
+			get => _editingUrl;
+			set
+			{
+				_editingUrl = value;
+				IsEditingUrlSetted = true;
+			}
+		}
+
+		internal bool IsEmptyRecordsSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the information to be displayed when the returned (or the current) number of records is zero.
+		/// </summary>
+		public string EmptyRecords
+		{
+			get => _emptyRecords;
+			set
+			{
+				_emptyRecords = value;
+				IsEmptyRecordsSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the tree is expanded and/or collapsed when user clicks on the text of the expanded column, not only on the image.
+		/// </summary>
+		public bool? ExpandColumnClick { get; set; }
+
+		internal bool IsExpandColumnSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the name of column which should be used to expand the tree grid.
+		/// </summary>
+		public string ExpandColumn
+		{
+			get => _expandColumn;
+			set
+			{
+				_expandColumn = value;
+				IsExpandColumnSetted = true;
+			}
+		}
+
+		internal bool IsErrorCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when there is a server error while saving cell.
+		/// </summary>
+		public string ErrorCell
+		{
+			get => _errorCell;
+			set
+			{
+				_errorCell = value;
+				IsErrorCellSetted = true;
+			}
+		}
+
+		internal bool IsFormatCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which allows formatting the cell content before editing.
+		/// </summary>
+		public string FormatCell
+		{
+			get => _formatCell;
+			set
+			{
+				_formatCell = value;
+				IsFormatCellSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value indicating if the footer table (with one row) will be placed below the grid records and above the pager. The number of columns equal of these from ColumnsModels.
+		/// </summary>
+		public bool? FooterEnabled { get; set; }
+
+		internal bool IsGridCompleteSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after all the data is loaded into the grid and all other processes are complete.
+		/// </summary>
+		public string GridComplete
+		{
+			get => _gridComplete;
+			set
+			{
+				_gridComplete = value;
+				IsGridCompleteSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value indicating if all the data should be inserted into DOM with one jQuery call (5 to 10 times faster).
+		/// </summary>
+		/// <remarks>Following features can not be used when this option is enabled:
+		/// <list type="bullet">
+		/// <item><description>TreeGrid</description></item>
+		/// <item><description>SubGrid</description></item>
+		/// <item><description>AfterInsertRow event.</description></item>
+		/// </list>
+		/// </remarks>
+		public bool? GridView { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the grouping is enabled.
+		/// </summary>
+		public bool? GroupingEnabled { get; set; }
+
+		/// <summary>
+		/// Gets or sets the grouping view options.
+		/// </summary>
+		public JqGridGroupingView GroupingView { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value indicating if the title attribute is added to the column headers.
+		/// </summary>
+		public bool? HeaderTitles { get; set; }
+
+		/// <summary>
+		/// Gets or sets the height of the grid in pixels (default 'auto').
+		/// </summary>
+		public int? Height { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the grid is initialy hidden (no data loaded, only caption layer is shown).
+		/// Takes effect only if the Caption property is not empty string and HiddenEnabled is set to true.
+		/// </summary>
+		public bool? Hidden { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the show/hide grid button is enabled.
+		/// Takes effect only if the Caption property is not empty string.
+		/// </summary>
+		public bool? HiddenEnabled { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value which defines whether mouse hovering over the grid data rows is enabled.
+		/// </summary>
+		public bool? HoverRows { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the local searching is case-sensitive.
+		/// </summary>
+		public bool? IgnoreCase { get; set; }
+
+		/// <summary>
+		/// Gets or sets the JSON reader for the grid, set this if you want to change JsonReader for this grid
+		/// </summary>
+		public JqGridJsonReader JsonReader { get; set; }
+
+		internal bool IsLoadBeforeSendSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for pre-callback to modify the XMLHttpRequest object before it is sent.
+		/// </summary>
+		public string LoadBeforeSend
+		{
+			get => _loadBeforeSend;
+			set
+			{
+				_loadBeforeSend = value;
+				IsLoadBeforeSendSetted = true;
+			}
+		}
+
+		internal bool IsLoadCompleteSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised immediately after every server request.
+		/// </summary>
+		public string LoadComplete
+		{
+			get => _loadComplete;
+			set
+			{
+				_loadComplete = value;
+				IsLoadCompleteSetted = true;
+			}
+		}
+
+		internal bool IsLoadErrorSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the request fails.
+		/// </summary>
+		public string LoadError
+		{
+			get => _loadError;
+			set
+			{
+				_loadError = value;
+				IsLoadErrorSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the grid should load the data only once and all further manipulationsshould be done on the client side.
+		/// </summary>
+		public bool? LoadOnce { get; set; }
+
+		/// <summary>
+		/// Gets or sets the type of request to make (default JqGridMethodTypes.Get).
+		/// </summary>
+		public JqGridMethodTypes MethodType { get; set; } = JqGridMethodTypes.Default;
+
+		/// <summary>
+		/// Gets or sets the key which should be pressed when the user makes multiselection.
+		/// </summary>
+		public JqGridMultiKeys MultiKey { get; set; } = JqGridMultiKeys.Default;
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the multiselection is done only when the checkbox is clicked.
+		/// </summary>
+		public bool? MultiBoxOnly { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the multiselection is enabled.
+		/// </summary>
+		public bool? MultiSelect { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the sorting by multiple columns is enabled.
+		/// </summary>
+		public bool? MultiSort { get; set; }
+
+		/// <summary>
+		/// Gets or sets the width of the multiselect colum.
+		/// </summary>
+		public int? MultiSelectWidth { get; set; }
+
+		internal bool IsOnCellSelectSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when user clicks on particular cell in the grid.
+		/// </summary>
+		public string OnCellSelect
+		{
+			get => _onCellSelect;
+			set
+			{
+				_onCellSelect = value;
+				IsOnCellSelectSetted = true;
+			}
+		}
+
+		internal bool IsOnDoubleClickRowSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised immediately after row was double clicked.
+		/// </summary>
+		public string OnDoubleClickRow
+		{
+			get => _onDoubleClickRow;
+			set
+			{
+				_onDoubleClickRow = value;
+				IsOnDoubleClickRowSetted = true;
+			}
+		}
+
+		internal bool IsOnHeaderClickSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after clicking to hide or show grid.
+		/// </summary>
+		public string OnHeaderClick
+		{
+			get => _onHeaderClick;
+			set
+			{
+				_onHeaderClick = value;
+				IsOnHeaderClickSetted = true;
+			}
+		}
+
+		internal bool IsOnInitGridSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised only once before populating the data.
+		/// </summary>
+		public string OnInitGrid
+		{
+			get => _onInitGrid;
+			set
+			{
+				_onInitGrid = value;
+				IsOnInitGridSetted = true;
+			}
+		}
+
+		internal bool IsOnPagingSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised before populating the data after page index/size change.
+		/// </summary>
+		public string OnPaging
+		{
+			get => _onPaging;
+			set
+			{
+				_onPaging = value;
+				IsOnPagingSetted = true;
+			}
+		}
+
+		internal bool IsOnRightClickRowSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised immediately after row was right clicked.
+		/// </summary>
+		public string OnRightClickRow
+		{
+			get => _onRightClickRow;
+			set
+			{
+				_onRightClickRow = value;
+				IsOnRightClickRowSetted = true;
+			}
+		}
+
+		internal bool IsOnSelectAllSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when MultipleSelect option is true and user clicks on the header checkbox.
+		/// </summary>
+		public string OnSelectAll
+		{
+			get => _onSelectAll;
+			set
+			{
+				_onSelectAll = value;
+				IsOnSelectAllSetted = true;
+			}
+		}
+
+		internal bool IsOnSelectCellSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the cell is selected for editing.
+		/// </summary>
+		public string OnSelectCell
+		{
+			get => _onSelectCell;
+			set
+			{
+				_onSelectCell = value;
+				IsOnSelectCellSetted = true;
+			}
+		}
+
+		internal bool IsOnSelectRowSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised immediately after row was clicked.
+		/// </summary>
+		public string OnSelectRow
+		{
+			get => _onSelectRow;
+			set
+			{
+				_onSelectRow = value;
+				IsOnSelectRowSetted = true;
+			}
+		}
+
+		internal bool IsOnSortColSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised immediately after sortable column was clicked and before sorting the data.
+		/// </summary>
+		public string OnSortCol
+		{
+			get => _onSortCol;
+			set
+			{
+				_onSortCol = value;
+				IsOnSortColSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets if grid should use a pager bar to navigate through the records (default: false).
+		/// </summary>
+		public bool Pager { get; set; }
+
+		internal bool IsPostDataSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the additional data which will be added to the request.
+		/// </summary>
+		public object PostData
+		{
+			get => _postData;
+			set
+			{
+				_postData = value;
+				IsPostDataSetted = true;
+			}
+		}
+
+		internal bool IsPostDataScriptSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the JavaScript which will dynamically generate the additional data which will be added to the request (this property takes precedence over PostData).
+		/// </summary>
+		public string PostDataScript
+		{
+			get => _postDataScript;
+			set
+			{
+				_postDataScript = value;
+				IsPostDataScriptSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets customized names for jqGrid request parameters. Set this if you want redefine ParametersNames for this grid.
+		/// </summary>
+		public JqGridParametersNames ParametersNames { get; set; }
+
+		internal bool IsResizeStartSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when user starts resizing a column.
+		/// </summary>
+		public string ResizeStart
+		{
+			get => _resizeStart;
+			set
+			{
+				_resizeStart = value;
+				IsResizeStartSetted = true;
+			}
+		}
+
+		internal bool IsResizeStopSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised after the column is resized.
+		/// </summary>
+		public string ResizeStop
+		{
+			get => _resizeStop;
+			set
+			{
+				_resizeStop = value;
+				IsResizeStopSetted = true;
+			}
+		}
+
+		internal bool IsRowAttributesSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function which can add attributes to the row during the creation of the data (dynamically).
+		/// </summary>
+		public string RowAttributes
+		{
+			get => _rowAttributes;
+			set
+			{
+				_rowAttributes = value;
+				IsRowAttributesSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets an array to construct a select box element in the pager in which user can change the number of the visible rows.
+		/// </summary>
+		public IEnumerable<int> RowsList { get; set; }
+
+		/// <summary>
+		/// Gets or sets how many records should be displayed in the grid (default 20).
+		/// </summary>
+		public int? RowsNumber { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines whether a new column, which purpose is to count the number of available rows, should be added at left of the grid.
+		/// </summary>
+		public bool? RowsNumbers { get; set; }
+
+		/// <summary>
+		/// Gets or sets the width of the row number column.
+		/// </summary>
+		public int? RowsNumbersWidth { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the columns width should be recalculated to fit the width of the grid.
+		/// </summary>
+		public bool? ShrinkToFit { get; set; }
+
+		/// <summary>
+		/// Gets or sets the width of vertical scrollbar
+		/// </summary>
+		public int? ScrollOffset { get; set; }
+
+		internal bool IsSerializeCellDataSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which can serialize the data passed to the ajax request when the cell is being saved.
+		/// </summary>
+		public string SerializeCellData
+		{
+			get => _serializeCellData;
+			set
+			{
+				_serializeCellData = value;
+				IsSerializeCellDataSetted = true;
+			}
+		}
+
+		internal bool IsSerializeGridDataSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which can serialize the data passed to the ajax request.
+		/// </summary>
+		public string SerializeGridData
+		{
+			get => _serializeGridData;
+			set
+			{
+				_serializeGridData = value;
+				IsSerializeGridDataSetted = true;
+			}
+		}
+
+		internal bool IsSerializeSubGridDataSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which can serialize the data passed to the subgrid ajax request.
+		/// </summary>
+		public string SerializeSubGridData
+		{
+			get => _serializeSubGridData;
+			set
+			{
+				_serializeSubGridData = value;
+				IsSerializeSubGridDataSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value which defines whether the columns can be reordered by dragging and dropping them with the mouse.
+		/// </summary>
+		/// <remarks>This option requires the jQuery UI sortable widget and the jQuery UI Addons module.</remarks>
+		public bool? Sortable { get; set; }
+
+		internal bool IsSortingNameSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the initial sorting column index, when  using data returned from server (default: String.Empty)
+		/// </summary>
+		public string SortingName
+		{
+			get => _sortingName;
+			set
+			{
+				_sortingName = value;
+				IsSortingNameSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the initial sorting order, when  using data returned from server (default JqGridSortingOrders.Asc)
+		/// </summary>
+		public JqGridSortingOrders SortingOrder { get; set; } = JqGridSortingOrders.Default;
+
+		/// <summary>
+		/// Gets or set the CSS framework  
+		/// </summary>
+		/// <remarks>
+		/// Available since Guriddo jqGrid 5.0
+		/// </remarks>
+		public JqGridStyleUIOptions StyleUI { get; set; } = JqGridStyleUIOptions.Default;
+
+		/// <summary>
+		/// Gets or set the icon set for Bootstrap 4 style UI
+		/// </summary>
+		/// <remarks>Available since Gurido JqGrid 5.3.0</remarks>
+		public JqGridBootstrap4IconSet IconSet { get; set; } = JqGridBootstrap4IconSet.Default;
+
+		/// <summary>
+		/// Gets or sets the value which defines if subgrid is enabled.
+		/// </summary>
+		public bool? SubgridEnabled { get; set; }
+
+		/// <summary>
+		/// Gets or sets the subgrid model.
+		/// </summary>
+		public JqGridSubgridModel SubgridModel { get; set; }
+
+		internal bool IsSubgridUrlSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the url for subgrid data requests.
+		/// </summary>
+		public string SubgridUrl
+		{
+			get => _subgridUrl;
+			set
+			{
+				_subgridUrl = value;
+				IsSubgridUrlSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the width of subgrid expand/colapse column.
+		/// </summary>
+		public int? SubgridColumnWidth { get; set; }
+
+		internal bool IsSubGridBeforeExpandSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised just before expanding the subgrid.
+		/// </summary>
+		public string SubGridBeforeExpand
+		{
+			get => _subGridBeforeExpand;
+			set
+			{
+				_subGridBeforeExpand = value;
+				IsSubGridBeforeExpandSetted = true;
+			}
+		}
+
+		internal bool IsSubGridRowExpandedSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when the user clicks on the plus icon of the grid.
+		/// </summary>
+		public string SubGridRowExpanded
+		{
+			get => _subGridRowExpanded;
+			set
+			{
+				_subGridRowExpanded = value;
+				IsSubGridRowExpandedSetted = true;
+			}
+		}
+
+		internal bool IsSubGridRowColapsedSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the function for event which is raised when the user clicks on the minus icon of the grid.
+		/// </summary>
+		public string SubGridRowColapsed
+		{
+			get => _subGridRowColapsed;
+			set
+			{
+				_subGridRowColapsed = value;
+				IsSubGridRowColapsedSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value indicating if jqGrid should place a pager element at top of the grid below the caption (if available).
+		/// </summary>
+		public bool? TopPager { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value which defines if TreeGrid is enabled.
+		/// </summary>
+		public bool? TreeGridEnabled { get; set; }
+
+		/// <summary>
+		/// Gets or sets the model for TreeGrid.
+		/// </summary>
+		public JqGridTreeGridModels TreeGridModel { get; set; }
+
+		internal bool IsUrlSetted { get; private set; }
+		/// <summary>
+		/// Gets or sets the url for data requests (default null)
+		/// </summary>
+		public string Url
+		{
+			get => _url;
+			set
+			{
+				_url = value;
+				IsUrlSetted = true;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value indicating if the values from user data should be placed on footer.
+		/// </summary>
+		public bool? UserDataOnFooter { get; set; }
+
+		/// <summary>
+		/// Gets or sets if grid should display the beginning and ending record number out of the total number of records in the query (default: false)
+		/// </summary>
+		public bool? ViewRecords { get; set; }
+
+		/// <summary>
+		/// Gets or sets the width of the grid in pixels (default 'auto').
+		/// </summary>
+		public int? Width { get; set; }
+
+		internal bool IsUsedDataString => DataType == JqGridDataTypes.JsonString || DataType == JqGridDataTypes.XmlString;
+
+		#endregion
+
+		#region Constructors
+		/// <summary>
+		/// Initialize new instant of JqGridOptions.
+		/// </summary>
+		/// <param name="id">Id of Grid</param>
+		public JqGridOptions(string id)
+		{
+			Id = id;
+			ColumnsModels = new List<JqGridColumnModel>();
+			ColumnsNames = new List<string>();
+		}
+
+		/// <summary>
+		/// Initialize new instant of JqGridOptions.
+		/// </summary>
+		/// <param name="id">Id of Grid</param>
+		/// <param name="modelType">Type of used model</param>
+		public JqGridOptions(string id, Type modelType)
+			: this(id)
+		{
+			SetModel(modelType);
+		}
+
+		#endregion
+
+		#region Methods
+		/// <summary>
+		/// Sets the grid columns models
+		/// </summary>
+		/// <param name="modelType"></param>
+		public void SetModel(Type modelType)
+		{
+			ColumnsModels = new List<JqGridColumnModel>();
+			ColumnsNames = new List<string>();
+			var jqGridModelMetadata = ModelMetadataProviders.Current.GetMetadataForType(null, modelType);
+			foreach (var propertyMetadata in jqGridModelMetadata.Properties.Where(p => p.IsValidForColumn()))
+			{
+				var columnModel = new JqGridColumnModel(propertyMetadata);
+				ColumnsModels.Add(columnModel);
+				ColumnsNames.Add(propertyMetadata.GetDisplayName());
+			}
+		}
+
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridOptions`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridOptions`1.cs
@@ -1,34 +1,23 @@
-﻿using System.Linq;
-using System.Web.Mvc;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jqGrid options
-    /// </summary>
-    /// <typeparam name="TModel">Type of model for grid</typeparam>
-    public sealed class JqGridOptions<TModel> : JqGridOptions
-    {
-        #region Properties
-        internal ModelMetadata JqGridModelMetadata { get; private set; }
-        #endregion
+	/// <inheritdoc />
+	/// <summary>
+	/// jqGrid options
+	/// </summary>
+	/// <typeparam name="TModel">Type of model for grid</typeparam>
+	public sealed class JqGridOptions<TModel> : JqGridOptions
+	{
+		#region Constructor
+		/// <inheritdoc />
+		/// <summary>
+		/// Initializes a new instance of the JqGridOptions class.
+		/// </summary>
+		/// <param name="id">Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div (id='{0}Search') and in JavaScript.</param>
+		public JqGridOptions(string id)
+			: base(id, typeof(TModel))
+		{
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridOptions class.
-        /// </summary>
-        /// <param name="id">Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div (id='{0}Search') and in JavaScript.</param>
-        public JqGridOptions(string id)
-            : base (id)
-        {
-            JqGridModelMetadata = ModelMetadataProviders.Current.GetMetadataForType(null, typeof(TModel));
-            foreach (ModelMetadata propertyMetadata in JqGridModelMetadata.Properties.Where(p => p.IsValidForColumn()))
-            {
-                JqGridColumnModel columnModel = new JqGridColumnModel(propertyMetadata);
-                ColumnsModels.Add(columnModel);
-                ColumnsNames.Add(propertyMetadata.GetDisplayName());
-            }
-        }
-        #endregion
-    }
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridOptions`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridOptions`1.cs
@@ -1,23 +1,27 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <inheritdoc />
-	/// <summary>
-	/// jqGrid options
-	/// </summary>
-	/// <typeparam name="TModel">Type of model for grid</typeparam>
-	public sealed class JqGridOptions<TModel> : JqGridOptions
-	{
-		#region Constructor
-		/// <inheritdoc />
-		/// <summary>
-		/// Initializes a new instance of the JqGridOptions class.
-		/// </summary>
-		/// <param name="id">Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div (id='{0}Search') and in JavaScript.</param>
-		public JqGridOptions(string id)
-			: base(id, typeof(TModel))
-		{
+    /// <inheritdoc />
+    /// <summary>
+    ///     jqGrid options
+    /// </summary>
+    /// <typeparam name="TModel">Type of model for grid</typeparam>
+    public sealed class JqGridOptions<TModel> : JqGridOptions
+    {
+        #region Constructor
 
-		}
-		#endregion
-	}
+        /// <inheritdoc />
+        /// <summary>
+        ///     Initializes a new instance of the JqGridOptions class.
+        /// </summary>
+        /// <param name="id">
+        ///     Identifier, which will be used for table (id='{0}'), pager div (id='{0}Pager'), filter grid div
+        ///     (id='{0}Search') and in JavaScript.
+        /// </param>
+        public JqGridOptions(string id)
+            : base(id, typeof(TModel))
+        {
+        }
+
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridParametersNames.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridParametersNames.cs
@@ -2,131 +2,131 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents names for jqGrid request parameters.
-	/// </summary>
-	public class JqGridParametersNames
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or sets the name for page index parametr.
-		/// </summary>
-		public string PageIndex { get; set; }
+    /// <summary>
+    /// Class which represents names for jqGrid request parameters.
+    /// </summary>
+    public class JqGridParametersNames
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or sets the name for page index parametr.
+        /// </summary>
+        public string PageIndex { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for records count parametr.
-		/// </summary>
-		public string RecordsCount { get; set; }
+        /// <summary>
+        /// Gets or sets the name for records count parametr.
+        /// </summary>
+        public string RecordsCount { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for sorting name parametr.
-		/// </summary>
-		public string SortingName { get; set; }
+        /// <summary>
+        /// Gets or sets the name for sorting name parametr.
+        /// </summary>
+        public string SortingName { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for sorting order parametr.
-		/// </summary>
-		public string SortingOrder { get; set; }
+        /// <summary>
+        /// Gets or sets the name for sorting order parametr.
+        /// </summary>
+        public string SortingOrder { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for searching parametr.
-		/// </summary>
-		public string Searching { get; set; }
+        /// <summary>
+        /// Gets or sets the name for searching parametr.
+        /// </summary>
+        public string Searching { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for id parametr.
-		/// </summary>
-		public string Id { get; set; }
+        /// <summary>
+        /// Gets or sets the name for id parametr.
+        /// </summary>
+        public string Id { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for operator parametr.
-		/// </summary>
-		public string Operator { get; set; }
+        /// <summary>
+        /// Gets or sets the name for operator parametr.
+        /// </summary>
+        public string Operator { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for edit operator parametr.
-		/// </summary>
-		public string EditOperator { get; set; }
+        /// <summary>
+        /// Gets or sets the name for edit operator parametr.
+        /// </summary>
+        public string EditOperator { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for add operator parametr.
-		/// </summary>
-		public string AddOperator { get; set; }
+        /// <summary>
+        /// Gets or sets the name for add operator parametr.
+        /// </summary>
+        public string AddOperator { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for delete operator parametr.
-		/// </summary>
-		public string DeleteOperator { get; set; }
+        /// <summary>
+        /// Gets or sets the name for delete operator parametr.
+        /// </summary>
+        public string DeleteOperator { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for subgrid id parametr.
-		/// </summary>
-		public string SubgridId { get; set; }
+        /// <summary>
+        /// Gets or sets the name for subgrid id parametr.
+        /// </summary>
+        public string SubgridId { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for pages count parametr.
-		/// </summary>
-		public string PagesCount { get; set; }
+        /// <summary>
+        /// Gets or sets the name for pages count parametr.
+        /// </summary>
+        public string PagesCount { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name for total rows parametr.
-		/// </summary>
-		public string TotalRows { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the name for total rows parametr.
+        /// </summary>
+        public string TotalRows { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridParametersNames class.
-		/// </summary>
-		public JqGridParametersNames()
-		{
-			PageIndex = JqGridOptionsDefaults.RequestPageIndex;
-			RecordsCount = JqGridOptionsDefaults.RequestRecordsCount;
-			SortingName = JqGridOptionsDefaults.RequestSortingName;
-			SortingOrder = JqGridOptionsDefaults.RequestSortingOrder;
-			Searching = JqGridOptionsDefaults.RequestSearching;
-			Id = JqGridOptionsDefaults.RequestId;
-			Operator = JqGridOptionsDefaults.RequestOperator;
-			EditOperator = JqGridOptionsDefaults.RequestEditOperator;
-			AddOperator = JqGridOptionsDefaults.RequestAddOperator;
-			DeleteOperator = JqGridOptionsDefaults.RequestDeleteOperator;
-			SubgridId = JqGridOptionsDefaults.RequestSubgridId;
-			PagesCount = null;
-			TotalRows = JqGridOptionsDefaults.RequestTotalRows;
-		}
-		#endregion
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridParametersNames class.
+        /// </summary>
+        public JqGridParametersNames()
+        {
+            PageIndex = JqGridOptionsDefaults.RequestPageIndex;
+            RecordsCount = JqGridOptionsDefaults.RequestRecordsCount;
+            SortingName = JqGridOptionsDefaults.RequestSortingName;
+            SortingOrder = JqGridOptionsDefaults.RequestSortingOrder;
+            Searching = JqGridOptionsDefaults.RequestSearching;
+            Id = JqGridOptionsDefaults.RequestId;
+            Operator = JqGridOptionsDefaults.RequestOperator;
+            EditOperator = JqGridOptionsDefaults.RequestEditOperator;
+            AddOperator = JqGridOptionsDefaults.RequestAddOperator;
+            DeleteOperator = JqGridOptionsDefaults.RequestDeleteOperator;
+            SubgridId = JqGridOptionsDefaults.RequestSubgridId;
+            PagesCount = null;
+            TotalRows = JqGridOptionsDefaults.RequestTotalRows;
+        }
+        #endregion
 
-		#region Methods
-		internal bool IsDefault()
-		{
-			return PageIndex == JqGridOptionsDefaults.RequestPageIndex
-				   && RecordsCount == JqGridOptionsDefaults.RequestRecordsCount
-				   && SortingName == JqGridOptionsDefaults.RequestSortingName
-				   && SortingOrder == JqGridOptionsDefaults.RequestSortingOrder
-				   && Searching == JqGridOptionsDefaults.RequestSearching
-				   && Id == JqGridOptionsDefaults.RequestId
-				   && Operator == JqGridOptionsDefaults.RequestOperator
-				   && EditOperator == JqGridOptionsDefaults.RequestEditOperator
-				   && AddOperator == JqGridOptionsDefaults.RequestAddOperator
-				   && DeleteOperator == JqGridOptionsDefaults.RequestDeleteOperator
-				   && SubgridId == JqGridOptionsDefaults.RequestSubgridId
-				   && string.IsNullOrWhiteSpace(PagesCount)
-				   && TotalRows == JqGridOptionsDefaults.RequestTotalRows;
-		}
+        #region Methods
+        internal bool IsDefault()
+        {
+            return PageIndex == JqGridOptionsDefaults.RequestPageIndex
+                   && RecordsCount == JqGridOptionsDefaults.RequestRecordsCount
+                   && SortingName == JqGridOptionsDefaults.RequestSortingName
+                   && SortingOrder == JqGridOptionsDefaults.RequestSortingOrder
+                   && Searching == JqGridOptionsDefaults.RequestSearching
+                   && Id == JqGridOptionsDefaults.RequestId
+                   && Operator == JqGridOptionsDefaults.RequestOperator
+                   && EditOperator == JqGridOptionsDefaults.RequestEditOperator
+                   && AddOperator == JqGridOptionsDefaults.RequestAddOperator
+                   && DeleteOperator == JqGridOptionsDefaults.RequestDeleteOperator
+                   && SubgridId == JqGridOptionsDefaults.RequestSubgridId
+                   && string.IsNullOrWhiteSpace(PagesCount)
+                   && TotalRows == JqGridOptionsDefaults.RequestTotalRows;
+        }
 
-		internal bool IsGlobal => PageIndex == JqGridRequest.ParameterNames.PageIndex
-								  && RecordsCount == JqGridRequest.ParameterNames.RecordsCount
-								  && SortingName == JqGridRequest.ParameterNames.SortingName
-								  && SortingOrder == JqGridRequest.ParameterNames.SortingOrder
-								  && Searching == JqGridRequest.ParameterNames.Searching
-								  && Id == JqGridRequest.ParameterNames.Id
-								  && Operator == JqGridRequest.ParameterNames.Operator
-								  && EditOperator == JqGridRequest.ParameterNames.EditOperator
-								  && AddOperator == JqGridRequest.ParameterNames.AddOperator
-								  && DeleteOperator == JqGridRequest.ParameterNames.DeleteOperator
-								  && SubgridId == JqGridRequest.ParameterNames.SubgridId
-								  && PagesCount == JqGridRequest.ParameterNames.PagesCount
-								  && TotalRows == JqGridRequest.ParameterNames.TotalRows;
-		#endregion
-	}
+        internal bool IsGlobal => PageIndex == JqGridRequest.ParameterNames.PageIndex
+                                  && RecordsCount == JqGridRequest.ParameterNames.RecordsCount
+                                  && SortingName == JqGridRequest.ParameterNames.SortingName
+                                  && SortingOrder == JqGridRequest.ParameterNames.SortingOrder
+                                  && Searching == JqGridRequest.ParameterNames.Searching
+                                  && Id == JqGridRequest.ParameterNames.Id
+                                  && Operator == JqGridRequest.ParameterNames.Operator
+                                  && EditOperator == JqGridRequest.ParameterNames.EditOperator
+                                  && AddOperator == JqGridRequest.ParameterNames.AddOperator
+                                  && DeleteOperator == JqGridRequest.ParameterNames.DeleteOperator
+                                  && SubgridId == JqGridRequest.ParameterNames.SubgridId
+                                  && PagesCount == JqGridRequest.ParameterNames.PagesCount
+                                  && TotalRows == JqGridRequest.ParameterNames.TotalRows;
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridParametersNames.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridParametersNames.cs
@@ -1,110 +1,132 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Lib.Web.Mvc.JQuery.JqGrid.Constants;
+﻿using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents names for jqGrid request parameters.
-    /// </summary>
-    public class JqGridParametersNames
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or sets the name for page index parametr.
-        /// </summary>
-        public string PageIndex { get; set; }
+	/// <summary>
+	/// Class which represents names for jqGrid request parameters.
+	/// </summary>
+	public class JqGridParametersNames
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or sets the name for page index parametr.
+		/// </summary>
+		public string PageIndex { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for records count parametr.
-        /// </summary>
-        public string RecordsCount { get; set; }
+		/// <summary>
+		/// Gets or sets the name for records count parametr.
+		/// </summary>
+		public string RecordsCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for sorting name parametr.
-        /// </summary>
-        public string SortingName { get; set; }
+		/// <summary>
+		/// Gets or sets the name for sorting name parametr.
+		/// </summary>
+		public string SortingName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for sorting order parametr.
-        /// </summary>
-        public string SortingOrder { get; set; }
+		/// <summary>
+		/// Gets or sets the name for sorting order parametr.
+		/// </summary>
+		public string SortingOrder { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for searching parametr.
-        /// </summary>
-        public string Searching { get; set; }
+		/// <summary>
+		/// Gets or sets the name for searching parametr.
+		/// </summary>
+		public string Searching { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for id parametr.
-        /// </summary>
-        public string Id { get; set; }
+		/// <summary>
+		/// Gets or sets the name for id parametr.
+		/// </summary>
+		public string Id { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for operator parametr.
-        /// </summary>
-        public string Operator { get; set; }
+		/// <summary>
+		/// Gets or sets the name for operator parametr.
+		/// </summary>
+		public string Operator { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for edit operator parametr.
-        /// </summary>
-        public string EditOperator { get; set; }
+		/// <summary>
+		/// Gets or sets the name for edit operator parametr.
+		/// </summary>
+		public string EditOperator { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for add operator parametr.
-        /// </summary>
-        public string AddOperator { get; set; }
+		/// <summary>
+		/// Gets or sets the name for add operator parametr.
+		/// </summary>
+		public string AddOperator { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for delete operator parametr.
-        /// </summary>
-        public string DeleteOperator { get; set; }
+		/// <summary>
+		/// Gets or sets the name for delete operator parametr.
+		/// </summary>
+		public string DeleteOperator { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for subgrid id parametr.
-        /// </summary>
-        public string SubgridId { get; set; }
+		/// <summary>
+		/// Gets or sets the name for subgrid id parametr.
+		/// </summary>
+		public string SubgridId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for pages count parametr.
-        /// </summary>
-        public string PagesCount { get; set; }
+		/// <summary>
+		/// Gets or sets the name for pages count parametr.
+		/// </summary>
+		public string PagesCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name for total rows parametr.
-        /// </summary>
-        public string TotalRows { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the name for total rows parametr.
+		/// </summary>
+		public string TotalRows { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridParametersNames class.
-        /// </summary>
-        public JqGridParametersNames()
-        {
-            PageIndex = JqGridOptionsDefaults.RequestPageIndex;
-            RecordsCount = JqGridOptionsDefaults.RequestRecordsCount;
-            SortingName = JqGridOptionsDefaults.RequestSortingName;
-            SortingOrder = JqGridOptionsDefaults.RequestSortingOrder;
-            Searching = JqGridOptionsDefaults.RequestSearching;
-            Id = JqGridOptionsDefaults.RequestId;
-            Operator = JqGridOptionsDefaults.RequestOperator;
-            EditOperator = JqGridOptionsDefaults.RequestEditOperator;
-            AddOperator = JqGridOptionsDefaults.RequestAddOperator;
-            DeleteOperator = JqGridOptionsDefaults.RequestDeleteOperator;
-            SubgridId = JqGridOptionsDefaults.RequestSubgridId;
-            PagesCount = null;
-            TotalRows = JqGridOptionsDefaults.RequestTotalRows;
-        }
-        #endregion
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridParametersNames class.
+		/// </summary>
+		public JqGridParametersNames()
+		{
+			PageIndex = JqGridOptionsDefaults.RequestPageIndex;
+			RecordsCount = JqGridOptionsDefaults.RequestRecordsCount;
+			SortingName = JqGridOptionsDefaults.RequestSortingName;
+			SortingOrder = JqGridOptionsDefaults.RequestSortingOrder;
+			Searching = JqGridOptionsDefaults.RequestSearching;
+			Id = JqGridOptionsDefaults.RequestId;
+			Operator = JqGridOptionsDefaults.RequestOperator;
+			EditOperator = JqGridOptionsDefaults.RequestEditOperator;
+			AddOperator = JqGridOptionsDefaults.RequestAddOperator;
+			DeleteOperator = JqGridOptionsDefaults.RequestDeleteOperator;
+			SubgridId = JqGridOptionsDefaults.RequestSubgridId;
+			PagesCount = null;
+			TotalRows = JqGridOptionsDefaults.RequestTotalRows;
+		}
+		#endregion
 
-        #region Methods
-        internal bool IsDefault()
-        {
-            return ((PageIndex == JqGridOptionsDefaults.RequestPageIndex) && (RecordsCount == JqGridOptionsDefaults.RequestRecordsCount) && (SortingName == JqGridOptionsDefaults.RequestSortingName) && (SortingOrder == JqGridOptionsDefaults.RequestSortingOrder) && (Searching == JqGridOptionsDefaults.RequestSearching) && (Id == JqGridOptionsDefaults.RequestId) && (Operator == JqGridOptionsDefaults.RequestOperator) && (EditOperator == JqGridOptionsDefaults.RequestEditOperator) && (AddOperator == JqGridOptionsDefaults.RequestAddOperator) && (DeleteOperator == JqGridOptionsDefaults.RequestDeleteOperator) && (SubgridId == JqGridOptionsDefaults.RequestSubgridId) && String.IsNullOrWhiteSpace(PagesCount) && (TotalRows == JqGridOptionsDefaults.RequestTotalRows));
-        }
-        #endregion
-    }
+		#region Methods
+		internal bool IsDefault()
+		{
+			return PageIndex == JqGridOptionsDefaults.RequestPageIndex
+				   && RecordsCount == JqGridOptionsDefaults.RequestRecordsCount
+				   && SortingName == JqGridOptionsDefaults.RequestSortingName
+				   && SortingOrder == JqGridOptionsDefaults.RequestSortingOrder
+				   && Searching == JqGridOptionsDefaults.RequestSearching
+				   && Id == JqGridOptionsDefaults.RequestId
+				   && Operator == JqGridOptionsDefaults.RequestOperator
+				   && EditOperator == JqGridOptionsDefaults.RequestEditOperator
+				   && AddOperator == JqGridOptionsDefaults.RequestAddOperator
+				   && DeleteOperator == JqGridOptionsDefaults.RequestDeleteOperator
+				   && SubgridId == JqGridOptionsDefaults.RequestSubgridId
+				   && string.IsNullOrWhiteSpace(PagesCount)
+				   && TotalRows == JqGridOptionsDefaults.RequestTotalRows;
+		}
+
+		internal bool IsGlobal => PageIndex == JqGridRequest.ParameterNames.PageIndex
+								  && RecordsCount == JqGridRequest.ParameterNames.RecordsCount
+								  && SortingName == JqGridRequest.ParameterNames.SortingName
+								  && SortingOrder == JqGridRequest.ParameterNames.SortingOrder
+								  && Searching == JqGridRequest.ParameterNames.Searching
+								  && Id == JqGridRequest.ParameterNames.Id
+								  && Operator == JqGridRequest.ParameterNames.Operator
+								  && EditOperator == JqGridRequest.ParameterNames.EditOperator
+								  && AddOperator == JqGridRequest.ParameterNames.AddOperator
+								  && DeleteOperator == JqGridRequest.ParameterNames.DeleteOperator
+								  && SubgridId == JqGridRequest.ParameterNames.SubgridId
+								  && PagesCount == JqGridRequest.ParameterNames.PagesCount
+								  && TotalRows == JqGridRequest.ParameterNames.TotalRows;
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRecord.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRecord.cs
@@ -1,85 +1,82 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents record for jqGrid.
-    /// </summary>
-    public class JqGridRecord
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the record cells values.
-        /// </summary>
-        public List<object> Values { get; private set; }
+	/// <summary>
+	/// Class which represents record for jqGrid.
+	/// </summary>
+	public class JqGridRecord
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the record cells values.
+		/// </summary>
+		public List<object> Values { get; }
 
-        /// <summary>
-        /// Gets the record value.
-        /// </summary>
-        public object Value { get; private set; }
+		/// <summary>
+		/// Gets the record value.
+		/// </summary>
+		public object Value { get; }
 
-        /// <summary>
-        /// Gets the record identifier.
-        /// </summary>
-        public string Id { get; private set; }
-        #endregion
+		/// <summary>
+		/// Gets the record identifier.
+		/// </summary>
+		public string Id { get; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="values">The record cells values.</param>
-        public JqGridRecord(string id, List<object> values)
-        {
-            Id = id;
-            Values = values;
-            Value = null;
-        }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="values">The record cells values.</param>
+		public JqGridRecord(string id, List<object> values)
+		{
+			Id = id;
+			Values = values;
+			Value = null;
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="value">The record values</param>
-        public JqGridRecord(string id, object value)
-        {
-            Id = id;
-            Value = value;
-            Values = GetValuesAsList();
-        }
-        #endregion
+		/// <summary>
+		/// Initializes a new instance of the JqGridRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="value">The record values</param>
+		public JqGridRecord(string id, object value)
+		{
+			Id = id;
+			Value = value;
+			Values = GetValuesAsList();
+		}
+		#endregion
 
-        #region Methods
-        protected internal virtual List<object> GetValuesAsList()
-        {
-            List<object> values = new List<object>();
+		#region Methods
+		protected internal virtual List<object> GetValuesAsList()
+		{
+			var values = new List<object>();
 
-            if (Value != null)
-            {
-                foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(Value))
-                    values.Add(property.GetValue(Value));
-            }
+			if (Value != null)
+			{
+				foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(Value))
+					values.Add(property.GetValue(Value));
+			}
 
-            return values;
-        }
+			return values;
+		}
 
-        protected internal virtual Dictionary<string, object> GetValuesAsDictionary()
-        {
-            Dictionary<string, object> values = new Dictionary<string, object>();
+		protected internal virtual Dictionary<string, object> GetValuesAsDictionary()
+		{
+			var values = new Dictionary<string, object>();
 
-            if (Value != null)
-            {
-                foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(Value))
-                    values.Add(property.Name, property.GetValue(Value));
-            }
+			if (Value != null)
+			{
+				foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(Value))
+					values.Add(property.Name, property.GetValue(Value));
+			}
 
-            return values;
-        }
-        #endregion
-    }
+			return values;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRecord.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRecord.cs
@@ -3,80 +3,80 @@ using System.ComponentModel;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents record for jqGrid.
-	/// </summary>
-	public class JqGridRecord
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the record cells values.
-		/// </summary>
-		public List<object> Values { get; }
+    /// <summary>
+    /// Class which represents record for jqGrid.
+    /// </summary>
+    public class JqGridRecord
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the record cells values.
+        /// </summary>
+        public List<object> Values { get; }
 
-		/// <summary>
-		/// Gets the record value.
-		/// </summary>
-		public object Value { get; }
+        /// <summary>
+        /// Gets the record value.
+        /// </summary>
+        public object Value { get; }
 
-		/// <summary>
-		/// Gets the record identifier.
-		/// </summary>
-		public string Id { get; }
-		#endregion
+        /// <summary>
+        /// Gets the record identifier.
+        /// </summary>
+        public string Id { get; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="values">The record cells values.</param>
-		public JqGridRecord(string id, List<object> values)
-		{
-			Id = id;
-			Values = values;
-			Value = null;
-		}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="values">The record cells values.</param>
+        public JqGridRecord(string id, List<object> values)
+        {
+            Id = id;
+            Values = values;
+            Value = null;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="value">The record values</param>
-		public JqGridRecord(string id, object value)
-		{
-			Id = id;
-			Value = value;
-			Values = GetValuesAsList();
-		}
-		#endregion
+        /// <summary>
+        /// Initializes a new instance of the JqGridRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="value">The record values</param>
+        public JqGridRecord(string id, object value)
+        {
+            Id = id;
+            Value = value;
+            Values = GetValuesAsList();
+        }
+        #endregion
 
-		#region Methods
-		protected internal virtual List<object> GetValuesAsList()
-		{
-			var values = new List<object>();
+        #region Methods
+        protected internal virtual List<object> GetValuesAsList()
+        {
+            List<object> values = new List<object>();
 
-			if (Value != null)
-			{
-				foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(Value))
-					values.Add(property.GetValue(Value));
-			}
+            if (Value != null)
+            {
+                foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(Value))
+                    values.Add(property.GetValue(Value));
+            }
 
-			return values;
-		}
+            return values;
+        }
 
-		protected internal virtual Dictionary<string, object> GetValuesAsDictionary()
-		{
-			var values = new Dictionary<string, object>();
+        protected internal virtual Dictionary<string, object> GetValuesAsDictionary()
+        {
+            Dictionary<string, object> values = new Dictionary<string, object>();
 
-			if (Value != null)
-			{
-				foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(Value))
-					values.Add(property.Name, property.GetValue(Value));
-			}
+            if (Value != null)
+            {
+                foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(Value))
+                    values.Add(property.Name, property.GetValue(Value));
+            }
 
-			return values;
-		}
-		#endregion
-	}
+            return values;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRecord`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRecord`1.cs
@@ -1,73 +1,72 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 using System.Globalization;
 using System.Data.Linq;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents record for jqGrid.
-    /// </summary>
-    /// <typeparam name="TModel">Type of model for this grid</typeparam>
-    public class JqGridRecord<TModel>: JqGridRecord
-    {
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier</param>
-        /// <param name="value">The value for record</param>
-        public JqGridRecord(string id, TModel value)
-            : base(id, value)
-        { }
-        #endregion
+	/// <summary>
+	/// Class which represents record for jqGrid.
+	/// </summary>
+	/// <typeparam name="TModel">Type of model for this grid</typeparam>
+	public class JqGridRecord<TModel> : JqGridRecord
+	{
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier</param>
+		/// <param name="value">The value for record</param>
+		public JqGridRecord(string id, TModel value)
+			: base(id, value)
+		{ }
+		#endregion
 
-        #region Methods
-        protected internal override List<object> GetValuesAsList()
-        {
-            List<object> values = new List<object>();
+		#region Methods
+		protected internal override List<object> GetValuesAsList()
+		{
+			var values = new List<object>();
 
-            IEnumerable<ModelMetadata> modelMetadata = ModelMetadataProviders.Current.GetMetadataForProperties(Value, typeof(TModel)).OrderBy(m => m.Order);
-            foreach (ModelMetadata propertyMetadata in modelMetadata.Where(p => p.IsValidForColumn()))
-                values.Add(GetFormattedValue(propertyMetadata));
+			IEnumerable<ModelMetadata> modelMetadata = ModelMetadataProviders.Current.GetMetadataForProperties(Value, typeof(TModel)).OrderBy(m => m.Order);
+			foreach (var propertyMetadata in modelMetadata.Where(p => p.IsValidForColumn()))
+				values.Add(GetFormattedValue(propertyMetadata));
 
-            return values;
-        }
+			return values;
+		}
 
-        protected internal override Dictionary<string, object> GetValuesAsDictionary()
-        {
-            Dictionary<string, object> values = new Dictionary<string, object>();
+		protected internal override Dictionary<string, object> GetValuesAsDictionary()
+		{
+			var values = new Dictionary<string, object>();
 
-            IEnumerable<ModelMetadata> modelMetadata = ModelMetadataProviders.Current.GetMetadataForProperties(Value, typeof(TModel));
-            foreach (ModelMetadata propertyMetadata in modelMetadata.Where(p => p.IsValidForColumn()))
-                values.Add(propertyMetadata.PropertyName, GetFormattedValue(propertyMetadata));
+			var modelMetadata = ModelMetadataProviders.Current.GetMetadataForProperties(Value, typeof(TModel));
+			foreach (var propertyMetadata in modelMetadata.Where(p => p.IsValidForColumn()))
+				values.Add(propertyMetadata.PropertyName, GetFormattedValue(propertyMetadata));
 
-            return values;
-        }
+			return values;
+		}
 
-        private static object GetFormattedValue(ModelMetadata propertyMetadata)
-        {
-            object formattedValue = propertyMetadata.Model;
-                
-            if (propertyMetadata.Model == null)
-                formattedValue = propertyMetadata.NullDisplayText;
-            else
-            {
-                if (propertyMetadata.IsComplexType)
-                {
-                    if (propertyMetadata.ModelType == typeof(Binary))
-                        formattedValue = Convert.ToBase64String((propertyMetadata.Model as Binary).ToArray());
-                    else if (propertyMetadata.ModelType == typeof(byte[]))
-                        formattedValue = Convert.ToBase64String(propertyMetadata.Model as byte[]);
-                }
-                else if (!String.IsNullOrEmpty(propertyMetadata.DisplayFormatString))
-                    formattedValue = String.Format(CultureInfo.CurrentCulture, propertyMetadata.DisplayFormatString, propertyMetadata.Model);
-            }
-            return formattedValue;
-        }
-        #endregion
-    }
+		private static object GetFormattedValue(ModelMetadata propertyMetadata)
+		{
+			var formattedValue = propertyMetadata.Model;
+
+			if (propertyMetadata.Model == null)
+				formattedValue = propertyMetadata.NullDisplayText;
+			else
+			{
+				if (propertyMetadata.IsComplexType)
+				{
+					if (propertyMetadata.ModelType == typeof(Binary))
+						formattedValue = Convert.ToBase64String((propertyMetadata.Model as Binary).ToArray());
+					else if (propertyMetadata.ModelType == typeof(byte[]))
+						formattedValue = Convert.ToBase64String(propertyMetadata.Model as byte[]);
+				}
+				else if (!string.IsNullOrEmpty(propertyMetadata.DisplayFormatString))
+					formattedValue = string.Format(CultureInfo.CurrentCulture, propertyMetadata.DisplayFormatString, propertyMetadata.Model);
+			}
+			return formattedValue;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRecord`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRecord`1.cs
@@ -7,66 +7,66 @@ using System.Data.Linq;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents record for jqGrid.
-	/// </summary>
-	/// <typeparam name="TModel">Type of model for this grid</typeparam>
-	public class JqGridRecord<TModel> : JqGridRecord
-	{
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier</param>
-		/// <param name="value">The value for record</param>
-		public JqGridRecord(string id, TModel value)
-			: base(id, value)
-		{ }
-		#endregion
+    /// <summary>
+    /// Class which represents record for jqGrid.
+    /// </summary>
+    /// <typeparam name="TModel">Type of model for this grid</typeparam>
+    public class JqGridRecord<TModel> : JqGridRecord
+    {
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier</param>
+        /// <param name="value">The value for record</param>
+        public JqGridRecord(string id, TModel value)
+            : base(id, value)
+        { }
+        #endregion
 
-		#region Methods
-		protected internal override List<object> GetValuesAsList()
-		{
-			var values = new List<object>();
+        #region Methods
+        protected internal override List<object> GetValuesAsList()
+        {
+            List<object> values = new List<object>();
 
-			IEnumerable<ModelMetadata> modelMetadata = ModelMetadataProviders.Current.GetMetadataForProperties(Value, typeof(TModel)).OrderBy(m => m.Order);
-			foreach (var propertyMetadata in modelMetadata.Where(p => p.IsValidForColumn()))
-				values.Add(GetFormattedValue(propertyMetadata));
+            IEnumerable<ModelMetadata> modelMetadata = ModelMetadataProviders.Current.GetMetadataForProperties(Value, typeof(TModel)).OrderBy(m => m.Order);
+            foreach (ModelMetadata propertyMetadata in modelMetadata.Where(p => p.IsValidForColumn()))
+                values.Add(GetFormattedValue(propertyMetadata));
 
-			return values;
-		}
+            return values;
+        }
 
-		protected internal override Dictionary<string, object> GetValuesAsDictionary()
-		{
-			var values = new Dictionary<string, object>();
+        protected internal override Dictionary<string, object> GetValuesAsDictionary()
+        {
+            Dictionary<string, object> values = new Dictionary<string, object>();
 
-			var modelMetadata = ModelMetadataProviders.Current.GetMetadataForProperties(Value, typeof(TModel));
-			foreach (var propertyMetadata in modelMetadata.Where(p => p.IsValidForColumn()))
-				values.Add(propertyMetadata.PropertyName, GetFormattedValue(propertyMetadata));
+            IEnumerable<ModelMetadata> modelMetadata = ModelMetadataProviders.Current.GetMetadataForProperties(Value, typeof(TModel));
+            foreach (ModelMetadata propertyMetadata in modelMetadata.Where(p => p.IsValidForColumn()))
+                values.Add(propertyMetadata.PropertyName, GetFormattedValue(propertyMetadata));
 
-			return values;
-		}
+            return values;
+        }
 
-		private static object GetFormattedValue(ModelMetadata propertyMetadata)
-		{
-			var formattedValue = propertyMetadata.Model;
+        private static object GetFormattedValue(ModelMetadata propertyMetadata)
+        {
+            object formattedValue = propertyMetadata.Model;
 
-			if (propertyMetadata.Model == null)
-				formattedValue = propertyMetadata.NullDisplayText;
-			else
-			{
-				if (propertyMetadata.IsComplexType)
-				{
-					if (propertyMetadata.ModelType == typeof(Binary))
-						formattedValue = Convert.ToBase64String((propertyMetadata.Model as Binary).ToArray());
-					else if (propertyMetadata.ModelType == typeof(byte[]))
-						formattedValue = Convert.ToBase64String(propertyMetadata.Model as byte[]);
-				}
-				else if (!string.IsNullOrEmpty(propertyMetadata.DisplayFormatString))
-					formattedValue = string.Format(CultureInfo.CurrentCulture, propertyMetadata.DisplayFormatString, propertyMetadata.Model);
-			}
-			return formattedValue;
-		}
-		#endregion
-	}
+            if (propertyMetadata.Model == null)
+                formattedValue = propertyMetadata.NullDisplayText;
+            else
+            {
+                if (propertyMetadata.IsComplexType)
+                {
+                    if (propertyMetadata.ModelType == typeof(Binary))
+                        formattedValue = Convert.ToBase64String((propertyMetadata.Model as Binary).ToArray());
+                    else if (propertyMetadata.ModelType == typeof(byte[]))
+                        formattedValue = Convert.ToBase64String(propertyMetadata.Model as byte[]);
+                }
+                else if (!string.IsNullOrEmpty(propertyMetadata.DisplayFormatString))
+                    formattedValue = string.Format(CultureInfo.CurrentCulture, propertyMetadata.DisplayFormatString, propertyMetadata.Model);
+            }
+            return formattedValue;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequest.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequest.cs
@@ -1,82 +1,74 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents request from jqGrid.
-    /// </summary>
-    [ModelBinder(typeof(ModelBinders.JqGridRequestModelBinder))]
-    public class JqGridRequest
-    {
-        #region Fields
-        private static JqGridParametersNames _parametersNames;
-        #endregion
+	/// <summary>
+	/// Class which represents request from jqGrid.
+	/// </summary>
+	[ModelBinder(typeof(ModelBinders.JqGridRequestModelBinder))]
+	public class JqGridRequest
+	{
+		#region Fields
+		private static JqGridParametersNames _parametersNames;
+		#endregion
 
-        #region Properties
-        /// <summary>
-        /// Gets or sets the customized names for jqGrid request parameters (will be also use as defaults for JqGridOptions/JqGridHelper).
-        /// </summary>
-        public static JqGridParametersNames ParameterNames
-        {
-            get { return _parametersNames; }
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException("value");
-                _parametersNames = value;
-            }
-        }
+		#region Properties
+		/// <summary>
+		/// Gets or sets the customized names for jqGrid request parameters (will be also use as defaults for JqGridOptions/JqGridHelper).
+		/// </summary>
+		public static JqGridParametersNames ParameterNames
+		{
+			get => _parametersNames;
+			set => _parametersNames = value ?? throw new ArgumentNullException(nameof(value));
+		}
 
-        /// <summary>
-        /// Gets the value indicating searching.
-        /// </summary>
-        public bool Searching { get; set; }
+		/// <summary>
+		/// Gets the value indicating searching.
+		/// </summary>
+		public bool Searching { get; set; }
 
-        /// <summary>
-        /// Gets the searching filter (single searching). 
-        /// </summary>
-        public JqGridRequestSearchingFilter SearchingFilter { get; set; }
+		/// <summary>
+		/// Gets the searching filter (single searching). 
+		/// </summary>
+		public JqGridRequestSearchingFilter SearchingFilter { get; set; }
 
-        /// <summary>
-        /// Gets the searching filters (advanced searching or toolbar searching with JqGridFilterToolbarOptions.StringResult = true). 
-        /// </summary>
-        public JqGridRequestSearchingFilters SearchingFilters { get; set; }
+		/// <summary>
+		/// Gets the searching filters (advanced searching or toolbar searching with JqGridFilterToolbarOptions.StringResult = true). 
+		/// </summary>
+		public JqGridRequestSearchingFilters SearchingFilters { get; set; }
 
-        /// <summary>
-        /// Gets the sorting column name.
-        /// </summary>
-        public string SortingName { get; set; }
+		/// <summary>
+		/// Gets the sorting column name.
+		/// </summary>
+		public string SortingName { get; set; }
 
-        /// <summary>
-        /// Gets the sorting order
-        /// </summary>
-        public JqGridSortingOrders SortingOrder { get; set; }
+		/// <summary>
+		/// Gets the sorting order
+		/// </summary>
+		public JqGridSortingOrders SortingOrder { get; set; }
 
-        /// <summary>
-        /// Gets the index (zero based) of page to return
-        /// </summary>
-        public int PageIndex { get; set; }
+		/// <summary>
+		/// Gets the index (zero based) of page to return
+		/// </summary>
+		public int PageIndex { get; set; }
 
-        /// <summary>
-        /// Gets the number of pages to return
-        /// </summary>
-        public int? PagesCount { get; set; }
+		/// <summary>
+		/// Gets the number of pages to return
+		/// </summary>
+		public int? PagesCount { get; set; }
 
-        /// <summary>
-        /// Gets the number of rows to return
-        /// </summary>
-        public int RecordsCount { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets the number of rows to return
+		/// </summary>
+		public int RecordsCount { get; set; }
+		#endregion
 
-        #region Constructors
-        static JqGridRequest()
-        {
-            ParameterNames = new JqGridParametersNames();
-        }
-        #endregion
-    }
+		#region Constructors
+		static JqGridRequest()
+		{
+			ParameterNames = new JqGridParametersNames();
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequest.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequest.cs
@@ -3,72 +3,72 @@ using System.Web.Mvc;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents request from jqGrid.
-	/// </summary>
-	[ModelBinder(typeof(ModelBinders.JqGridRequestModelBinder))]
-	public class JqGridRequest
-	{
-		#region Fields
-		private static JqGridParametersNames _parametersNames;
-		#endregion
+    /// <summary>
+    /// Class which represents request from jqGrid.
+    /// </summary>
+    [ModelBinder(typeof(ModelBinders.JqGridRequestModelBinder))]
+    public class JqGridRequest
+    {
+        #region Fields
+        private static JqGridParametersNames _parametersNames;
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets the customized names for jqGrid request parameters (will be also use as defaults for JqGridOptions/JqGridHelper).
-		/// </summary>
-		public static JqGridParametersNames ParameterNames
-		{
-			get => _parametersNames;
-			set => _parametersNames = value ?? throw new ArgumentNullException(nameof(value));
-		}
+        #region Properties
+        /// <summary>
+        /// Gets or sets the customized names for jqGrid request parameters (will be also use as defaults for JqGridOptions/JqGridHelper).
+        /// </summary>
+        public static JqGridParametersNames ParameterNames
+        {
+            get => _parametersNames;
+            set => _parametersNames = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
-		/// <summary>
-		/// Gets the value indicating searching.
-		/// </summary>
-		public bool Searching { get; set; }
+        /// <summary>
+        /// Gets the value indicating searching.
+        /// </summary>
+        public bool Searching { get; set; }
 
-		/// <summary>
-		/// Gets the searching filter (single searching). 
-		/// </summary>
-		public JqGridRequestSearchingFilter SearchingFilter { get; set; }
+        /// <summary>
+        /// Gets the searching filter (single searching). 
+        /// </summary>
+        public JqGridRequestSearchingFilter SearchingFilter { get; set; }
 
-		/// <summary>
-		/// Gets the searching filters (advanced searching or toolbar searching with JqGridFilterToolbarOptions.StringResult = true). 
-		/// </summary>
-		public JqGridRequestSearchingFilters SearchingFilters { get; set; }
+        /// <summary>
+        /// Gets the searching filters (advanced searching or toolbar searching with JqGridFilterToolbarOptions.StringResult = true). 
+        /// </summary>
+        public JqGridRequestSearchingFilters SearchingFilters { get; set; }
 
-		/// <summary>
-		/// Gets the sorting column name.
-		/// </summary>
-		public string SortingName { get; set; }
+        /// <summary>
+        /// Gets the sorting column name.
+        /// </summary>
+        public string SortingName { get; set; }
 
-		/// <summary>
-		/// Gets the sorting order
-		/// </summary>
-		public JqGridSortingOrders SortingOrder { get; set; }
+        /// <summary>
+        /// Gets the sorting order
+        /// </summary>
+        public JqGridSortingOrders SortingOrder { get; set; }
 
-		/// <summary>
-		/// Gets the index (zero based) of page to return
-		/// </summary>
-		public int PageIndex { get; set; }
+        /// <summary>
+        /// Gets the index (zero based) of page to return
+        /// </summary>
+        public int PageIndex { get; set; }
 
-		/// <summary>
-		/// Gets the number of pages to return
-		/// </summary>
-		public int? PagesCount { get; set; }
+        /// <summary>
+        /// Gets the number of pages to return
+        /// </summary>
+        public int? PagesCount { get; set; }
 
-		/// <summary>
-		/// Gets the number of rows to return
-		/// </summary>
-		public int RecordsCount { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets the number of rows to return
+        /// </summary>
+        public int RecordsCount { get; set; }
+        #endregion
 
-		#region Constructors
-		static JqGridRequest()
-		{
-			ParameterNames = new JqGridParametersNames();
-		}
-		#endregion
-	}
+        #region Constructors
+        static JqGridRequest()
+        {
+            ParameterNames = new JqGridParametersNames();
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequestSearchingFilter.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequestSearchingFilter.cs
@@ -1,25 +1,25 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents filter in request from jqGrid.
-	/// </summary>
-	public class JqGridRequestSearchingFilter
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the searching column name.
-		/// </summary>
-		public string SearchingName { get; set; }
+    /// <summary>
+    /// Class which represents filter in request from jqGrid.
+    /// </summary>
+    public class JqGridRequestSearchingFilter
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the searching column name.
+        /// </summary>
+        public string SearchingName { get; set; }
 
-		/// <summary>
-		/// Gets the searching value.
-		/// </summary>
-		public string SearchingValue { get; set; }
+        /// <summary>
+        /// Gets the searching value.
+        /// </summary>
+        public string SearchingValue { get; set; }
 
-		/// <summary>
-		/// Gets the searching operator.
-		/// </summary>
-		public JqGridSearchOperators SearchingOperator { get; set; }
-		#endregion
-	}
+        /// <summary>
+        /// Gets the searching operator.
+        /// </summary>
+        public JqGridSearchOperators SearchingOperator { get; set; }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequestSearchingFilter.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequestSearchingFilter.cs
@@ -1,30 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents filter in request from jqGrid.
-    /// </summary>
-    public class JqGridRequestSearchingFilter
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the searching column name.
-        /// </summary>
-        public string SearchingName { get; set; }
+	/// <summary>
+	/// Class which represents filter in request from jqGrid.
+	/// </summary>
+	public class JqGridRequestSearchingFilter
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the searching column name.
+		/// </summary>
+		public string SearchingName { get; set; }
 
-        /// <summary>
-        /// Gets the searching value.
-        /// </summary>
-        public string SearchingValue { get; set; }
+		/// <summary>
+		/// Gets the searching value.
+		/// </summary>
+		public string SearchingValue { get; set; }
 
-        /// <summary>
-        /// Gets the searching operator.
-        /// </summary>
-        public JqGridSearchOperators SearchingOperator { get; set; }
-        #endregion
-    }
+		/// <summary>
+		/// Gets the searching operator.
+		/// </summary>
+		public JqGridSearchOperators SearchingOperator { get; set; }
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequestSearchingFilters.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequestSearchingFilters.cs
@@ -1,41 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents filters in request from jqGrid.
-    /// </summary>
-    public class JqGridRequestSearchingFilters
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the operator grouping the filters.
-        /// </summary>
-        public JqGridSearchGroupingOperators GroupingOperator { get; set; }
+	/// <summary>
+	/// Class which represents filters in request from jqGrid.
+	/// </summary>
+	public class JqGridRequestSearchingFilters
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the operator grouping the filters.
+		/// </summary>
+		public JqGridSearchGroupingOperators GroupingOperator { get; set; }
 
-        /// <summary>
-        /// Gets the list of filters.
-        /// </summary>
-        public List<JqGridRequestSearchingFilter> Filters { get; set; }
+		/// <summary>
+		/// Gets the list of filters.
+		/// </summary>
+		public List<JqGridRequestSearchingFilter> Filters { get; set; }
 
-        /// <summary>
-        /// Gets the list of filters sub groups.
-        /// </summary>
-        public List<JqGridRequestSearchingFilters> Groups { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets the list of filters sub groups.
+		/// </summary>
+		public List<JqGridRequestSearchingFilters> Groups { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridRequestSearchingFilters class.
-        /// </summary>
-        public JqGridRequestSearchingFilters()
-        {
-            Filters = new List<JqGridRequestSearchingFilter>();
-            Groups = new List<JqGridRequestSearchingFilters>();
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridRequestSearchingFilters class.
+		/// </summary>
+		public JqGridRequestSearchingFilters()
+		{
+			Filters = new List<JqGridRequestSearchingFilter>();
+			Groups = new List<JqGridRequestSearchingFilters>();
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequestSearchingFilters.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridRequestSearchingFilters.cs
@@ -2,37 +2,37 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents filters in request from jqGrid.
-	/// </summary>
-	public class JqGridRequestSearchingFilters
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the operator grouping the filters.
-		/// </summary>
-		public JqGridSearchGroupingOperators GroupingOperator { get; set; }
+    /// <summary>
+    /// Class which represents filters in request from jqGrid.
+    /// </summary>
+    public class JqGridRequestSearchingFilters
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the operator grouping the filters.
+        /// </summary>
+        public JqGridSearchGroupingOperators GroupingOperator { get; set; }
 
-		/// <summary>
-		/// Gets the list of filters.
-		/// </summary>
-		public List<JqGridRequestSearchingFilter> Filters { get; set; }
+        /// <summary>
+        /// Gets the list of filters.
+        /// </summary>
+        public List<JqGridRequestSearchingFilter> Filters { get; set; }
 
-		/// <summary>
-		/// Gets the list of filters sub groups.
-		/// </summary>
-		public List<JqGridRequestSearchingFilters> Groups { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets the list of filters sub groups.
+        /// </summary>
+        public List<JqGridRequestSearchingFilters> Groups { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridRequestSearchingFilters class.
-		/// </summary>
-		public JqGridRequestSearchingFilters()
-		{
-			Filters = new List<JqGridRequestSearchingFilter>();
-			Groups = new List<JqGridRequestSearchingFilters>();
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridRequestSearchingFilters class.
+        /// </summary>
+        public JqGridRequestSearchingFilters()
+        {
+            Filters = new List<JqGridRequestSearchingFilter>();
+            Groups = new List<JqGridRequestSearchingFilters>();
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridResponse.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridResponse.cs
@@ -3,73 +3,73 @@ using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents response for jqGrid.
-	/// </summary>
-	public class JqGridResponse
-	{
-		#region Fields
-		private static JqGridJsonReader _jsonReader;
-		#endregion
+    /// <summary>
+    /// Class which represents response for jqGrid.
+    /// </summary>
+    public class JqGridResponse
+    {
+        #region Fields
+        private static JqGridJsonReader _jsonReader;
+        #endregion
 
-		#region Properties
-		/// <summary>
-		/// Gets or sets the customized JSON reader for jqGrid (will be also use as defaults for JqGridOptions/JqGridHelper).
-		/// </summary>
-		public static JqGridJsonReader JsonReader
-		{
-			get => _jsonReader;
-			set => _jsonReader = value ?? throw new ArgumentNullException(nameof(value));
-		}
+        #region Properties
+        /// <summary>
+        /// Gets or sets the customized JSON reader for jqGrid (will be also use as defaults for JqGridOptions/JqGridHelper).
+        /// </summary>
+        public static JqGridJsonReader JsonReader
+        {
+            get => _jsonReader;
+            set => _jsonReader = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
-		/// <summary>
-		/// Gets or sets the index (zero based) of page to return
-		/// </summary>
-		public int PageIndex { get; set; }
+        /// <summary>
+        /// Gets or sets the index (zero based) of page to return
+        /// </summary>
+        public int PageIndex { get; set; }
 
-		internal bool IsSubgridResponse { get; }
+        internal bool IsSubgridResponse { get; }
 
-		/// <summary>
-		/// Gets or sets total pages count
-		/// </summary>
-		public int TotalPagesCount { get; set; }
+        /// <summary>
+        /// Gets or sets total pages count
+        /// </summary>
+        public int TotalPagesCount { get; set; }
 
-		/// <summary>
-		/// Gets or sets total records count
-		/// </summary>
-		public int TotalRecordsCount { get; set; }
+        /// <summary>
+        /// Gets or sets total records count
+        /// </summary>
+        public int TotalRecordsCount { get; set; }
 
-		/// <summary>
-		/// Gets the records list
-		/// </summary>
-		public List<JqGridRecord> Records { get; }
+        /// <summary>
+        /// Gets the records list
+        /// </summary>
+        public List<JqGridRecord> Records { get; }
 
-		/// <summary>
-		/// Gets or sets the customized JSON reader for this response.
-		/// </summary>
-		public JqGridJsonReader Reader { get; set; }
+        /// <summary>
+        /// Gets or sets the customized JSON reader for this response.
+        /// </summary>
+        public JqGridJsonReader Reader { get; set; }
 
-		/// <summary>
-		/// Gets or sets custom data that will be send with the response.
-		/// </summary>
-		public object UserData { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets custom data that will be send with the response.
+        /// </summary>
+        public object UserData { get; set; }
+        #endregion
 
-		#region Constructor
-		static JqGridResponse()
-		{
-			JsonReader = new JqGridJsonReader();
-		}
+        #region Constructor
+        static JqGridResponse()
+        {
+            JsonReader = new JqGridJsonReader();
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridResponse class.
-		/// </summary>
-		public JqGridResponse(bool isSubgridResponse = false)
-		{
-			IsSubgridResponse = isSubgridResponse;
-			Records = new List<JqGridRecord>();
-			Reader = (JqGridJsonReader)JsonReader.Clone();
-		}
-		#endregion
-	}
+        /// <summary>
+        /// Initializes a new instance of the JqGridResponse class.
+        /// </summary>
+        public JqGridResponse(bool isSubgridResponse = false)
+        {
+            IsSubgridResponse = isSubgridResponse;
+            Records = new List<JqGridRecord>();
+            Reader = (JqGridJsonReader)JsonReader.Clone();
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridResponse.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridResponse.cs
@@ -1,82 +1,75 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents response for jqGrid.
-    /// </summary>
-    public class JqGridResponse
-    {
-        #region Fields
-        private static JqGridJsonReader _jsonReader;
-        #endregion
+	/// <summary>
+	/// Class which represents response for jqGrid.
+	/// </summary>
+	public class JqGridResponse
+	{
+		#region Fields
+		private static JqGridJsonReader _jsonReader;
+		#endregion
 
-        #region Properties
-        /// <summary>
-        /// Gets or sets the customized JSON reader for jqGrid (will be also use as defaults for JqGridOptions/JqGridHelper).
-        /// </summary>
-        public static JqGridJsonReader JsonReader
-        {
-            get { return _jsonReader; }
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException("value");
-                _jsonReader = value;
-            }
-        }
+		#region Properties
+		/// <summary>
+		/// Gets or sets the customized JSON reader for jqGrid (will be also use as defaults for JqGridOptions/JqGridHelper).
+		/// </summary>
+		public static JqGridJsonReader JsonReader
+		{
+			get => _jsonReader;
+			set => _jsonReader = value ?? throw new ArgumentNullException(nameof(value));
+		}
 
-        /// <summary>
-        /// Gets or sets the index (zero based) of page to return
-        /// </summary>
-        public int PageIndex { get; set; }
+		/// <summary>
+		/// Gets or sets the index (zero based) of page to return
+		/// </summary>
+		public int PageIndex { get; set; }
 
-        internal bool IsSubgridResponse { get; private set; }
+		internal bool IsSubgridResponse { get; }
 
-        /// <summary>
-        /// Gets or sets total pages count
-        /// </summary>
-        public int TotalPagesCount { get; set; }
+		/// <summary>
+		/// Gets or sets total pages count
+		/// </summary>
+		public int TotalPagesCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets total records count
-        /// </summary>
-        public int TotalRecordsCount { get; set; }
+		/// <summary>
+		/// Gets or sets total records count
+		/// </summary>
+		public int TotalRecordsCount { get; set; }
 
-        /// <summary>
-        /// Gets the records list
-        /// </summary>
-        public List<JqGridRecord> Records { get; private set; }
+		/// <summary>
+		/// Gets the records list
+		/// </summary>
+		public List<JqGridRecord> Records { get; }
 
-        /// <summary>
-        /// Gets or sets the customized JSON reader for this response.
-        /// </summary>
-        public JqGridJsonReader Reader { get; set; }
+		/// <summary>
+		/// Gets or sets the customized JSON reader for this response.
+		/// </summary>
+		public JqGridJsonReader Reader { get; set; }
 
-        /// <summary>
-        /// Gets or sets custom data that will be send with the response.
-        /// </summary>
-        public object UserData { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets custom data that will be send with the response.
+		/// </summary>
+		public object UserData { get; set; }
+		#endregion
 
-        #region Constructor
-        static JqGridResponse()
-        {
-            JsonReader = new JqGridJsonReader();
-        }
+		#region Constructor
+		static JqGridResponse()
+		{
+			JsonReader = new JqGridJsonReader();
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridResponse class.
-        /// </summary>
-        public JqGridResponse(bool isSubgridResponse = false)
-        {
-            IsSubgridResponse = isSubgridResponse;
-            Records = new List<JqGridRecord>();
-            Reader = (JqGridJsonReader)JsonReader.Clone();
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Initializes a new instance of the JqGridResponse class.
+		/// </summary>
+		public JqGridResponse(bool isSubgridResponse = false)
+		{
+			IsSubgridResponse = isSubgridResponse;
+			Records = new List<JqGridRecord>();
+			Reader = (JqGridJsonReader)JsonReader.Clone();
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSearchGroupingOperators.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSearchGroupingOperators.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available group operators for searching in jqGrid
-    /// </summary>
-    public enum JqGridSearchGroupingOperators
-    {
-        /// <summary>
-        /// All
-        /// </summary>
-        And,
-        /// <summary>
-        /// Any
-        /// </summary>
-        Or
-    }
+	/// <summary>
+	/// Defines available group operators for searching in jqGrid
+	/// </summary>
+	public enum JqGridSearchGroupingOperators
+	{
+		/// <summary>
+		/// All
+		/// </summary>
+		And,
+		/// <summary>
+		/// Any
+		/// </summary>
+		Or
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSearchGroupingOperators.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSearchGroupingOperators.cs
@@ -1,17 +1,17 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available group operators for searching in jqGrid
-	/// </summary>
-	public enum JqGridSearchGroupingOperators
-	{
-		/// <summary>
-		/// All
-		/// </summary>
-		And,
-		/// <summary>
-		/// Any
-		/// </summary>
-		Or
-	}
+    /// <summary>
+    /// Defines available group operators for searching in jqGrid
+    /// </summary>
+    public enum JqGridSearchGroupingOperators
+    {
+        /// <summary>
+        /// All
+        /// </summary>
+        And,
+        /// <summary>
+        /// Any
+        /// </summary>
+        Or
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSearchOperators.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSearchOperators.cs
@@ -1,95 +1,96 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available operators for search fields for jqGrid
-    /// </summary>
-    [Flags]
-    public enum JqGridSearchOperators
-    {
-        /// <summary>
-        /// Equal
-        /// </summary>
-        Eq = 1,
-        /// <summary>
-        /// Not equal
-        /// </summary>
-        Ne = 2,
-        /// <summary>
-        /// Combines equal and not equal
-        /// </summary>
-        EqualOrNotEqual = JqGridSearchOperators.Eq | JqGridSearchOperators.Ne,
-        /// <summary>
-        /// Less
-        /// </summary>
-        Lt = 4,
-        /// <summary>
-        /// Less or equal
-        /// </summary>
-        Le = 8,
-        /// <summary>
-        /// Greater
-        /// </summary>
-        Gt = 16,
-        /// <summary>
-        /// Greater or equal
-        /// </summary>
-        Ge = 32,
-        /// <summary>
-        /// Begins with
-        /// </summary>
-        Bw = 64,
-        /// <summary>
-        /// Does not begin with
-        /// </summary>
-        Bn = 128,
-        /// <summary>
-        /// Is in
-        /// </summary>
-        In = 256,
-        /// <summary>
-        /// Is not in
-        /// </summary>
-        Ni = 512,
-        /// <summary>
-        /// Ends with
-        /// </summary>
-        Ew = 1024,
-        /// <summary>
-        /// Does not end with
-        /// </summary>
-        En = 2048,
-        /// <summary>
-        /// Contains
-        /// </summary>
-        Cn = 4096,
-        /// <summary>
-        /// Does not contain
-        /// </summary>
-        Nc = 8192,
-        /// <summary>
-        /// Is null
-        /// </summary>
-        Nu = 16384,
-        /// <summary>
-        /// Is not null
-        /// </summary>
-        Nn = 32768,
-        /// <summary>
-        /// Combines equal, not equal, less, less or equal, greater, greater or equal, is null, is not null.
-        /// </summary>
-        NoTextOperators = JqGridSearchOperators.Eq | JqGridSearchOperators.Ne | JqGridSearchOperators.Lt | JqGridSearchOperators.Le | JqGridSearchOperators.Gt | JqGridSearchOperators.Ge | JqGridSearchOperators.Nu | JqGridSearchOperators.Nn,
-        /// <summary>
-        /// Combines equal, not equal, begins with, does not begin with, ends with, does not end with, contains and does not contain, is null, is not null
-        /// </summary>
-        TextOperators = JqGridSearchOperators.Eq | JqGridSearchOperators.Ne | JqGridSearchOperators.Bw | JqGridSearchOperators.Bn | JqGridSearchOperators.Ew | JqGridSearchOperators.En | JqGridSearchOperators.Cn | JqGridSearchOperators.Nc | JqGridSearchOperators.Nu | JqGridSearchOperators.Nn,
-        /// <summary>
-        /// Combines is null, is not null
-        /// </summary>
-        NullOperators = JqGridSearchOperators.Nu | JqGridSearchOperators.Nn
-    }
+	/// <summary>
+	/// Defines available operators for search fields for jqGrid
+	/// </summary>
+	[Flags]
+	public enum JqGridSearchOperators
+	{
+		/// <summary>
+		/// Equal
+		/// </summary>
+		Eq = 1,
+		/// <summary>
+		/// Not equal
+		/// </summary>
+		Ne = 2,
+		/// <summary>
+		/// Combines equal and not equal
+		/// </summary>
+		EqualOrNotEqual = Eq | Ne,
+		/// <summary>
+		/// Less
+		/// </summary>
+		Lt = 4,
+		/// <summary>
+		/// Less or equal
+		/// </summary>
+		Le = 8,
+		/// <summary>
+		/// Greater
+		/// </summary>
+		Gt = 16,
+		/// <summary>
+		/// Greater or equal
+		/// </summary>
+		Ge = 32,
+		/// <summary>
+		/// Begins with
+		/// </summary>
+		Bw = 64,
+		/// <summary>
+		/// Does not begin with
+		/// </summary>
+		Bn = 128,
+		/// <summary>
+		/// Is in
+		/// </summary>
+		In = 256,
+		/// <summary>
+		/// Is not in
+		/// </summary>
+		Ni = 512,
+		/// <summary>
+		/// Ends with
+		/// </summary>
+		Ew = 1024,
+		/// <summary>
+		/// Does not end with
+		/// </summary>
+		En = 2048,
+		/// <summary>
+		/// Contains
+		/// </summary>
+		Cn = 4096,
+		/// <summary>
+		/// Does not contain
+		/// </summary>
+		Nc = 8192,
+		/// <summary>
+		/// Is null
+		/// </summary>
+		Nu = 16384,
+		/// <summary>
+		/// Is not null
+		/// </summary>
+		Nn = 32768,
+		/// <summary>
+		/// Combines equal, not equal, less, less or equal, greater, greater or equal, is null, is not null.
+		/// </summary>
+		NoTextOperators = Eq | Ne | Lt | Le | Gt | Ge | Nu | Nn,
+		/// <summary>
+		/// Combines equal, not equal, begins with, does not begin with, ends with, does not end with, contains and does not contain, is null, is not null
+		/// </summary>
+		TextOperators = Eq | Ne | Bw | Bn | Ew | En | Cn | Nc | Nu | Nn,
+		/// <summary>
+		/// Combines is null, is not null
+		/// </summary>
+		NullOperators = Nu | Nn,
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default = 65536
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSearchOperators.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSearchOperators.cs
@@ -2,95 +2,95 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available operators for search fields for jqGrid
-	/// </summary>
-	[Flags]
-	public enum JqGridSearchOperators
-	{
-		/// <summary>
-		/// Equal
-		/// </summary>
-		Eq = 1,
-		/// <summary>
-		/// Not equal
-		/// </summary>
-		Ne = 2,
-		/// <summary>
-		/// Combines equal and not equal
-		/// </summary>
-		EqualOrNotEqual = Eq | Ne,
-		/// <summary>
-		/// Less
-		/// </summary>
-		Lt = 4,
-		/// <summary>
-		/// Less or equal
-		/// </summary>
-		Le = 8,
-		/// <summary>
-		/// Greater
-		/// </summary>
-		Gt = 16,
-		/// <summary>
-		/// Greater or equal
-		/// </summary>
-		Ge = 32,
-		/// <summary>
-		/// Begins with
-		/// </summary>
-		Bw = 64,
-		/// <summary>
-		/// Does not begin with
-		/// </summary>
-		Bn = 128,
-		/// <summary>
-		/// Is in
-		/// </summary>
-		In = 256,
-		/// <summary>
-		/// Is not in
-		/// </summary>
-		Ni = 512,
-		/// <summary>
-		/// Ends with
-		/// </summary>
-		Ew = 1024,
-		/// <summary>
-		/// Does not end with
-		/// </summary>
-		En = 2048,
-		/// <summary>
-		/// Contains
-		/// </summary>
-		Cn = 4096,
-		/// <summary>
-		/// Does not contain
-		/// </summary>
-		Nc = 8192,
-		/// <summary>
-		/// Is null
-		/// </summary>
-		Nu = 16384,
-		/// <summary>
-		/// Is not null
-		/// </summary>
-		Nn = 32768,
-		/// <summary>
-		/// Combines equal, not equal, less, less or equal, greater, greater or equal, is null, is not null.
-		/// </summary>
-		NoTextOperators = Eq | Ne | Lt | Le | Gt | Ge | Nu | Nn,
-		/// <summary>
-		/// Combines equal, not equal, begins with, does not begin with, ends with, does not end with, contains and does not contain, is null, is not null
-		/// </summary>
-		TextOperators = Eq | Ne | Bw | Bn | Ew | En | Cn | Nc | Nu | Nn,
-		/// <summary>
-		/// Combines is null, is not null
-		/// </summary>
-		NullOperators = Nu | Nn,
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default = 65536
-	}
+    /// <summary>
+    /// Defines available operators for search fields for jqGrid
+    /// </summary>
+    [Flags]
+    public enum JqGridSearchOperators
+    {
+        /// <summary>
+        /// Equal
+        /// </summary>
+        Eq = 1,
+        /// <summary>
+        /// Not equal
+        /// </summary>
+        Ne = 2,
+        /// <summary>
+        /// Combines equal and not equal
+        /// </summary>
+        EqualOrNotEqual = Eq | Ne,
+        /// <summary>
+        /// Less
+        /// </summary>
+        Lt = 4,
+        /// <summary>
+        /// Less or equal
+        /// </summary>
+        Le = 8,
+        /// <summary>
+        /// Greater
+        /// </summary>
+        Gt = 16,
+        /// <summary>
+        /// Greater or equal
+        /// </summary>
+        Ge = 32,
+        /// <summary>
+        /// Begins with
+        /// </summary>
+        Bw = 64,
+        /// <summary>
+        /// Does not begin with
+        /// </summary>
+        Bn = 128,
+        /// <summary>
+        /// Is in
+        /// </summary>
+        In = 256,
+        /// <summary>
+        /// Is not in
+        /// </summary>
+        Ni = 512,
+        /// <summary>
+        /// Ends with
+        /// </summary>
+        Ew = 1024,
+        /// <summary>
+        /// Does not end with
+        /// </summary>
+        En = 2048,
+        /// <summary>
+        /// Contains
+        /// </summary>
+        Cn = 4096,
+        /// <summary>
+        /// Does not contain
+        /// </summary>
+        Nc = 8192,
+        /// <summary>
+        /// Is null
+        /// </summary>
+        Nu = 16384,
+        /// <summary>
+        /// Is not null
+        /// </summary>
+        Nn = 32768,
+        /// <summary>
+        /// Combines equal, not equal, less, less or equal, greater, greater or equal, is null, is not null.
+        /// </summary>
+        NoTextOperators = Eq | Ne | Lt | Le | Gt | Ge | Nu | Nn,
+        /// <summary>
+        /// Combines equal, not equal, begins with, does not begin with, ends with, does not end with, contains and does not contain, is null, is not null
+        /// </summary>
+        TextOperators = Eq | Ne | Bw | Bn | Ew | En | Cn | Nc | Nu | Nn,
+        /// <summary>
+        /// Combines is null, is not null
+        /// </summary>
+        NullOperators = Nu | Nn,
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default = 65536
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSortingOrders.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSortingOrders.cs
@@ -1,21 +1,21 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// jqGrid sorting order values
-	/// </summary>
-	public enum JqGridSortingOrders
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Ascending
-		/// </summary>
-		Asc,
-		/// <summary>
-		/// Descending
-		/// </summary>
-		Desc
-	}
+    /// <summary>
+    /// jqGrid sorting order values
+    /// </summary>
+    public enum JqGridSortingOrders
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Ascending
+        /// </summary>
+        Asc,
+        /// <summary>
+        /// Descending
+        /// </summary>
+        Desc
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSortingOrders.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSortingOrders.cs
@@ -1,19 +1,21 @@
-﻿using System;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// jqGrid sorting order values
-    /// </summary>
-    public enum JqGridSortingOrders
-    {
-        /// <summary>
-        /// Ascending
-        /// </summary>
-        Asc,
-        /// <summary>
-        /// Descending
-        /// </summary>
-        Desc
-    }
+	/// <summary>
+	/// jqGrid sorting order values
+	/// </summary>
+	public enum JqGridSortingOrders
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Ascending
+		/// </summary>
+		Asc,
+		/// <summary>
+		/// Descending
+		/// </summary>
+		Desc
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridStyleUIOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridStyleUIOptions.cs
@@ -1,29 +1,29 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available CSS frameworks for jqGrid
-	/// </summary>
-	public enum JqGridStyleUIOptions
-	{
-		/// <summary>
-		/// Use default JqGrid value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Bootstrap 3
-		/// </summary>
-		/// <remarks>
-		/// Available since Guriddo jqGrid 5.0
-		/// </remarks>
-		Bootstrap,
-		/// <summary>
-		/// Bootstrap 4
-		/// </summary>
-		/// <remarks>Available since Gurido jqGrid 5.3.0</remarks>
-		Bootstrap4,
-		/// <summary>
-		///  jQueryUI
-		/// </summary>
-		jQueryUI
-	}
+    /// <summary>
+    /// Defines available CSS frameworks for jqGrid
+    /// </summary>
+    public enum JqGridStyleUIOptions
+    {
+        /// <summary>
+        /// Use default JqGrid value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Bootstrap 3
+        /// </summary>
+        /// <remarks>
+        /// Available since Guriddo jqGrid 5.0
+        /// </remarks>
+        Bootstrap,
+        /// <summary>
+        /// Bootstrap 4
+        /// </summary>
+        /// <remarks>Available since Gurido jqGrid 5.3.0</remarks>
+        Bootstrap4,
+        /// <summary>
+        ///  jQueryUI
+        /// </summary>
+        jQueryUI
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridStyleUIOptions.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridStyleUIOptions.cs
@@ -1,20 +1,29 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available CSS frameworks for jqGrid
-    /// </summary>
-    public enum JqGridStyleUIOptions
-    {
-        /// <summary>
-        /// Bootstrap
-        /// </summary>
-        /// <remarks>
-        /// Available since Guriddo jqGrid 5.0
-        /// </remarks>
-        Bootstrap,
-        /// <summary>
-        ///  jQueryUI
-        /// </summary>
-        jQueryUI
-    }
+	/// <summary>
+	/// Defines available CSS frameworks for jqGrid
+	/// </summary>
+	public enum JqGridStyleUIOptions
+	{
+		/// <summary>
+		/// Use default JqGrid value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Bootstrap 3
+		/// </summary>
+		/// <remarks>
+		/// Available since Guriddo jqGrid 5.0
+		/// </remarks>
+		Bootstrap,
+		/// <summary>
+		/// Bootstrap 4
+		/// </summary>
+		/// <remarks>Available since Gurido jqGrid 5.3.0</remarks>
+		Bootstrap4,
+		/// <summary>
+		///  jQueryUI
+		/// </summary>
+		jQueryUI
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSubgridModel.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSubgridModel.cs
@@ -1,42 +1,39 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents subgrid model for jqGrid.
-    /// </summary>
-    public class JqGridSubgridModel
-    {
-        #region Properties
-        /// <summary>
-        /// Gets the list of columns names.
-        /// </summary>
-        public List<string> ColumnsNames { get; private set; }
+	/// <summary>
+	/// Class which represents subgrid model for jqGrid.
+	/// </summary>
+	public class JqGridSubgridModel
+	{
+		#region Properties
+		/// <summary>
+		/// Gets the list of columns names.
+		/// </summary>
+		public List<string> ColumnsNames { get; }
 
-        /// <summary>
-        /// Gets the list of columns alignments.
-        /// </summary>
-        public List<JqGridAlignments> ColumnsAlignments { get; private set; }
+		/// <summary>
+		/// Gets the list of columns alignments.
+		/// </summary>
+		public List<JqGridAlignments> ColumnsAlignments { get; }
 
-        /// <summary>
-        /// Gets the list of columns widths.
-        /// </summary>
-        public List<int> ColumnsWidths { get; private set; }
-        #endregion
+		/// <summary>
+		/// Gets the list of columns widths.
+		/// </summary>
+		public List<int> ColumnsWidths { get; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridSubgridModel class.
-        /// </summary>
-        public JqGridSubgridModel()
-        {
-            ColumnsNames = new List<string>();
-            ColumnsAlignments = new List<JqGridAlignments>();
-            ColumnsWidths = new List<int>();
-        }
-        #endregion
-    }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridSubgridModel class.
+		/// </summary>
+		public JqGridSubgridModel()
+		{
+			ColumnsNames = new List<string>();
+			ColumnsAlignments = new List<JqGridAlignments>();
+			ColumnsWidths = new List<int>();
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSubgridModel.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSubgridModel.cs
@@ -2,38 +2,38 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents subgrid model for jqGrid.
-	/// </summary>
-	public class JqGridSubgridModel
-	{
-		#region Properties
-		/// <summary>
-		/// Gets the list of columns names.
-		/// </summary>
-		public List<string> ColumnsNames { get; }
+    /// <summary>
+    /// Class which represents subgrid model for jqGrid.
+    /// </summary>
+    public class JqGridSubgridModel
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the list of columns names.
+        /// </summary>
+        public List<string> ColumnsNames { get; }
 
-		/// <summary>
-		/// Gets the list of columns alignments.
-		/// </summary>
-		public List<JqGridAlignments> ColumnsAlignments { get; }
+        /// <summary>
+        /// Gets the list of columns alignments.
+        /// </summary>
+        public List<JqGridAlignments> ColumnsAlignments { get; }
 
-		/// <summary>
-		/// Gets the list of columns widths.
-		/// </summary>
-		public List<int> ColumnsWidths { get; }
-		#endregion
+        /// <summary>
+        /// Gets the list of columns widths.
+        /// </summary>
+        public List<int> ColumnsWidths { get; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridSubgridModel class.
-		/// </summary>
-		public JqGridSubgridModel()
-		{
-			ColumnsNames = new List<string>();
-			ColumnsAlignments = new List<JqGridAlignments>();
-			ColumnsWidths = new List<int>();
-		}
-		#endregion
-	}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridSubgridModel class.
+        /// </summary>
+        public JqGridSubgridModel()
+        {
+            ColumnsNames = new List<string>();
+            ColumnsAlignments = new List<JqGridAlignments>();
+            ColumnsWidths = new List<int>();
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSubgridModel`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSubgridModel`1.cs
@@ -5,38 +5,38 @@ using Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Class which represents subgrid model for jqGrid.
-	/// </summary>
-	/// <typeparam name="TModel">Type of model for grid</typeparam>
-	public class JqGridSubgridModel<TModel> : JqGridSubgridModel
-	{
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridSubgridModel class.
-		/// </summary>
-		public JqGridSubgridModel()
-		{
-			var modelMetadata = ModelMetadataProviders.Current.GetMetadataForType(null, typeof(TModel));
-			foreach (var propertyMetadata in modelMetadata.Properties.Where(p => p.ShowForDisplay && !p.IsComplexType))
-			{
-				var customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
+    /// <summary>
+    /// Class which represents subgrid model for jqGrid.
+    /// </summary>
+    /// <typeparam name="TModel">Type of model for grid</typeparam>
+    public class JqGridSubgridModel<TModel> : JqGridSubgridModel
+    {
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridSubgridModel class.
+        /// </summary>
+        public JqGridSubgridModel()
+        {
+            ModelMetadata modelMetadata = ModelMetadataProviders.Current.GetMetadataForType(null, typeof(TModel));
+            foreach (ModelMetadata propertyMetadata in modelMetadata.Properties.Where(p => p.ShowForDisplay && !p.IsComplexType))
+            {
+                IEnumerable<object> customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
 
-				var columnLayoutAttribute = customAttributes.OfType<JqGridColumnLayoutAttribute>().FirstOrDefault();
-				if (columnLayoutAttribute != null)
-				{
-					ColumnsAlignments.Add(columnLayoutAttribute.Alignment);
-					ColumnsWidths.Add(columnLayoutAttribute.Width);
-				}
-				else
-				{
-					ColumnsAlignments.Add(JqGridAlignments.Left);
-					ColumnsWidths.Add(150);
-				}
+                JqGridColumnLayoutAttribute columnLayoutAttribute = customAttributes.OfType<JqGridColumnLayoutAttribute>().FirstOrDefault();
+                if (columnLayoutAttribute != null)
+                {
+                    ColumnsAlignments.Add(columnLayoutAttribute.Alignment);
+                    ColumnsWidths.Add(columnLayoutAttribute.Width);
+                }
+                else
+                {
+                    ColumnsAlignments.Add(JqGridAlignments.Left);
+                    ColumnsWidths.Add(150);
+                }
 
-				ColumnsNames.Add(propertyMetadata.GetDisplayName());
-			}
-		}
-		#endregion
-	}
+                ColumnsNames.Add(propertyMetadata.GetDisplayName());
+            }
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridSubgridModel`1.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridSubgridModel`1.cs
@@ -1,45 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 using Lib.Web.Mvc.JQuery.JqGrid.DataAnnotations;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Class which represents subgrid model for jqGrid.
-    /// </summary>
-    /// <typeparam name="TModel">Type of model for grid</typeparam>
-    public class JqGridSubgridModel<TModel> : JqGridSubgridModel
-    {
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridSubgridModel class.
-        /// </summary>
-        public JqGridSubgridModel()
-            : base()
-        {
-            ModelMetadata modelMetadata = ModelMetadataProviders.Current.GetMetadataForType(null, typeof(TModel));
-            foreach (ModelMetadata propertyMetadata in modelMetadata.Properties.Where(p => p.ShowForDisplay && !p.IsComplexType))
-            {
-                IEnumerable<object> customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
+	/// <summary>
+	/// Class which represents subgrid model for jqGrid.
+	/// </summary>
+	/// <typeparam name="TModel">Type of model for grid</typeparam>
+	public class JqGridSubgridModel<TModel> : JqGridSubgridModel
+	{
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridSubgridModel class.
+		/// </summary>
+		public JqGridSubgridModel()
+		{
+			var modelMetadata = ModelMetadataProviders.Current.GetMetadataForType(null, typeof(TModel));
+			foreach (var propertyMetadata in modelMetadata.Properties.Where(p => p.ShowForDisplay && !p.IsComplexType))
+			{
+				var customAttributes = propertyMetadata.ContainerType.GetProperty(propertyMetadata.PropertyName).GetCustomAttributes(true).AsEnumerable();
 
-                JqGridColumnLayoutAttribute columnLayoutAttribute = customAttributes.OfType<JqGridColumnLayoutAttribute>().FirstOrDefault();
-                if (columnLayoutAttribute != null)
-                {
-                    ColumnsAlignments.Add(columnLayoutAttribute.Alignment);
-                    ColumnsWidths.Add(columnLayoutAttribute.Width);
-                }
-                else
-                {
-                    ColumnsAlignments.Add(JqGridAlignments.Left);
-                    ColumnsWidths.Add(150);
-                }
+				var columnLayoutAttribute = customAttributes.OfType<JqGridColumnLayoutAttribute>().FirstOrDefault();
+				if (columnLayoutAttribute != null)
+				{
+					ColumnsAlignments.Add(columnLayoutAttribute.Alignment);
+					ColumnsWidths.Add(columnLayoutAttribute.Width);
+				}
+				else
+				{
+					ColumnsAlignments.Add(JqGridAlignments.Left);
+					ColumnsWidths.Add(150);
+				}
 
-                ColumnsNames.Add(propertyMetadata.GetDisplayName());
-            }
-        }
-        #endregion
-    }
+				ColumnsNames.Add(propertyMetadata.GetDisplayName());
+			}
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridTreeGridModels.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridTreeGridModels.cs
@@ -1,21 +1,21 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Defines available models for jqGrid TrreGrid
-	/// </summary>
-	public enum JqGridTreeGridModels
-	{
-		/// <summary>
-		/// Use JqGrid default value
-		/// </summary>
-		Default,
-		/// <summary>
-		/// Nested set model
-		/// </summary>
-		Nested,
-		/// <summary>
-		/// Adjacency model
-		/// </summary>
-		Adjacency
-	}
+    /// <summary>
+    /// Defines available models for jqGrid TrreGrid
+    /// </summary>
+    public enum JqGridTreeGridModels
+    {
+        /// <summary>
+        /// Use JqGrid default value
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Nested set model
+        /// </summary>
+        Nested,
+        /// <summary>
+        /// Adjacency model
+        /// </summary>
+        Adjacency
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridTreeGridModels.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridTreeGridModels.cs
@@ -1,22 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Lib.Web.Mvc.JQuery.JqGrid
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Defines available models for jqGrid TrreGrid
-    /// </summary>
-    public enum JqGridTreeGridModels
-    {
-        /// <summary>
-        /// Nested set model
-        /// </summary>
-        Nested,
-        /// <summary>
-        /// Adjacency model
-        /// </summary>
-        Adjacency
-    }
+	/// <summary>
+	/// Defines available models for jqGrid TrreGrid
+	/// </summary>
+	public enum JqGridTreeGridModels
+	{
+		/// <summary>
+		/// Use JqGrid default value
+		/// </summary>
+		Default,
+		/// <summary>
+		/// Nested set model
+		/// </summary>
+		Nested,
+		/// <summary>
+		/// Adjacency model
+		/// </summary>
+		Adjacency
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridTreeRecord.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridTreeRecord.cs
@@ -2,56 +2,56 @@
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Abstract class which represents TreeGrid record for jqGrid.
-	/// </summary>
-	public abstract class JqGridTreeRecord : JqGridRecord
-	{
-		#region Properties
-		/// <summary>
-		/// Gets or set the level of the record in the hierarchy.
-		/// </summary>
-		public int Level { get; private set; }
+    /// <summary>
+    /// Abstract class which represents TreeGrid record for jqGrid.
+    /// </summary>
+    public abstract class JqGridTreeRecord : JqGridRecord
+    {
+        #region Properties
+        /// <summary>
+        /// Gets or set the level of the record in the hierarchy.
+        /// </summary>
+        public int Level { get; private set; }
 
-		/// <summary>
-		/// Gets or sets value wich defines if the record is leaf (default false).
-		/// </summary>
-		public bool Leaf { get; set; }
+        /// <summary>
+        /// Gets or sets value wich defines if the record is leaf (default false).
+        /// </summary>
+        public bool Leaf { get; set; }
 
-		/// <summary>
-		/// Gets or sets the value which defines whether this element should be expanded during the loading (default false).
-		/// </summary>
-		public bool Expanded { get; set; }
-		#endregion
+        /// <summary>
+        /// Gets or sets the value which defines whether this element should be expanded during the loading (default false).
+        /// </summary>
+        public bool Expanded { get; set; }
+        #endregion
 
-		#region Constructor
-		/// <summary>
-		/// Initializes a new instance of the JqGridTreeRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="values">The record cells values.</param>
-		/// <param name="level">The level of the record in the hierarchy.</param>
-		public JqGridTreeRecord(string id, List<object> values, int level)
-			: base(id, values)
-		{
-			Level = level;
-			Leaf = false;
-			Expanded = false;
-		}
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the JqGridTreeRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="values">The record cells values.</param>
+        /// <param name="level">The level of the record in the hierarchy.</param>
+        public JqGridTreeRecord(string id, List<object> values, int level)
+            : base(id, values)
+        {
+            Level = level;
+            Leaf = false;
+            Expanded = false;
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the JqGridTreeRecord class.
-		/// </summary>
-		/// <param name="id">The record identifier.</param>
-		/// <param name="value">The record value.</param>
-		/// <param name="level">The level of the record in the hierarchy.</param>
-		public JqGridTreeRecord(string id, object value, int level)
-			: base(id, value)
-		{
-			Level = level;
-			Leaf = false;
-			Expanded = false;
-		}
-		#endregion
-	}
+        /// <summary>
+        /// Initializes a new instance of the JqGridTreeRecord class.
+        /// </summary>
+        /// <param name="id">The record identifier.</param>
+        /// <param name="value">The record value.</param>
+        /// <param name="level">The level of the record in the hierarchy.</param>
+        public JqGridTreeRecord(string id, object value, int level)
+            : base(id, value)
+        {
+            Level = level;
+            Leaf = false;
+            Expanded = false;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridTreeRecord.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridTreeRecord.cs
@@ -1,60 +1,57 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    /// <summary>
-    /// Abstract class which represents TreeGrid record for jqGrid.
-    /// </summary>
-    public abstract class JqGridTreeRecord : JqGridRecord
-    {
-        #region Properties
-        /// <summary>
-        /// Gets or set the level of the record in the hierarchy.
-        /// </summary>
-        public int Level { get; private set; }
+	/// <summary>
+	/// Abstract class which represents TreeGrid record for jqGrid.
+	/// </summary>
+	public abstract class JqGridTreeRecord : JqGridRecord
+	{
+		#region Properties
+		/// <summary>
+		/// Gets or set the level of the record in the hierarchy.
+		/// </summary>
+		public int Level { get; private set; }
 
-        /// <summary>
-        /// Gets or sets value wich defines if the record is leaf (default false).
-        /// </summary>
-        public bool Leaf { get; set; }
+		/// <summary>
+		/// Gets or sets value wich defines if the record is leaf (default false).
+		/// </summary>
+		public bool Leaf { get; set; }
 
-        /// <summary>
-        /// Gets or sets the value which defines whether this element should be expanded during the loading (default false).
-        /// </summary>
-        public bool Expanded { get; set; }
-        #endregion
+		/// <summary>
+		/// Gets or sets the value which defines whether this element should be expanded during the loading (default false).
+		/// </summary>
+		public bool Expanded { get; set; }
+		#endregion
 
-        #region Constructor
-        /// <summary>
-        /// Initializes a new instance of the JqGridTreeRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="values">The record cells values.</param>
-        /// <param name="level">The level of the record in the hierarchy.</param>
-        public JqGridTreeRecord(string id, List<object> values, int level)
-            : base(id, values)
-        {
-            Level = level;
-            Leaf = false;
-            Expanded = false;
-        }
+		#region Constructor
+		/// <summary>
+		/// Initializes a new instance of the JqGridTreeRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="values">The record cells values.</param>
+		/// <param name="level">The level of the record in the hierarchy.</param>
+		public JqGridTreeRecord(string id, List<object> values, int level)
+			: base(id, values)
+		{
+			Level = level;
+			Leaf = false;
+			Expanded = false;
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the JqGridTreeRecord class.
-        /// </summary>
-        /// <param name="id">The record identifier.</param>
-        /// <param name="value">The record value.</param>
-        /// <param name="level">The level of the record in the hierarchy.</param>
-        public JqGridTreeRecord(string id, object value, int level)
-            : base(id, value)
-        {
-            Level = level;
-            Leaf = false;
-            Expanded = false;
-        }
-        #endregion
-    }
+		/// <summary>
+		/// Initializes a new instance of the JqGridTreeRecord class.
+		/// </summary>
+		/// <param name="id">The record identifier.</param>
+		/// <param name="value">The record value.</param>
+		/// <param name="level">The level of the record in the hierarchy.</param>
+		public JqGridTreeRecord(string id, object value, int level)
+			: base(id, value)
+		{
+			Level = level;
+			Leaf = false;
+			Expanded = false;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridUtility.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridUtility.cs
@@ -5,21 +5,21 @@ using System.Data.Linq;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	internal static class JqGridUtility
-	{
-		#region Methods
-		internal static bool IsValidForColumn(this ModelMetadata metadata)
-		{
-			return
-				metadata.ShowForDisplay
-				&& metadata.ModelType != typeof(EntityState)
-				&& (!metadata.IsComplexType || metadata.ModelType == typeof(Binary) || metadata.ModelType == typeof(byte[]));
-		}
+    internal static class JqGridUtility
+    {
+        #region Methods
+        internal static bool IsValidForColumn(this ModelMetadata metadata)
+        {
+            return
+                metadata.ShowForDisplay
+                && metadata.ModelType != typeof(EntityState)
+                && (!metadata.IsComplexType || metadata.ModelType == typeof(Binary) || metadata.ModelType == typeof(byte[]));
+        }
 
-		internal static string ToNullString(this string s)
-		{
-			return string.IsNullOrWhiteSpace(s) ? "null" : s;
-		}
-		#endregion
-	}
+        internal static string ToNullString(this string s)
+        {
+            return string.IsNullOrWhiteSpace(s) ? "null" : s;
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/JqGridUtility.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/JqGridUtility.cs
@@ -1,23 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 using System.Data;
 using System.Data.Linq;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-    internal static class JqGridUtility
-    {
-        #region Methods
-        internal static bool IsValidForColumn(this ModelMetadata metadata)
-        {
-            return
-                metadata.ShowForDisplay
-                && metadata.ModelType != typeof(EntityState)
-                && (!metadata.IsComplexType || metadata.ModelType == typeof(Binary) || metadata.ModelType == typeof(byte[]));
-        }
-        #endregion
-    }
+	internal static class JqGridUtility
+	{
+		#region Methods
+		internal static bool IsValidForColumn(this ModelMetadata metadata)
+		{
+			return
+				metadata.ShowForDisplay
+				&& metadata.ModelType != typeof(EntityState)
+				&& (!metadata.IsComplexType || metadata.ModelType == typeof(Binary) || metadata.ModelType == typeof(byte[]));
+		}
+
+		internal static string ToNullString(this string s)
+		{
+			return string.IsNullOrWhiteSpace(s) ? "null" : s;
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/ModelBinders/JqGridJsonModelBinder.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/ModelBinders/JqGridJsonModelBinder.cs
@@ -5,31 +5,31 @@ using System.IO;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.ModelBinders
 {
-	internal class JqGridJsonModelBinder : DefaultModelBinder
-	{
-		public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
-		{
-			if (controllerContext == null)
-				throw new ArgumentNullException(nameof(controllerContext));
-			if (bindingContext == null)
-				throw new ArgumentNullException(nameof(bindingContext));
+    internal class JqGridJsonModelBinder : DefaultModelBinder
+    {
+        public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
+        {
+            if (controllerContext == null)
+                throw new ArgumentNullException(nameof(controllerContext));
+            if (bindingContext == null)
+                throw new ArgumentNullException(nameof(bindingContext));
 
-			var serializer = new JavaScriptSerializer();
-			serializer.RegisterConverters(new JavaScriptConverter[] { new Serialization.JqGridScriptConverter() });
+            JavaScriptSerializer serializer = new JavaScriptSerializer();
+            serializer.RegisterConverters(new JavaScriptConverter[] { new Serialization.JqGridScriptConverter() });
 
-			string jsonString;
-			if (controllerContext.RequestContext.HttpContext.Request.ContentType.Contains("application/json"))
-			{
-				controllerContext.HttpContext.Request.InputStream.Seek(0, SeekOrigin.Begin);
-				using (var jsonReader = new StreamReader(controllerContext.HttpContext.Request.InputStream))
-					jsonString = jsonReader.ReadToEnd();
-			}
-			else
-				jsonString = controllerContext.HttpContext.Request[bindingContext.ModelName];
+            string jsonString;
+            if (controllerContext.RequestContext.HttpContext.Request.ContentType.Contains("application/json"))
+            {
+                controllerContext.HttpContext.Request.InputStream.Seek(0, SeekOrigin.Begin);
+                using (StreamReader jsonReader = new StreamReader(controllerContext.HttpContext.Request.InputStream))
+                    jsonString = jsonReader.ReadToEnd();
+            }
+            else
+                jsonString = controllerContext.HttpContext.Request[bindingContext.ModelName];
 
-			if (string.IsNullOrEmpty(jsonString))
-				return null;
-			return serializer.Deserialize(jsonString, bindingContext.ModelType);
-		}
-	}
+            if (string.IsNullOrEmpty(jsonString))
+                return null;
+            return serializer.Deserialize(jsonString, bindingContext.ModelType);
+        }
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/ModelBinders/JqGridJsonModelBinder.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/ModelBinders/JqGridJsonModelBinder.cs
@@ -1,39 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 using System.Web.Script.Serialization;
 using System.IO;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.ModelBinders
 {
-    internal class JqGridJsonModelBinder : DefaultModelBinder
-    {
-        public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
-        {
-            if (controllerContext == null)
-                throw new ArgumentNullException("controllerContext");
-            if (bindingContext == null)
-                throw new ArgumentNullException("bindingContext");
+	internal class JqGridJsonModelBinder : DefaultModelBinder
+	{
+		public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
+		{
+			if (controllerContext == null)
+				throw new ArgumentNullException(nameof(controllerContext));
+			if (bindingContext == null)
+				throw new ArgumentNullException(nameof(bindingContext));
 
-            JavaScriptSerializer serializer = new JavaScriptSerializer();
-            serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
-            
-            string jsonString = String.Empty;
-            if (controllerContext.RequestContext.HttpContext.Request.ContentType.Contains("application/json"))
-            {
-                controllerContext.HttpContext.Request.InputStream.Seek(0, SeekOrigin.Begin);
-                using (StreamReader jsonReader = new StreamReader(controllerContext.HttpContext.Request.InputStream))
-                    jsonString = jsonReader.ReadToEnd();
-            }
-            else
-                jsonString = controllerContext.HttpContext.Request[bindingContext.ModelName];
+			var serializer = new JavaScriptSerializer();
+			serializer.RegisterConverters(new JavaScriptConverter[] { new Serialization.JqGridScriptConverter() });
 
-            if (String.IsNullOrEmpty(jsonString))
-                    return null;
-                else
-                    return serializer.Deserialize(jsonString, bindingContext.ModelType);
-        }
-    }
+			string jsonString;
+			if (controllerContext.RequestContext.HttpContext.Request.ContentType.Contains("application/json"))
+			{
+				controllerContext.HttpContext.Request.InputStream.Seek(0, SeekOrigin.Begin);
+				using (var jsonReader = new StreamReader(controllerContext.HttpContext.Request.InputStream))
+					jsonString = jsonReader.ReadToEnd();
+			}
+			else
+				jsonString = controllerContext.HttpContext.Request[bindingContext.ModelName];
+
+			if (string.IsNullOrEmpty(jsonString))
+				return null;
+			return serializer.Deserialize(jsonString, bindingContext.ModelType);
+		}
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/ModelBinders/JqGridRequestModelBinder.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/ModelBinders/JqGridRequestModelBinder.cs
@@ -1,95 +1,92 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 using System.Web.Script.Serialization;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.ModelBinders
 {
-    internal class JqGridRequestModelBinder : DefaultModelBinder
-    {
-        public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
-        {
-            if (controllerContext == null)
-                throw new ArgumentNullException("controllerContext");
-            if (bindingContext == null)
-                throw new ArgumentNullException("bindingContext");
+	internal class JqGridRequestModelBinder : DefaultModelBinder
+	{
+		public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
+		{
+			if (controllerContext == null)
+				throw new ArgumentNullException(nameof(controllerContext));
+			if (bindingContext == null)
+				throw new ArgumentNullException(nameof(bindingContext));
 
-            JqGridRequest model = new JqGridRequest();
+			var model = new JqGridRequest();
 
-            model.Searching = false;
-            if (!String.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.Searching))
-            {
-                ValueProviderResult searchingResult = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.Searching);
-                if (searchingResult != null)
-                    model.Searching = (bool)searchingResult.ConvertTo(typeof(Boolean));
-            }
+			model.Searching = false;
+			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.Searching))
+			{
+				var searchingResult = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.Searching);
+				if (searchingResult != null)
+					model.Searching = (bool)searchingResult.ConvertTo(typeof(bool));
+			}
 
-            model.SearchingFilter = null;
-            model.SearchingFilters = null;
-            if (model.Searching)
-            {
-                ValueProviderResult searchingFiltersResult = bindingContext.ValueProvider.GetValue("filters");
-                if (searchingFiltersResult != null && !String.IsNullOrWhiteSpace(searchingFiltersResult.AttemptedValue))
-                {
-                    JavaScriptSerializer serializer = new JavaScriptSerializer();
-                    serializer.RegisterConverters(new JavaScriptConverter[] { new Lib.Web.Mvc.JQuery.JqGrid.Serialization.JqGridScriptConverter() });
-                    model.SearchingFilters = serializer.Deserialize<JqGridRequestSearchingFilters>((string)searchingFiltersResult.ConvertTo(typeof(String)));
-                }
-                else
-                {
-                    string searchingName = String.Empty;
-                    ValueProviderResult searchingNameResult = bindingContext.ValueProvider.GetValue("searchField");
-                    if (searchingNameResult != null)
-                        searchingName = (string)searchingNameResult.ConvertTo(typeof(String));
+			model.SearchingFilter = null;
+			model.SearchingFilters = null;
+			if (model.Searching)
+			{
+				var searchingFiltersResult = bindingContext.ValueProvider.GetValue("filters");
+				if (!string.IsNullOrWhiteSpace(searchingFiltersResult?.AttemptedValue))
+				{
+					var serializer = new JavaScriptSerializer();
+					serializer.RegisterConverters(new JavaScriptConverter[] { new Serialization.JqGridScriptConverter() });
+					model.SearchingFilters = serializer.Deserialize<JqGridRequestSearchingFilters>((string)searchingFiltersResult.ConvertTo(typeof(string)));
+				}
+				else
+				{
+					var searchingName = string.Empty;
+					var searchingNameResult = bindingContext.ValueProvider.GetValue("searchField");
+					if (searchingNameResult != null)
+						searchingName = (string)searchingNameResult.ConvertTo(typeof(string));
 
-                    string searchingValue = String.Empty;
-                    ValueProviderResult searchingValueResult = bindingContext.ValueProvider.GetValue("searchString");
-                    if (searchingValueResult != null)
-                        searchingValue = (string)searchingValueResult.ConvertTo(typeof(String));
+					var searchingValue = string.Empty;
+					var searchingValueResult = bindingContext.ValueProvider.GetValue("searchString");
+					if (searchingValueResult != null)
+						searchingValue = (string)searchingValueResult.ConvertTo(typeof(string));
 
-                    JqGridSearchOperators searchingOperator = JqGridSearchOperators.Eq;
-                    ValueProviderResult searchingOperatorResult = bindingContext.ValueProvider.GetValue("searchOper");
-                    if (searchingOperatorResult != null)
-                        Enum.TryParse<JqGridSearchOperators>((string)searchingOperatorResult.ConvertTo(typeof(String)), true, out searchingOperator);
+					var searchingOperator = JqGridSearchOperators.Eq;
+					var searchingOperatorResult = bindingContext.ValueProvider.GetValue("searchOper");
+					if (searchingOperatorResult != null)
+						Enum.TryParse((string)searchingOperatorResult.ConvertTo(typeof(string)), true, out searchingOperator);
 
-                    if (!String.IsNullOrWhiteSpace(searchingName) && (!String.IsNullOrWhiteSpace(searchingValue) || ((searchingOperator & JqGridSearchOperators.NullOperators) != 0)))
-                        model.SearchingFilter = new JqGridRequestSearchingFilter() { SearchingName = searchingName, SearchingOperator = searchingOperator, SearchingValue = searchingValue };
-                }
-            }
+					if (!string.IsNullOrWhiteSpace(searchingName) && (!string.IsNullOrWhiteSpace(searchingValue) || ((searchingOperator & JqGridSearchOperators.NullOperators) != 0)))
+						model.SearchingFilter = new JqGridRequestSearchingFilter() { SearchingName = searchingName, SearchingOperator = searchingOperator, SearchingValue = searchingValue };
+				}
+			}
 
-            if (!String.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.SortingName))
-            {
-                ValueProviderResult sortingName = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.SortingName);
-                if (sortingName != null && !String.IsNullOrWhiteSpace(sortingName.AttemptedValue))
-                    model.SortingName = (string)sortingName.ConvertTo(typeof(String));
-            }
+			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.SortingName))
+			{
+				var sortingName = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.SortingName);
+				if (!string.IsNullOrWhiteSpace(sortingName?.AttemptedValue))
+					model.SortingName = (string)sortingName.ConvertTo(typeof(string));
+			}
 
-            if (!String.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.SortingOrder))
-            {
-                ValueProviderResult sortingOrder = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.SortingOrder);
-                if (sortingOrder != null && !String.IsNullOrWhiteSpace(sortingOrder.AttemptedValue))
-                    model.SortingOrder = (JqGridSortingOrders)sortingOrder.ConvertTo(typeof(JqGridSortingOrders));
-            }
+			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.SortingOrder))
+			{
+				var sortingOrder = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.SortingOrder);
+				if (!string.IsNullOrWhiteSpace(sortingOrder?.AttemptedValue))
+					model.SortingOrder = (JqGridSortingOrders)sortingOrder.ConvertTo(typeof(JqGridSortingOrders));
+			}
 
-            if (!String.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.PageIndex))
-                model.PageIndex = (int)bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.PageIndex).ConvertTo(typeof(Int32)) - 1;
-            else
-                model.PageIndex = 0;
+			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.PageIndex))
+				model.PageIndex = (int)bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.PageIndex).ConvertTo(typeof(int)) - 1;
+			else
+				model.PageIndex = 0;
 
-            model.PagesCount = null;
-            if (!String.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.PagesCount))
-            {
-                ValueProviderResult pagesCountValueResult = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.PagesCount);
-                if (pagesCountValueResult != null)
-                    model.PagesCount = (int)pagesCountValueResult.ConvertTo(typeof(Int32));
-            }
+			model.PagesCount = null;
+			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.PagesCount))
+			{
+				var pagesCountValueResult = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.PagesCount);
+				if (pagesCountValueResult != null)
+					model.PagesCount = (int)pagesCountValueResult.ConvertTo(typeof(int));
+			}
 
-            if (!String.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.RecordsCount))
-                model.RecordsCount = (int)bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.RecordsCount).ConvertTo(typeof(Int32));
+			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.RecordsCount))
+				model.RecordsCount = (int)bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.RecordsCount).ConvertTo(typeof(int));
 
-            return model;
-        }
-    }
+			return model;
+		}
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/ModelBinders/JqGridRequestModelBinder.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/ModelBinders/JqGridRequestModelBinder.cs
@@ -4,89 +4,89 @@ using System.Web.Script.Serialization;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.ModelBinders
 {
-	internal class JqGridRequestModelBinder : DefaultModelBinder
-	{
-		public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
-		{
-			if (controllerContext == null)
-				throw new ArgumentNullException(nameof(controllerContext));
-			if (bindingContext == null)
-				throw new ArgumentNullException(nameof(bindingContext));
+    internal class JqGridRequestModelBinder : DefaultModelBinder
+    {
+        public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
+        {
+            if (controllerContext == null)
+                throw new ArgumentNullException(nameof(controllerContext));
+            if (bindingContext == null)
+                throw new ArgumentNullException(nameof(bindingContext));
 
-			var model = new JqGridRequest();
+            JqGridRequest model = new JqGridRequest();
 
-			model.Searching = false;
-			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.Searching))
-			{
-				var searchingResult = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.Searching);
-				if (searchingResult != null)
-					model.Searching = (bool)searchingResult.ConvertTo(typeof(bool));
-			}
+            model.Searching = false;
+            if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.Searching))
+            {
+                ValueProviderResult searchingResult = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.Searching);
+                if (searchingResult != null)
+                    model.Searching = (bool)searchingResult.ConvertTo(typeof(bool));
+            }
 
-			model.SearchingFilter = null;
-			model.SearchingFilters = null;
-			if (model.Searching)
-			{
-				var searchingFiltersResult = bindingContext.ValueProvider.GetValue("filters");
-				if (!string.IsNullOrWhiteSpace(searchingFiltersResult?.AttemptedValue))
-				{
-					var serializer = new JavaScriptSerializer();
-					serializer.RegisterConverters(new JavaScriptConverter[] { new Serialization.JqGridScriptConverter() });
-					model.SearchingFilters = serializer.Deserialize<JqGridRequestSearchingFilters>((string)searchingFiltersResult.ConvertTo(typeof(string)));
-				}
-				else
-				{
-					var searchingName = string.Empty;
-					var searchingNameResult = bindingContext.ValueProvider.GetValue("searchField");
-					if (searchingNameResult != null)
-						searchingName = (string)searchingNameResult.ConvertTo(typeof(string));
+            model.SearchingFilter = null;
+            model.SearchingFilters = null;
+            if (model.Searching)
+            {
+                ValueProviderResult searchingFiltersResult = bindingContext.ValueProvider.GetValue("filters");
+                if (!string.IsNullOrWhiteSpace(searchingFiltersResult?.AttemptedValue))
+                {
+                    JavaScriptSerializer serializer = new JavaScriptSerializer();
+                    serializer.RegisterConverters(new JavaScriptConverter[] { new Serialization.JqGridScriptConverter() });
+                    model.SearchingFilters = serializer.Deserialize<JqGridRequestSearchingFilters>((string)searchingFiltersResult.ConvertTo(typeof(string)));
+                }
+                else
+                {
+                    string searchingName = string.Empty;
+                    ValueProviderResult searchingNameResult = bindingContext.ValueProvider.GetValue("searchField");
+                    if (searchingNameResult != null)
+                        searchingName = (string)searchingNameResult.ConvertTo(typeof(string));
 
-					var searchingValue = string.Empty;
-					var searchingValueResult = bindingContext.ValueProvider.GetValue("searchString");
-					if (searchingValueResult != null)
-						searchingValue = (string)searchingValueResult.ConvertTo(typeof(string));
+                    string searchingValue = string.Empty;
+                    ValueProviderResult searchingValueResult = bindingContext.ValueProvider.GetValue("searchString");
+                    if (searchingValueResult != null)
+                        searchingValue = (string)searchingValueResult.ConvertTo(typeof(string));
 
-					var searchingOperator = JqGridSearchOperators.Eq;
-					var searchingOperatorResult = bindingContext.ValueProvider.GetValue("searchOper");
-					if (searchingOperatorResult != null)
-						Enum.TryParse((string)searchingOperatorResult.ConvertTo(typeof(string)), true, out searchingOperator);
+                    JqGridSearchOperators searchingOperator = JqGridSearchOperators.Eq;
+                    ValueProviderResult searchingOperatorResult = bindingContext.ValueProvider.GetValue("searchOper");
+                    if (searchingOperatorResult != null)
+                        Enum.TryParse((string)searchingOperatorResult.ConvertTo(typeof(string)), true, out searchingOperator);
 
-					if (!string.IsNullOrWhiteSpace(searchingName) && (!string.IsNullOrWhiteSpace(searchingValue) || ((searchingOperator & JqGridSearchOperators.NullOperators) != 0)))
-						model.SearchingFilter = new JqGridRequestSearchingFilter() { SearchingName = searchingName, SearchingOperator = searchingOperator, SearchingValue = searchingValue };
-				}
-			}
+                    if (!string.IsNullOrWhiteSpace(searchingName) && (!string.IsNullOrWhiteSpace(searchingValue) || ((searchingOperator & JqGridSearchOperators.NullOperators) != 0)))
+                        model.SearchingFilter = new JqGridRequestSearchingFilter() { SearchingName = searchingName, SearchingOperator = searchingOperator, SearchingValue = searchingValue };
+                }
+            }
 
-			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.SortingName))
-			{
-				var sortingName = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.SortingName);
-				if (!string.IsNullOrWhiteSpace(sortingName?.AttemptedValue))
-					model.SortingName = (string)sortingName.ConvertTo(typeof(string));
-			}
+            if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.SortingName))
+            {
+                ValueProviderResult sortingName = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.SortingName);
+                if (!string.IsNullOrWhiteSpace(sortingName?.AttemptedValue))
+                    model.SortingName = (string)sortingName.ConvertTo(typeof(string));
+            }
 
-			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.SortingOrder))
-			{
-				var sortingOrder = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.SortingOrder);
-				if (!string.IsNullOrWhiteSpace(sortingOrder?.AttemptedValue))
-					model.SortingOrder = (JqGridSortingOrders)sortingOrder.ConvertTo(typeof(JqGridSortingOrders));
-			}
+            if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.SortingOrder))
+            {
+                ValueProviderResult sortingOrder = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.SortingOrder);
+                if (!string.IsNullOrWhiteSpace(sortingOrder?.AttemptedValue))
+                    model.SortingOrder = (JqGridSortingOrders)sortingOrder.ConvertTo(typeof(JqGridSortingOrders));
+            }
 
-			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.PageIndex))
-				model.PageIndex = (int)bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.PageIndex).ConvertTo(typeof(int)) - 1;
-			else
-				model.PageIndex = 0;
+            if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.PageIndex))
+                model.PageIndex = (int)bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.PageIndex).ConvertTo(typeof(int)) - 1;
+            else
+                model.PageIndex = 0;
 
-			model.PagesCount = null;
-			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.PagesCount))
-			{
-				var pagesCountValueResult = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.PagesCount);
-				if (pagesCountValueResult != null)
-					model.PagesCount = (int)pagesCountValueResult.ConvertTo(typeof(int));
-			}
+            model.PagesCount = null;
+            if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.PagesCount))
+            {
+                ValueProviderResult pagesCountValueResult = bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.PagesCount);
+                if (pagesCountValueResult != null)
+                    model.PagesCount = (int)pagesCountValueResult.ConvertTo(typeof(int));
+            }
 
-			if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.RecordsCount))
-				model.RecordsCount = (int)bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.RecordsCount).ConvertTo(typeof(int));
+            if (!string.IsNullOrWhiteSpace(JqGridRequest.ParameterNames.RecordsCount))
+                model.RecordsCount = (int)bindingContext.ValueProvider.GetValue(JqGridRequest.ParameterNames.RecordsCount).ConvertTo(typeof(int));
 
-			return model;
-		}
-	}
+            return model;
+        }
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Serialization/JqGridScriptConverter.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Serialization/JqGridScriptConverter.cs
@@ -8,1361 +8,1410 @@ using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.Serialization
 {
-    internal class JqGridScriptConverter : JavaScriptConverter
-    {
-        #region Fields
-        private static ReadOnlyCollection<Type> _supportedTypes = new ReadOnlyCollection<Type>(new List<Type>()
-        {
-            typeof(JqGridOptions),
-            typeof(JqGridColumnModel),
-            typeof(JqGridJsonReader),
-            typeof(JqGridParametersNames),
-            typeof(JqGridGroupingView),
-            typeof(JqGridColumnEditOptions),
-            typeof(JqGridColumnRules),
-            typeof(JqGridColumnFormOptions),
-            typeof(JqGridColumnFormatterOptions),
-            typeof(JqGridColumnSearchOptions),
-            typeof(JqGridSubgridModel),
-            typeof(JqGridResponse),
-            typeof(JqGridRequestSearchingFilters),
-            typeof(JqGridRequestSearchingFilter)
-        });
-        #endregion
-
-        #region JavaScriptConverter Members
-        public override object Deserialize(IDictionary<string, object> dictionary, Type type, JavaScriptSerializer serializer)
-        {
-            object obj = null;
-
-            if (dictionary != null)
-            {
-                if (type == typeof(JqGridOptions))
-                    obj = DeserializeJqGridOptions(dictionary, serializer);
-                else if (type == typeof(JqGridColumnModel))
-                    obj = DeserializeJqGridColumnModel(dictionary, serializer);
-                else if (type == typeof(JqGridJsonReader))
-                    obj = DeserializeJqGridJsonReader(dictionary, serializer);
-                else if (type == typeof(JqGridParametersNames))
-                    obj = DeserializeJqGridParametersNames(dictionary, serializer);
-                else if (type == typeof(JqGridGroupingView))
-                    obj = DeserializeJqGridGroupingView(dictionary, serializer);
-                else if (type == typeof(JqGridColumnEditOptions))
-                    obj = DeserializeJqGridColumnEditOptions(dictionary, serializer);
-                else if (type == typeof(JqGridColumnRules))
-                    obj = DeserializeJqGridColumnRules(dictionary, serializer);
-                else if (type == typeof(JqGridColumnFormOptions))
-                    obj = DeserializeJqGridColumnFormOptions(dictionary, serializer);
-                else if (type == typeof(JqGridColumnFormatterOptions))
-                    obj = DeserializeJqGridColumnFormatterOptions(dictionary, serializer);
-                else if (type == typeof(JqGridColumnSearchOptions))
-                    obj = DeserializeJqGridColumnSearchOptions(dictionary, serializer);
-                else if (type == typeof(JqGridSubgridModel))
-                    obj = DeserializeJqGridSubgridModel(dictionary, serializer);
-                else if (type == typeof(JqGridRequestSearchingFilters))
-                    obj = DeserializeJqGridRequestSearchingFilters(dictionary, serializer);
-                else if (type == typeof(JqGridRequestSearchingFilter))
-                    obj = DeserializeJqGridRequestSearchingFilter(dictionary, serializer);
-            }
-
-            return obj;
-        }
-
-        public override IDictionary<string, object> Serialize(object obj, JavaScriptSerializer serializer)
-        {
-            Dictionary<string, object> serializedObj = new Dictionary<string, object>();
-
-            if (obj != null)
-            {
-                if (obj is JqGridOptions)
-                    SerializeJqGridOptions((JqGridOptions)obj, serializer, serializedObj);
-                else if (obj is JqGridColumnModel)
-                    SerializeJqGridColumnModel((JqGridColumnModel)obj, serializer, serializedObj);
-                else if (obj is JqGridJsonReader)
-                    SerializeJqGridJsonReader((JqGridJsonReader)obj, serializer, serializedObj);
-                else if (obj is JqGridParametersNames)
-                    SerializeJqGridParametersNames((JqGridParametersNames)obj, serializer, serializedObj);
-                else if (obj is JqGridGroupingView)
-                    SerializeJqGridGroupingView((JqGridGroupingView)obj, serializer, serializedObj);
-                else if (obj is JqGridColumnEditOptions)
-                    SerializeJqGridColumnEditOptions((JqGridColumnEditOptions)obj, serializer, serializedObj);
-                else if (obj is JqGridColumnRules)
-                    SerializeJqGridColumnRules((JqGridColumnRules)obj, serializer, serializedObj);
-                else if (obj is JqGridColumnFormatterOptions)
-                    SerializeJqGridColumnFormatterOptions((JqGridColumnFormatterOptions)obj, serializer, serializedObj);
-                else if (obj is JqGridColumnFormOptions)
-                    SerializeJqGridColumnFormOptions((JqGridColumnFormOptions)obj, serializer, serializedObj);
-                else if (obj is JqGridColumnSearchOptions)
-                    SerializeJqGridColumnSearchOptions((JqGridColumnSearchOptions)obj, serializer, serializedObj);
-                else if (obj is JqGridSubgridModel)
-                    SerializeJqGridSubgridModel((JqGridSubgridModel)obj, serializer, serializedObj);
-                else if (obj is JqGridResponse)
-                    SerializeJqGridResponse((JqGridResponse)obj, serializer, serializedObj);
-                else if (obj is JqGridRequestSearchingFilters)
-                    SerializeJqGridRequestSearchingFilters((JqGridRequestSearchingFilters)obj, serializer, serializedObj);
-                else if (obj is JqGridRequestSearchingFilter)
-                    SerializeJqGridRequestSearchingFilter((JqGridRequestSearchingFilter)obj, serializer, serializedObj);
-            }
-
-            return serializedObj;
-        }
-
-        public override IEnumerable<Type> SupportedTypes
-        {
-            get { return _supportedTypes; }
-        }
-        #endregion
-
-        #region Methods
-        private static JqGridOptions DeserializeJqGridOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            string id = GetStringFromSerializedObj(serializedObj, "id");
-            if (!String.IsNullOrWhiteSpace(id))
-            {
-                JqGridOptions obj = new JqGridOptions(id);
-                obj.AltClass = GetStringFromSerializedObj(serializedObj, "altclass", JqGridOptionsDefaults.AltClass);
-                obj.AltRows = GetBooleanFromSerializedObj(serializedObj, "altRows", false);
-                obj.AutoEncode = GetBooleanFromSerializedObj(serializedObj, "autoencode", false);
-                obj.AutoWidth = GetBooleanFromSerializedObj(serializedObj, "autowidth", false);
-                obj.Caption = GetStringFromSerializedObj(serializedObj, "caption");
-                obj.CellLayout = GetInt32FromSerializedObj(serializedObj, "cellLayout", JqGridOptionsDefaults.CellLayout);
-                obj.CellEditingEnabled = GetBooleanFromSerializedObj(serializedObj, "cellEdit", false);
-                obj.CellEditingSubmitMode = GetEnumFromSerializedObj(serializedObj, "cellsubmit", JqGridCellEditingSubmitModes.Remote);
-                obj.CellEditingUrl = GetStringFromSerializedObj(serializedObj, "cellurl");
-
-                if (serializedObj.ContainsKey("colModel") && serializedObj["colModel"] is ArrayList)
-                {
-                    foreach (object innerSerializedObj in (ArrayList)serializedObj["colModel"])
-                    {
-                        if (innerSerializedObj is IDictionary<string, object>)
-                        {
-                            JqGridColumnModel columnModel = DeserializeJqGridColumnModel((IDictionary<string, object>)innerSerializedObj, serializer);
-                            if (columnModel != null)
-                                obj.ColumnsModels.Add(columnModel);
-                        }
-                    }
-                }
-
-                if (serializedObj.ContainsKey("colNames") && serializedObj["colNames"] is ArrayList)
-                {
-                    foreach (object innerSerializedObj in (ArrayList)serializedObj["colNames"])
-                        obj.ColumnsNames.Add(innerSerializedObj.ToString());
-                }
-
-                obj.DataString = GetStringFromSerializedObj(serializedObj, "datastr");
-                obj.DataType = GetEnumFromSerializedObj(serializedObj, "datatype", JqGridDataTypes.Xml);
-                obj.DeepEmpty = GetBooleanFromSerializedObj(serializedObj, "deepempty", false);
-                obj.Direction = GetEnumFromSerializedObj(serializedObj, "direction", JqGridLanguageDirections.Ltr);
-                obj.DynamicScrollingMode = JqGridDynamicScrollingModes.Disabled;
-                if (serializedObj.ContainsKey("scroll") && serializedObj["scroll"] != null)
-                {
-                    if (serializedObj["scroll"] is Boolean && (Boolean)serializedObj["scroll"])
-                        obj.DynamicScrollingMode = JqGridDynamicScrollingModes.HoldAllRows;
-                    else if (serializedObj["scroll"] is Int32)
-                        obj.DynamicScrollingMode = JqGridDynamicScrollingModes.HoldVisibleRows;
-                }
-
-                obj.DynamicScrollingTimeout = GetInt32FromSerializedObj(serializedObj, "scrollTimeout", 200);
-                obj.EditingUrl = GetStringFromSerializedObj(serializedObj, "editurl");
-                obj.EmptyRecords = GetStringFromSerializedObj(serializedObj, "emptyrecords", JqGridOptionsDefaults.EmptyRecords);
-                obj.ExpandColumnClick = GetBooleanFromSerializedObj(serializedObj, "ExpandColClick", true);
-                obj.ExpandColumn = GetStringFromSerializedObj(serializedObj, "ExpandColumn");
-                obj.FooterEnabled = GetBooleanFromSerializedObj(serializedObj, "footerrow", false);
-                obj.UserDataOnFooter = GetBooleanFromSerializedObj(serializedObj, "userDataOnFooter", false);
-                obj.GridView = GetBooleanFromSerializedObj(serializedObj, "gridview", false);
-
-                obj.GroupingEnabled = GetBooleanFromSerializedObj(serializedObj, "grouping", false);
-                if (serializedObj.ContainsKey("groupingView") && serializedObj["groupingView"] is IDictionary<string, object>)
-                    obj.GroupingView = DeserializeJqGridGroupingView((IDictionary<string, object>)serializedObj["groupingView"], serializer);
-
-                obj.Height = GetInt32FromSerializedObj(serializedObj, "height");
-                obj.Hidden = GetBooleanFromSerializedObj(serializedObj, "hiddengrid", false);
-                obj.HiddenEnabled  = GetBooleanFromSerializedObj(serializedObj, "hidegrid", true);
-                obj.HoverRows = GetBooleanFromSerializedObj(serializedObj, "hoverrows", true);
-                obj.IgnoreCase = GetBooleanFromSerializedObj(serializedObj, "ignoreCase", false);
-                obj.LoadOnce = GetBooleanFromSerializedObj(serializedObj, "loadonce", false);
-                obj.MethodType = GetEnumFromSerializedObj(serializedObj, "mtype", JqGridMethodTypes.Get);
-                obj.MultiKey = GetEnumFromSerializedObj<JqGridMultiKeys>(serializedObj, "multikey");
-                obj.MultiBoxOnly = GetBooleanFromSerializedObj(serializedObj, "multiboxonly", false);
-                obj.MultiSelect = GetBooleanFromSerializedObj(serializedObj, "multiselect", false);
-                obj.MultiSelectWidth = GetInt32FromSerializedObj(serializedObj, "multiselectWidth", 20);
-                obj.MultiSort = GetBooleanFromSerializedObj(serializedObj, "multiSort", false);
-                
-                if (serializedObj.ContainsKey("pager") && serializedObj["pager"] != null)
-                    obj.Pager = true;
-
-                if (serializedObj.ContainsKey("jsonReader") && serializedObj["jsonReader"] is IDictionary<string, object>)
-                    obj.JsonReader = DeserializeJqGridJsonReader((IDictionary<string, object>)serializedObj["jsonReader"], serializer);
-                else
-                    obj.JsonReader = JqGridResponse.JsonReader;
-
-                if (serializedObj.ContainsKey("prmNames") && serializedObj["prmNames"] is IDictionary<string, object>)
-                    obj.ParametersNames = DeserializeJqGridParametersNames((IDictionary<string, object>)serializedObj["prmNames"], serializer);
-                else
-                    obj.ParametersNames = JqGridRequest.ParameterNames;
-
-                obj.ColumnsRemaping = GetInt32ArrayFromSerializedObj(serializedObj, "remapColumns");
-                obj.RowsList = GetInt32ArrayFromSerializedObj(serializedObj, "rowList");
-                obj.RowsNumber = GetInt32FromSerializedObj(serializedObj, "rowNum", 20);
-                obj.RowsNumbers = GetBooleanFromSerializedObj(serializedObj, "rownumbers", false);
-                obj.RowsNumbersWidth = GetInt32FromSerializedObj(serializedObj, "rownumWidth", 25);
-                obj.ShrinkToFit = GetBooleanFromSerializedObj(serializedObj, "shrinkToFit", true);
-                obj.ScrollOffset = GetInt32FromSerializedObj(serializedObj, "scrollOffset", 18);
-                obj.Sortable = GetBooleanFromSerializedObj(serializedObj, "sortable", false);
-                obj.SortingName = GetStringFromSerializedObj(serializedObj, "sortname");
-                obj.SortingOrder = GetEnumFromSerializedObj(serializedObj, "sortorder", JqGridSortingOrders.Asc);
-                obj.StyleUI = GetEnumFromSerializedObj(serializedObj, "styleUI", JqGridStyleUIOptions.jQueryUI);
-                obj.SubgridEnabled = GetBooleanFromSerializedObj(serializedObj, "subGrid", false);
-
-                if (serializedObj.ContainsKey("subGridModel") && serializedObj["subGridModel"] != null && serializedObj["subGridModel"] is IDictionary<string, object>)
-                    obj.SubgridModel = DeserializeJqGridSubgridModel((IDictionary<string, object>)serializedObj["subGridModel"], serializer);
-
-                obj.SubgridUrl = GetStringFromSerializedObj(serializedObj, "subGridUrl");
-                obj.SubgridColumnWidth = GetInt32FromSerializedObj(serializedObj, "subGridWidth", 20);
-                obj.TopPager = GetBooleanFromSerializedObj(serializedObj, "toppager", false);
-                obj.TreeGridEnabled = GetBooleanFromSerializedObj(serializedObj, "treeGrid", false);
-                obj.TreeGridModel = GetEnumFromSerializedObj(serializedObj, "treeGridModel", JqGridTreeGridModels.Nested);
-                obj.Url = GetStringFromSerializedObj(serializedObj, "url");
-                obj.ViewRecords = GetBooleanFromSerializedObj(serializedObj, "viewrecords", false);
-                obj.Width = GetInt32FromSerializedObj(serializedObj, "width");
-
-                return obj;
-            }
-            else
-                return null;
-        }
-
-        private static void SerializeJqGridOptions(JqGridOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            serializedObj.Add("id", obj.Id);
-
-            if (obj.AltClass != JqGridOptionsDefaults.AltClass)
-                serializedObj.Add("altclass", obj.AltClass);
-
-            if (obj.AltRows)
-                serializedObj.Add("altRows", true);
-
-            if (obj.AutoEncode)
-                serializedObj.Add("autoencode", true);
-
-            if (obj.AutoWidth)
-                serializedObj.Add("autowidth", true);
-
-            if (obj.CellLayout != JqGridOptionsDefaults.CellLayout)
-                serializedObj.Add("cellLayout", obj.CellLayout);
-
-            if (obj.CellEditingEnabled)
-            {
-                serializedObj.Add("cellEdit", true);
-                if (obj.CellEditingSubmitMode != JqGridCellEditingSubmitModes.Remote)
-                    serializedObj.Add("cellsubmit", "clientArray");
-
-                if (!String.IsNullOrWhiteSpace(obj.CellEditingUrl))
-                    serializedObj.Add("cellurl", obj.CellEditingUrl);
-            }
-
-            serializedObj.Add("colModel", obj.ColumnsModels);
-            serializedObj.Add("colNames", obj.ColumnsNames);
-
-            if (!String.IsNullOrEmpty(obj.Caption))
-            {
-                serializedObj.Add("caption", obj.Caption);
-
-                if (!obj.HiddenEnabled)
-                    serializedObj.Add("hidegrid", false);
-                else if (obj.Hidden)
-                    serializedObj.Add("hiddengrid", true);
-            }
-
-            if (obj.UseDataString())
-                serializedObj.Add("datastr", obj.DataString);
-            else
-                serializedObj.Add("url", obj.Url);
-
-            if (obj.DataType != JqGridDataTypes.Xml)
-                serializedObj.Add("datatype", obj.DataType.ToString().ToLower());
-
-            if (obj.DeepEmpty)
-                serializedObj.Add("deepempty", true);
-
-            if (obj.Direction != JqGridLanguageDirections.Ltr)
-                serializedObj.Add("direction", "rtl");
-
-            if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldAllRows)
-                serializedObj.Add("scroll", true);
-            else if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldVisibleRows)
-            {
-                serializedObj.Add("scroll", 10);
-                if (obj.DynamicScrollingTimeout != 200)
-                    serializedObj.Add("scrollTimeout", obj.DynamicScrollingTimeout);
-            }
-
-            if (obj.EmptyRecords != JqGridOptionsDefaults.EmptyRecords)
-                serializedObj.Add("emptyrecords", obj.EmptyRecords);
-
-            if (!String.IsNullOrWhiteSpace(obj.EditingUrl))
-                serializedObj.Add("editurl", obj.EditingUrl);
-
-            if (obj.FooterEnabled)
-            {
-                serializedObj.Add("footerrow", true);
-                if (obj.UserDataOnFooter)
-                    serializedObj.Add("userDataOnFooter", true);
-            }
-
-            if (obj.GridView)
-                serializedObj.Add("gridview", true);
-
-            if (obj.GroupingEnabled)
-            {
-                serializedObj.Add("grouping", true);
-
-                if (obj.GroupingView != null)
-                    serializedObj.Add("groupingView", obj.GroupingView);
-            }
-
-            if (obj.Height.HasValue)
-                serializedObj.Add("height", obj.Height.Value);
-            else
-                serializedObj.Add("height", "100%");
-
-            if (!obj.HoverRows)
-                serializedObj.Add("hoverrows", false);
-
-            if (obj.IgnoreCase)
-                serializedObj.Add("ignoreCase", true);
-
-            if (obj.LoadOnce)
-                serializedObj.Add("loadonce", true);
-
-            if (obj.MethodType != JqGridMethodTypes.Get)
-                serializedObj.Add("mtype", "POST");
-
-            if (obj.MultiKey.HasValue)
-                serializedObj.Add("multikey", String.Format("{0}Key", obj.MultiKey.Value.ToString().ToLower()));
-
-            if (obj.MultiBoxOnly)
-                serializedObj.Add("multiboxonly", true);
-
-            if (obj.MultiSelect)
-                serializedObj.Add("multiselect", true);
-
-            if (obj.MultiSelectWidth != 20)
-                serializedObj.Add("multiselectWidth", obj.MultiSelectWidth);
-
-            if (obj.MultiSort)
-                serializedObj.Add("multiSort", true);
-
-            if (obj.Pager)
-                serializedObj.Add("pager", String.Format("#{0}Pager", obj.Id));
-
-            if (obj.JsonReader != null && !obj.JsonReader.IsDefault())
-                serializedObj.Add("jsonReader", obj.JsonReader);
-
-            if (obj.ParametersNames != null && !obj.ParametersNames.IsDefault())
-                serializedObj.Add("prmNames", obj.ParametersNames);
-
-            serializedObj.Add("remapColumns", obj.ColumnsRemaping);
-
-            if (obj.RowsList != null && obj.RowsList.Count > 0)
-                serializedObj.Add("rowList", obj.RowsList);
-
-            if (obj.RowsNumber != 20)
-                serializedObj.Add("rowNum", obj.RowsNumber);
-
-            if (obj.RowsNumbers)
-                serializedObj.Add("rownumbers", true);
-
-            if (obj.RowsNumbersWidth != 25)
-                serializedObj.Add("rownumWidth", obj.RowsNumbersWidth);
-
-            if (!obj.ShrinkToFit)
-                serializedObj.Add("shrinkToFit", false);
-
-            if (obj.ScrollOffset != 18)
-                serializedObj.Add("scrollOffset", obj.ScrollOffset);
-
-            if (obj.Sortable)
-                serializedObj.Add("sortable", true);
-
-            if (!String.IsNullOrWhiteSpace(obj.SortingName))
-                serializedObj.Add("sortname", obj.SortingName);
-
-            if (obj.SortingOrder != JqGridSortingOrders.Asc)
-                serializedObj.Add("sortorder", "desc");
-
-            if (obj.StyleUI != JqGridStyleUIOptions.jQueryUI)
-                serializedObj.Add("styleUI", obj.StyleUI.ToString());
-
-            if (obj.SubgridEnabled)
-            {
-                serializedObj.Add("subGrid", true);
-                if (obj.SubgridModel != null)
-                    serializedObj.Add("subGridModel", obj.SubgridModel);
-
-                if (!String.IsNullOrWhiteSpace(obj.SubgridUrl))
-                    serializedObj.Add("subGridUrl", obj.SubgridUrl);
-
-                if (obj.SubgridColumnWidth != 20)
-                    serializedObj.Add("subGridWidth", obj.SubgridColumnWidth);
-            }
-
-            if (obj.TopPager)
-                serializedObj.Add("toppager", true);
-
-            if (obj.TreeGridEnabled)
-            {
-                serializedObj.Add("treeGrid", true);
-
-                if (obj.TreeGridModel != JqGridTreeGridModels.Nested)
-                    serializedObj.Add("treeGridModel", "adjacency");
-
-                if (!obj.ExpandColumnClick)
-                    serializedObj.Add("ExpandColClick", false);
-
-                if (!String.IsNullOrWhiteSpace(obj.ExpandColumn))
-                    serializedObj.Add("ExpandColumn", obj.ExpandColumn);
-            }
-
-            if (obj.ViewRecords)
-                serializedObj.Add("viewrecords", true);
-
-            if (obj.Width.HasValue)
-                serializedObj.Add("width", obj.Width.Value);
-        }
-
-        private static JqGridColumnModel DeserializeJqGridColumnModel(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            string name = GetStringFromSerializedObj(serializedObj, "name");
-            if (!String.IsNullOrWhiteSpace(name))
-            {
-                JqGridColumnModel obj = new JqGridColumnModel(name);
-
-                obj.Alignment = GetEnumFromSerializedObj(serializedObj, "align", obj.Alignment);
-                obj.DateFormat = GetStringFromSerializedObj(serializedObj, "datefmt", JqGridOptionsDefaults.DateFormat);
-                obj.Classes = GetStringFromSerializedObj(serializedObj, "classes");
-                obj.Editable = GetBooleanFromSerializedObj(serializedObj, "editable", false);
-                obj.EditType = GetEnumFromSerializedObj(serializedObj, "edittype", JqGridColumnEditTypes.Text);
-
-                if (serializedObj.ContainsKey("editoptions") && serializedObj["editoptions"] != null && serializedObj["editoptions"] is IDictionary<string, object>)
-                    obj.EditOptions = DeserializeJqGridColumnEditOptions((IDictionary<string, object>)serializedObj["editoptions"], serializer);
-
-                if (serializedObj.ContainsKey("editrules") && serializedObj["editrules"] != null && serializedObj["editrules"] is IDictionary<string, object>)
-                    obj.EditRules = DeserializeJqGridColumnRules((IDictionary<string, object>)serializedObj["editrules"], serializer);
-
-                obj.Fixed = GetBooleanFromSerializedObj(serializedObj, "fixed", false);
-                obj.Frozen = GetBooleanFromSerializedObj(serializedObj, "frozen", false);
-                obj.Hidden = GetBooleanFromSerializedObj(serializedObj, "hidden", false);
-                obj.HideInDialog = GetBooleanFromSerializedObj(serializedObj, "hidedlg", false);
-
-                obj.Formatter = GetStringFromSerializedObj(serializedObj, "formatter");
-                if (!String.IsNullOrWhiteSpace(obj.Formatter))
-                    obj.Formatter = '\'' + obj.Formatter + '\'';
-
-                if (serializedObj.ContainsKey("formatoptions") && serializedObj["formatoptions"] != null && serializedObj["formatoptions"] is IDictionary<string, object>)
-                    obj.FormatterOptions = DeserializeJqGridColumnFormatterOptions((IDictionary<string, object>)serializedObj["formatoptions"], serializer);
-                //obj.UnFormatter = GetStringFromSerializedObj(serializedObj, "unformat");
-
-                if (serializedObj.ContainsKey("formoptions") && serializedObj["formoptions"] != null && serializedObj["formoptions"] is IDictionary<string, object>)
-                    obj.FormOptions = DeserializeJqGridColumnFormOptions((IDictionary<string, object>)serializedObj["formoptions"], serializer);
-
-                obj.InitialSortingOrder = GetEnumFromSerializedObj(serializedObj, "firstsortorder", JqGridSortingOrders.Asc);
-                obj.JsonMapping = GetStringFromSerializedObj(serializedObj, "jsonmap");
-                obj.Key = GetBooleanFromSerializedObj(serializedObj, "key", false);
-                obj.Resizable = GetBooleanFromSerializedObj(serializedObj, "resizable", true);
-                obj.SummaryType = GetEnumFromSerializedObj<JqGridColumnSummaryTypes>(serializedObj, "summaryType");
-                if (!obj.SummaryType.HasValue)
-                {
-                    obj.SummaryFunction = GetStringFromSerializedObj(serializedObj, "summaryType");
-                    if (!String.IsNullOrWhiteSpace(obj.SummaryFunction))
-                        obj.SummaryType = JqGridColumnSummaryTypes.Custom;
-                }
-
-                obj.SummaryTemplate = GetStringFromSerializedObj(serializedObj, "summaryTpl", "{0}");
-                obj.Sortable = GetBooleanFromSerializedObj(serializedObj, "sortable", true);
-                obj.SortType = GetEnumFromSerializedObj(serializedObj, "sorttype", JqGridColumnSortTypes.Text);
-                obj.Index = GetStringFromSerializedObj(serializedObj, "index");
-                obj.Searchable = GetBooleanFromSerializedObj(serializedObj, "search", true);
-                obj.SearchType = GetEnumFromSerializedObj(serializedObj, "stype", JqGridColumnSearchTypes.Text);
-
-                if (serializedObj.ContainsKey("searchoptions") && serializedObj["searchoptions"] != null && serializedObj["searchoptions"] is IDictionary<string, object>)
-                    obj.SearchOptions = DeserializeJqGridColumnSearchOptions((IDictionary<string, object>)serializedObj["searchoptions"], serializer);
-
-                if (serializedObj.ContainsKey("searchrules") && serializedObj["searchrules"] != null && serializedObj["searchrules"] is IDictionary<string, object>)
-                    obj.SearchRules = DeserializeJqGridColumnRules((IDictionary<string, object>)serializedObj["searchrules"], serializer);
-
-                obj.Title = GetBooleanFromSerializedObj(serializedObj, "title", true);
-                obj.Width = GetInt32FromSerializedObj(serializedObj, "width", 150);
-                obj.Viewable = GetBooleanFromSerializedObj(serializedObj, "viewable", true);
-                obj.XmlMapping = GetStringFromSerializedObj(serializedObj, "xmlmap");
-
-                return obj;
-            }
-            else
-                return null;
-        }
-
-        private static void SerializeJqGridColumnModel(JqGridColumnModel obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            serializedObj.Add("align", obj.Alignment.ToString().ToLower());
-
-            if (!String.IsNullOrWhiteSpace(obj.Classes))
-                serializedObj.Add("classes", obj.Classes);
-
-            if (obj.DateFormat != JqGridOptionsDefaults.DateFormat)
-                serializedObj.Add("datefmt", obj.DateFormat);
-
-            if (obj.Editable)
-            {
-                serializedObj.Add("editable", true);
-                if (obj.EditType != JqGridColumnEditTypes.Text)
-                    serializedObj.Add("edittype", obj.EditType.ToString().ToLower());
-
-                if (obj.EditOptions != null)
-                    serializedObj.Add("editoptions", obj.EditOptions);
-
-                if (obj.EditRules != null)
-                    serializedObj.Add("editrules", obj.EditRules);
-
-                if (obj.FormOptions != null)
-                    serializedObj.Add("formoptions", obj.FormOptions);
-            }
-
-            if (obj.Fixed)
-                serializedObj.Add("fixed", true);
-
-            if (obj.Frozen)
-                serializedObj.Add("frozen", true);
-
-            if (obj.InitialSortingOrder != JqGridSortingOrders.Asc)
-                serializedObj.Add("firstsortorder", "desc");
-
-            if (!String.IsNullOrWhiteSpace(obj.Formatter) && obj.Formatter[0] == '\'' && obj.Formatter[obj.Formatter.Length - 1] == '\'')
-            {
-                serializedObj.Add("formatter", obj.Formatter.Substring(1, obj.Formatter.Length - 2));
-
-                if (obj.FormatterOptions != null)
-                    serializedObj.Add("formatoptions", obj.FormatterOptions);
-            }
-
-            //if (!String.IsNullOrWhiteSpace(obj.UnFormatter))
-            //    serializedObj.Add("unformat", obj.UnFormatter);
-
-            if (obj.Hidden)
-                serializedObj.Add("hidden", true);
-
-            if (obj.HideInDialog) 
-                serializedObj.Add("hidedlg", true);
-
-            if (!String.IsNullOrWhiteSpace(obj.JsonMapping))
-                serializedObj.Add("jsonmap", obj.JsonMapping);
-
-            if (obj.Key)
-                serializedObj.Add("key", true);
-
-            if (!obj.Resizable)
-                serializedObj.Add("resizable", false);
-
-            if (obj.SummaryType.HasValue)
-            {
-                if (obj.SummaryType.Value != JqGridColumnSummaryTypes.Custom)
-                    serializedObj.Add("summaryType", obj.SummaryType.Value.ToString().ToLower());
-                else
-                    serializedObj.Add("summaryType", obj.SummaryFunction);
-            }
-
-            if (obj.SummaryTemplate != "{0}")
-                serializedObj.Add("summaryTpl", obj.SummaryTemplate);
-
-            if (!obj.Sortable)
-                serializedObj.Add("sortable", false);
-
-            if ((obj.SortType != JqGridColumnSortTypes.Text) && (obj.SortType != JqGridColumnSortTypes.Function))
-                serializedObj.Add("sorttype", obj.SortType.ToString().ToLower());
-
-            serializedObj.Add("index", obj.Index);
-
-            if (obj.Searchable)
-            {
-                if (obj.SearchType != JqGridColumnSearchTypes.Text)
-                    serializedObj.Add("stype", obj.SearchType.ToString().ToLower());
-                    
-                if (obj.SearchOptions != null)
-                    serializedObj.Add("searchoptions", obj.SearchOptions);
-
-                if (obj.SearchRules != null)
-                    serializedObj.Add("searchrules", obj.SearchRules);
-            }
-            else
-                serializedObj.Add("search", false);
-
-            serializedObj.Add("name", obj.Name);
-
-            if (!obj.Title)
-                serializedObj.Add("title", false);
-
-            if (obj.Width != 150)
-                serializedObj.Add("width", obj.Width);
-
-            if (!obj.Viewable)
-                serializedObj.Add("viewable", false);
-
-            if (!String.IsNullOrWhiteSpace(obj.XmlMapping))
-                serializedObj.Add("xmlmap", obj.XmlMapping);
-        }
-
-        private static JqGridColumnEditOptions DeserializeJqGridColumnEditOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridColumnEditOptions obj = new JqGridColumnEditOptions();
-
-            obj.CustomElementFunction = GetStringFromSerializedObj(serializedObj, "custom_element");
-            serializedObj.Remove("custom_element");
-            obj.CustomValueFunction = GetStringFromSerializedObj(serializedObj, "custom_value");
-            serializedObj.Remove("custom_value");
-            obj.DataUrl = GetStringFromSerializedObj(serializedObj, "dataUrl");
-            serializedObj.Remove("dataUrl");
-            obj.DefaultValue = GetStringFromSerializedObj(serializedObj, "defaultValue");
-            serializedObj.Remove("defaultValue");
-
-            if (serializedObj.ContainsKey("value") && serializedObj["value"] != null && serializedObj["value"] is IDictionary<string, object>)
-                obj.ValueDictionary = ((IDictionary<string, object>)serializedObj["value"]).ToDictionary(k => k.Key, v => v.Value.ToString());
-            else
-                obj.Value = GetStringFromSerializedObj(serializedObj, "value");
-            serializedObj.Remove("value");
-
-            obj.NullIfEmpty = GetBooleanFromSerializedObj(serializedObj, "NullIfEmpty", false);
-            serializedObj.Remove("NullIfEmpty");
-            obj.HtmlAttributes = serializedObj;
-
-            return obj;
-        }
-
-        private static void SerializeJqGridColumnEditOptions(JqGridColumnEditOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            if (!String.IsNullOrWhiteSpace(obj.CustomElementFunction))
-                serializedObj.Add("custom_element", obj.CustomElementFunction);
-
-            if (!String.IsNullOrWhiteSpace(obj.CustomValueFunction))
-                serializedObj.Add("custom_value", obj.CustomValueFunction);
-
-            SerializeJqGridColumnElementOptions(obj, serializer, serializedObj);
-
-            if (obj.NullIfEmpty)
-                serializedObj.Add("NullIfEmpty", true);
-
-            if (obj.HtmlAttributes != null)
-                foreach(KeyValuePair<string, object> htmlAttribute in obj.HtmlAttributes)
-                    serializedObj.Add(htmlAttribute.Key, htmlAttribute.Value);
-        }
-
-        private static JqGridJsonReader DeserializeJqGridJsonReader(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridJsonReader obj = new JqGridJsonReader();
-
-            obj.PageIndex = GetStringFromSerializedObj(serializedObj, "page", JqGridOptionsDefaults.ResponsePageIndex);
-            obj.RecordId = GetStringFromSerializedObj(serializedObj, "id", JqGridOptionsDefaults.ResponseRecordId);
-            obj.Records = GetStringFromSerializedObj(serializedObj, "root", JqGridOptionsDefaults.ResponseRecords);
-            obj.RecordValues = GetStringFromSerializedObj(serializedObj, "cell", JqGridOptionsDefaults.ResponseRecordValues);
-            obj.RepeatItems = GetBooleanFromSerializedObj(serializedObj, "repeatitems", true);
-            obj.TotalPagesCount = GetStringFromSerializedObj(serializedObj, "total", JqGridOptionsDefaults.ResponseTotalPagesCount);
-            obj.TotalRecordsCount = GetStringFromSerializedObj(serializedObj, "records", JqGridOptionsDefaults.ResponseTotalRecordsCount);
-            obj.UserData = GetStringFromSerializedObj(serializedObj, "userdata", JqGridOptionsDefaults.ResponseUserData);
-
-            if (serializedObj.ContainsKey("subgrid") && serializedObj["subgrid"] is IDictionary<string, object>)
-            {
-                IDictionary<string, object> serializedSubgrid = (IDictionary<string, object>)serializedObj["subgrid"];
-                obj.SubgridReader.Records = GetStringFromSerializedObj(serializedSubgrid, "root", JqGridOptionsDefaults.ResponseRecords);
-                obj.SubgridReader.RecordValues = GetStringFromSerializedObj(serializedSubgrid, "cell", JqGridOptionsDefaults.ResponseRecordValues);
-                obj.SubgridReader.RepeatItems = GetBooleanFromSerializedObj(serializedSubgrid, "repeatitems", true);
-            }
-
-            return obj;
-        }
-
-        private static void SerializeJqGridJsonReader(JqGridJsonReader obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            if (obj.Records != JqGridOptionsDefaults.ResponseRecords)
-                serializedObj.Add("root", obj.Records);
-
-            if (obj.PageIndex != JqGridOptionsDefaults.ResponsePageIndex)
-                serializedObj.Add("page", obj.PageIndex);
-
-            if (obj.TotalPagesCount != JqGridOptionsDefaults.ResponseTotalPagesCount)
-                serializedObj.Add("total", obj.TotalPagesCount);
-
-            if (obj.TotalRecordsCount != JqGridOptionsDefaults.ResponseTotalRecordsCount)
-                serializedObj.Add("records", obj.TotalRecordsCount);
-
-            if (!obj.RepeatItems)
-                serializedObj.Add("repeatitems", false);
-
-            if (obj.RecordValues != JqGridOptionsDefaults.ResponseRecordValues)
-                serializedObj.Add("cell", obj.RecordValues);
-
-            if (obj.RecordId != JqGridOptionsDefaults.ResponseRecordId)
-                serializedObj.Add("id", obj.RecordId);
-
-            if (obj.UserData != JqGridOptionsDefaults.ResponseUserData)
-                serializedObj.Add("userdata", obj.UserData);
-
-            if (!obj.SubgridReader.IsDefault())
-            {
-                Dictionary<string, object> serializedSubgrid = new Dictionary<string, object>();
-
-                if (obj.SubgridReader.Records != JqGridOptionsDefaults.ResponseRecords)
-                    serializedSubgrid.Add("root", obj.SubgridReader.Records);
-
-                if (!obj.SubgridReader.RepeatItems)
-                    serializedSubgrid.Add("repeatitems", false);
-
-                if (obj.SubgridReader.RecordValues != JqGridOptionsDefaults.ResponseRecordValues)
-                    serializedSubgrid.Add("cell", obj.SubgridReader.RecordValues);
-
-                serializedObj.Add("subgrid", serializedSubgrid);
-            }
-        }
-
-        private static JqGridParametersNames DeserializeJqGridParametersNames(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridParametersNames obj = new JqGridParametersNames();
-
-            obj.PageIndex = GetStringFromSerializedObj(serializedObj, "page", JqGridOptionsDefaults.RequestPageIndex);
-            obj.RecordsCount = GetStringFromSerializedObj(serializedObj, "rows", JqGridOptionsDefaults.RequestRecordsCount);
-            obj.SortingName = GetStringFromSerializedObj(serializedObj, "sort", JqGridOptionsDefaults.RequestSortingName);
-            obj.SortingOrder = GetStringFromSerializedObj(serializedObj, "order", JqGridOptionsDefaults.RequestSortingOrder);
-            obj.Searching = GetStringFromSerializedObj(serializedObj, "search", JqGridOptionsDefaults.RequestSearching);
-            obj.Id = GetStringFromSerializedObj(serializedObj, "id", JqGridOptionsDefaults.RequestId);
-            obj.Operator = GetStringFromSerializedObj(serializedObj, "oper", JqGridOptionsDefaults.RequestOperator);
-            obj.EditOperator = GetStringFromSerializedObj(serializedObj, "editoper", JqGridOptionsDefaults.RequestEditOperator);
-            obj.AddOperator = GetStringFromSerializedObj(serializedObj, "addoper", JqGridOptionsDefaults.RequestAddOperator);
-            obj.DeleteOperator = GetStringFromSerializedObj(serializedObj, "deloper", JqGridOptionsDefaults.RequestDeleteOperator);
-            obj.SubgridId = GetStringFromSerializedObj(serializedObj, "subgridid", JqGridOptionsDefaults.RequestSubgridId);
-            obj.PagesCount = GetStringFromSerializedObj(serializedObj, "npage");
-            obj.TotalRows = GetStringFromSerializedObj(serializedObj, "totalrows", JqGridOptionsDefaults.RequestTotalRows);
-
-            return obj;
-        }
-
-        private static void SerializeJqGridParametersNames(JqGridParametersNames obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            if (obj.PageIndex != JqGridOptionsDefaults.RequestPageIndex)
-                serializedObj.Add("page", obj.PageIndex);
-
-            if (obj.RecordsCount != JqGridOptionsDefaults.RequestRecordsCount)
-                serializedObj.Add("rows", obj.RecordsCount);
-
-            if (obj.SortingName != JqGridOptionsDefaults.RequestSortingName)
-                serializedObj.Add("sort", obj.SortingName);
-
-            if (obj.SortingOrder != JqGridOptionsDefaults.RequestSortingOrder)
-                serializedObj.Add("order", obj.SortingOrder);
-
-            if (obj.Searching != JqGridOptionsDefaults.RequestSearching)
-                serializedObj.Add("search", obj.Searching);
-
-            if (obj.Id != JqGridOptionsDefaults.RequestId)
-                serializedObj.Add("id", obj.Id);
-
-            if (obj.Operator != JqGridOptionsDefaults.RequestOperator)
-                serializedObj.Add("oper", obj.Operator);
-
-            if (obj.EditOperator != JqGridOptionsDefaults.RequestEditOperator)
-                serializedObj.Add("editoper", obj.EditOperator);
-
-            if (obj.AddOperator != JqGridOptionsDefaults.RequestAddOperator)
-                serializedObj.Add("addoper", obj.AddOperator);
-
-            if (obj.DeleteOperator != JqGridOptionsDefaults.RequestDeleteOperator)
-                serializedObj.Add("deloper", obj.DeleteOperator);
-
-            if (obj.SubgridId != JqGridOptionsDefaults.RequestSubgridId)
-                serializedObj.Add("subgridid", obj.SubgridId);
-
-            if (!String.IsNullOrWhiteSpace(obj.PagesCount))
-                serializedObj.Add("npage", obj.PagesCount);
-
-            if (obj.TotalRows != JqGridOptionsDefaults.RequestTotalRows)
-                serializedObj.Add("totalrows", obj.TotalRows);
-        }
-
-        private static JqGridGroupingView DeserializeJqGridGroupingView(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridGroupingView obj = new JqGridGroupingView();
-
-            if (serializedObj.ContainsKey("groupField") && serializedObj["groupField"] is ArrayList)
-                obj.Fields = (string[])((ArrayList)serializedObj["groupField"]).ToArray(typeof(String));
-
-            if (serializedObj.ContainsKey("groupOrder") && serializedObj["groupOrder"] is ArrayList)
-                obj.Orders = (JqGridSortingOrders[])((ArrayList)serializedObj["groupOrder"]).ToArray(typeof(JqGridSortingOrders));
-
-            if (serializedObj.ContainsKey("groupText") && serializedObj["groupText"] is ArrayList)
-                obj.Texts = (string[])((ArrayList)serializedObj["groupText"]).ToArray(typeof(String));
-
-            if (serializedObj.ContainsKey("groupSummary") && serializedObj["groupSummary"] is ArrayList)
-                obj.Summary = (bool[])((ArrayList)serializedObj["groupSummary"]).ToArray(typeof(Boolean));
-
-            if (serializedObj.ContainsKey("groupColumnShow") && serializedObj["groupColumnShow"] is ArrayList)
-                obj.ColumnShow = (bool[])((ArrayList)serializedObj["groupColumnShow"]).ToArray(typeof(Boolean));
-
-            obj.SummaryOnHide = GetBooleanFromSerializedObj(serializedObj, "showSummaryOnHide", false);
-            obj.DataSorted = GetBooleanFromSerializedObj(serializedObj, "groupDataSorted", false);
-            obj.Collapse = GetBooleanFromSerializedObj(serializedObj, "groupCollapse", false);
-            obj.PlusIcon = GetStringFromSerializedObj(serializedObj, "plusicon", JqGridOptionsDefaults.GroupingPlusIcon);
-            obj.MinusIcon = GetStringFromSerializedObj(serializedObj, "minusicon", JqGridOptionsDefaults.GroupingMinusIcon);
-
-            return obj;
-        }
-
-        private static void SerializeJqGridGroupingView(JqGridGroupingView obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            if (obj.Fields != null && obj.Fields.Length > 0)
-                serializedObj.Add("groupField", obj.Fields);
-
-            if (obj.Orders != null && obj.Orders.Length > 0 && obj.Orders.Contains(JqGridSortingOrders.Desc))
-                serializedObj.Add("groupOrder", obj.Orders);
-
-            if (obj.Texts != null && obj.Texts.Length > 0)
-                serializedObj.Add("groupText", obj.Texts);
-
-            if (obj.Summary != null && obj.Summary.Length > 0 && obj.Summary.Contains(true))
-                serializedObj.Add("groupSummary", obj.Summary);
-
-            if (obj.ColumnShow != null && obj.ColumnShow.Length > 0 && obj.ColumnShow.Contains(false))
-                serializedObj.Add("groupColumnShow", obj.ColumnShow);
-
-            if (obj.SummaryOnHide)
-                serializedObj.Add("showSummaryOnHide", true);
-
-            if (obj.DataSorted)
-                serializedObj.Add("groupDataSorted", true);
-
-            if (obj.Collapse)
-                serializedObj.Add("groupCollapse", true);
-
-            if (obj.PlusIcon != JqGridOptionsDefaults.GroupingPlusIcon)
-                serializedObj.Add("plusicon", obj.PlusIcon);
-
-            if (obj.MinusIcon != JqGridOptionsDefaults.GroupingMinusIcon)
-                serializedObj.Add("minusicon", obj.MinusIcon);
-        }
-
-        private static JqGridColumnRules DeserializeJqGridColumnRules(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridColumnRules obj = new JqGridColumnRules();
-
-            obj.Custom = GetBooleanFromSerializedObj(serializedObj, "custom", false);
-            obj.CustomFunction = GetStringFromSerializedObj(serializedObj, "custom_func");
-            obj.Date = GetBooleanFromSerializedObj(serializedObj, "date", false);
-            obj.EditHidden = GetBooleanFromSerializedObj(serializedObj, "edithidden", false);
-            obj.Email = GetBooleanFromSerializedObj(serializedObj, "email", false);
-            obj.Integer = GetBooleanFromSerializedObj(serializedObj, "integer", false);
-            obj.MaxValue = GetDoubleFromSerializedObj(serializedObj, "maxValue");
-            obj.MinValue = GetDoubleFromSerializedObj(serializedObj, "minValue");
-            obj.Number = GetBooleanFromSerializedObj(serializedObj, "number", false);
-            obj.Required = GetBooleanFromSerializedObj(serializedObj, "required", false);
-            obj.Time = GetBooleanFromSerializedObj(serializedObj, "time", false);
-            obj.Url = GetBooleanFromSerializedObj(serializedObj, "url", false);
-
-            return obj;
-        }
-
-        private static void SerializeJqGridColumnRules(JqGridColumnRules obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            if (obj.Custom)
-                serializedObj.Add("custom", true);
-
-            if (!String.IsNullOrWhiteSpace(obj.CustomFunction))
-                serializedObj.Add("custom_func", obj.CustomFunction);
-
-            if (obj.Date)
-                serializedObj.Add("date", true);
-
-            if (obj.EditHidden)
-                serializedObj.Add("edithidden", true);
-
-            if (obj.Email)
-                serializedObj.Add("email", true);
-
-            if (obj.Integer)
-                serializedObj.Add("integer", true);
-
-            if (obj.MaxValue.HasValue)
-                serializedObj.Add("maxValue", obj.MaxValue.Value);
-
-            if (obj.MinValue.HasValue)
-                serializedObj.Add("minValue", obj.MinValue.Value);
-
-            if (obj.Number)
-                serializedObj.Add("number", true);
-
-            if (obj.Required)
-                serializedObj.Add("required", true);
-
-            if (obj.Time)
-                serializedObj.Add("time", true);
-
-            if (obj.Url)
-                serializedObj.Add("url", true);
-        }
-
-        private static JqGridColumnFormOptions DeserializeJqGridColumnFormOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridColumnFormOptions obj = new JqGridColumnFormOptions();
-
-            obj.ColumnPosition = GetInt32FromSerializedObj(serializedObj, "colpos");
-            obj.ElementPrefix = GetStringFromSerializedObj(serializedObj, "elmprefix");
-            obj.ElementSuffix = GetStringFromSerializedObj(serializedObj, "elmsuffix");
-            obj.Label = GetStringFromSerializedObj(serializedObj, "label");
-            obj.RowPosition = GetInt32FromSerializedObj(serializedObj, "rowpos");
-            
-            return obj;
-        }
-
-        private static void SerializeJqGridColumnFormOptions(JqGridColumnFormOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            if (obj.ColumnPosition.HasValue)
-                serializedObj.Add("colpos", obj.ColumnPosition.Value);
-            
-            if (!String.IsNullOrWhiteSpace(obj.ElementPrefix))
-                serializedObj.Add("elmprefix", obj.ElementPrefix);
-
-            if (!String.IsNullOrWhiteSpace(obj.ElementSuffix))
-                serializedObj.Add("elmsuffix", obj.ElementSuffix);
-
-            if (!String.IsNullOrWhiteSpace(obj.Label))
-                serializedObj.Add("label", obj.Label);
-
-            if (obj.RowPosition.HasValue)
-                serializedObj.Add("rowpos", obj.RowPosition.Value);
-        }
-
-        private static JqGridColumnFormatterOptions DeserializeJqGridColumnFormatterOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridColumnFormatterOptions obj = new JqGridColumnFormatterOptions();
-
-            obj.AddParam = GetStringFromSerializedObj(serializedObj, "addParam", String.Empty);
-            obj.BaseLinkUrl = GetStringFromSerializedObj(serializedObj, "baseLinkUrl", String.Empty);
-            obj.DecimalPlaces = GetInt32FromSerializedObj(serializedObj, "decimalPlaces", 0);
-            obj.DecimalSeparator = GetStringFromSerializedObj(serializedObj, "decimalSeparator", String.Empty);
-            obj.DefaultValue = GetStringFromSerializedObj(serializedObj, "defaultValue", String.Empty);
-            obj.Disabled = GetBooleanFromSerializedObj(serializedObj, "disabled", true);
-            obj.IdName = GetStringFromSerializedObj(serializedObj, "idName", String.Empty);
-            obj.OutputFormat = GetStringFromSerializedObj(serializedObj, "srcformat", String.Empty);
-            obj.Prefix = GetStringFromSerializedObj(serializedObj, "prefix", String.Empty);
-            obj.ShowAction = GetStringFromSerializedObj(serializedObj, "showAction", String.Empty);
-            obj.SourceFormat = GetStringFromSerializedObj(serializedObj, "newformat", String.Empty);
-            obj.Suffix = GetStringFromSerializedObj(serializedObj, "suffix", String.Empty);
-            obj.Target = GetStringFromSerializedObj(serializedObj, "target", String.Empty);
-            obj.ThousandsSeparator = GetStringFromSerializedObj(serializedObj, "thousandsSeparator", String.Empty);
-
-            return obj;
-        }
-
-        private static void SerializeJqGridColumnFormatterOptions(JqGridColumnFormatterOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            serializedObj.Add("addParam", obj.AddParam);
-            serializedObj.Add("baseLinkUrl", obj.BaseLinkUrl);
-            serializedObj.Add("decimalPlaces", obj.DecimalPlaces);
-            serializedObj.Add("decimalSeparator", obj.DecimalSeparator);
-            serializedObj.Add("defaultValue", obj.DefaultValue);
-            serializedObj.Add("disabled", obj.Disabled);
-            serializedObj.Add("idName", obj.IdName);
-            serializedObj.Add("srcformat", obj.OutputFormat);
-            serializedObj.Add("prefix", obj.Prefix);
-            serializedObj.Add("showAction", obj.ShowAction);
-            serializedObj.Add("newformat", obj.SourceFormat);
-            serializedObj.Add("suffix", obj.Suffix);
-            serializedObj.Add("target", obj.Target);
-            serializedObj.Add("thousandsSeparator", obj.ThousandsSeparator);
-        }
-
-        private static void SerializeJqGridColumnElementOptions(JqGridColumnElementOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            if (!String.IsNullOrWhiteSpace(obj.DataUrl))
-                serializedObj.Add("dataUrl", obj.DataUrl);
-
-            if (!String.IsNullOrWhiteSpace(obj.DefaultValue))
-                serializedObj.Add("defaultValue", obj.DefaultValue);
-
-            if (!String.IsNullOrWhiteSpace(obj.Value))
-                serializedObj.Add("value", obj.Value);
-            else if (obj.ValueDictionary != null)
-                serializedObj.Add("value", obj.ValueDictionary);
-        }
-
-        private static JqGridColumnSearchOptions DeserializeJqGridColumnSearchOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridColumnSearchOptions obj = new JqGridColumnSearchOptions();
-
-            obj.ClearSearch = GetBooleanFromSerializedObj(serializedObj, "clearSearch", true);
-            obj.DataUrl = GetStringFromSerializedObj(serializedObj, "dataUrl");
-            obj.DefaultValue = GetStringFromSerializedObj(serializedObj, "defaultValue");
-
-            if (serializedObj.ContainsKey("value") && serializedObj["value"] != null && serializedObj["value"] is IDictionary<string, object>)
-                obj.ValueDictionary = ((IDictionary<string, object>)serializedObj["value"]).ToDictionary(k => k.Key, v => v.Value.ToString());
-            else
-                obj.Value = GetStringFromSerializedObj(serializedObj, "value");
-
-            if (serializedObj.ContainsKey("attr") && serializedObj["attr"] != null && serializedObj["attr"] is IDictionary<string, object>)
-                obj.HtmlAttributes = (IDictionary<string, object>)serializedObj["attr"];
-
-            obj.SearchHidden = GetBooleanFromSerializedObj(serializedObj, "searchhidden", false);
-
-            if (serializedObj.ContainsKey("sopt") && serializedObj["sopt"] is ArrayList)
-            {
-                JqGridSearchOperators? searchOperators = null;
-                foreach (object innerSerializedObj in (ArrayList)serializedObj["sopt"])
-                {
-                    JqGridSearchOperators searchOperator = JqGridSearchOperators.Eq;
-                    if (Enum.TryParse(innerSerializedObj.ToString(), true, out searchOperator))
-                    {
-                        if (searchOperators.HasValue)
-                            searchOperators = searchOperators | searchOperator;
-                        else
-                            searchOperators = searchOperator;
-                    }
-                }
-
-                if (searchOperators.HasValue)
-                    obj.SearchOperators = searchOperators.Value;
-            }
-            
-            return obj;
-        }
-
-        private static void SerializeJqGridColumnSearchOptions(JqGridColumnSearchOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            SerializeJqGridColumnElementOptions(obj, serializer, serializedObj);
-
-            if (obj.HtmlAttributes != null && obj.HtmlAttributes.Count > 0)
-                serializedObj.Add("attr", obj.HtmlAttributes);
-
-            if (!obj.ClearSearch)
-                serializedObj.Add("clearSearch", false);
-
-            if (obj.SearchHidden)
-                serializedObj.Add("searchhidden", true);
-
-            if (obj.SearchOperators != (JqGridSearchOperators)32768)
-            {
-                List<string> searchOperators = new List<string>();
-                foreach (JqGridSearchOperators searchOperator in Enum.GetValues(typeof(JqGridSearchOperators)))
-                {
-                    if (searchOperator != JqGridSearchOperators.EqualOrNotEqual && searchOperator != JqGridSearchOperators.NoTextOperators && searchOperator != JqGridSearchOperators.TextOperators && (obj.SearchOperators & searchOperator) == searchOperator)
-                        searchOperators.Add(Enum.GetName(typeof(JqGridSearchOperators), searchOperator).ToLower());
-                }
-                serializedObj.Add("sopt", searchOperators);
-            }
-        }
-
-        private static JqGridSubgridModel DeserializeJqGridSubgridModel(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridSubgridModel obj = new JqGridSubgridModel();
-
-            if (serializedObj.ContainsKey("name") && serializedObj["name"] is ArrayList)
-            {
-                foreach (object innerSerializedObj in (ArrayList)serializedObj["name"])
-                    obj.ColumnsNames.Add(innerSerializedObj.ToString());
-            }
-
-            if (serializedObj.ContainsKey("align") && serializedObj["align"] is ArrayList)
-            {
-                foreach (object innerSerializedObj in (ArrayList)serializedObj["align"])
-                {
-                    JqGridAlignments alignment = JqGridAlignments.Left;
-                    Enum.TryParse(innerSerializedObj.ToString(), true, out alignment);
-                    obj.ColumnsAlignments.Add(alignment);
-                }
-            }
-
-            if (serializedObj.ContainsKey("width") && serializedObj["width"] is ArrayList)
-            {
-                foreach (object innerSerializedObj in (ArrayList)serializedObj["width"])
-                {
-                    if (innerSerializedObj is Int32)
-                        obj.ColumnsWidths.Add((int)innerSerializedObj);
-                }
-            }
-
-            return obj;
-        }
-
-        private static void SerializeJqGridSubgridModel(JqGridSubgridModel obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            serializedObj.Add("name", obj.ColumnsNames);
-
-            List<string> alignments = new List<string>();
-            foreach (JqGridAlignments alignment in obj.ColumnsAlignments)
-                alignments.Add(alignment.ToString().ToLower());
-            serializedObj.Add("align", alignments);
-
-            serializedObj.Add("width", obj.ColumnsWidths);
-        }
-
-        private static void SerializeJqGridResponse(JqGridResponse obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            JqGridJsonReader jsonReader = (obj.Reader == null) ? JqGridResponse.JsonReader : obj.Reader;
-
-            if (!obj.IsSubgridResponse)
-            {
-                serializedObj.Add(jsonReader.PageIndex, obj.PageIndex + 1);
-                serializedObj.Add(jsonReader.TotalRecordsCount, obj.TotalRecordsCount);
-                serializedObj.Add(jsonReader.TotalPagesCount, obj.TotalPagesCount);
-
-                if (obj.UserData != null)
-                    serializedObj.Add(jsonReader.UserData, obj.UserData);
-            }
-
-            serializedObj.Add(obj.IsSubgridResponse ? jsonReader.SubgridReader.Records : jsonReader.Records, SerializeJqGridRecords(obj.Records, obj.IsSubgridResponse, jsonReader));
-        }
-
-        private static List<object> SerializeJqGridRecords(List<JqGridRecord> objs, bool isSubgridResponse, JqGridJsonReader jsonReader)
-        {
-            int recordIdIndex = 0;
-            bool isRecordIndexInt = Int32.TryParse(jsonReader.RecordId, out recordIdIndex);
-            bool isRecordValuesEmpty = String.IsNullOrWhiteSpace(jsonReader.RecordValues);
-            bool repeatItems = isSubgridResponse ? jsonReader.SubgridReader.RepeatItems : jsonReader.RepeatItems;
-
-            if (!isSubgridResponse)
-            {
-                if (repeatItems && isRecordValuesEmpty && !isRecordIndexInt)
-                    throw new InvalidOperationException("JqGridJsonReader.RecordId must be a number when JqGridJsonReader.RepeatItems is set to true and JqGridJsonReader.RecordValues is set to empty string.");
-
-                if (repeatItems && !isRecordValuesEmpty && isRecordIndexInt)
-                    throw new InvalidOperationException("JqGridJsonReader.RecordValues can't be an empty string when JqGridJsonReader.RepeatItems is set to true and JqGridJsonReader.RecordId is a number.");
-            }
-
-            List<object> serializedObjs = new List<object>();
-
-            foreach (JqGridRecord obj in objs)
-            {
-                JqGridAdjacencyTreeRecord adjacencyTreeRecord = obj as JqGridAdjacencyTreeRecord;
-                JqGridNestedSetTreeRecord nestedSetTreeRecord = obj as JqGridNestedSetTreeRecord;
-                if (repeatItems)
-                {
-                    List<object> values = obj.Values;
-
-                    if (!isSubgridResponse)
-                    {
-                        if (adjacencyTreeRecord != null)
-                        {
-                            values.Add(adjacencyTreeRecord.Level);
-                            values.Add(adjacencyTreeRecord.ParentId);
-                            values.Add(adjacencyTreeRecord.Leaf);
-                            values.Add(adjacencyTreeRecord.Expanded);
-                        }
-                        else if (nestedSetTreeRecord != null)
-                        {
-                            values.Add(nestedSetTreeRecord.Level);
-                            values.Add(nestedSetTreeRecord.LeftField);
-                            values.Add(nestedSetTreeRecord.RightField);
-                            values.Add(nestedSetTreeRecord.Leaf);
-                            values.Add(nestedSetTreeRecord.Expanded);
-                        }
-                    }
-
-                    if (isRecordValuesEmpty)
-                    {
-                        if (!isSubgridResponse && Convert.ToString(values[recordIdIndex]) != obj.Id)
-                            values.Insert(recordIdIndex, obj.Id);
-                        serializedObjs.Add(values);
-                    }
-                    else
-                    {
-                        Dictionary<string, object> serializedObj = new Dictionary<string, object>();
-                        serializedObj.Add(isSubgridResponse ? jsonReader.SubgridReader.RecordValues : jsonReader.RecordValues, values);
-                        if (!isSubgridResponse)
-                            serializedObj.Add(jsonReader.RecordId, obj.Id);
-                        serializedObjs.Add(serializedObj);
-                    }
-                }
-                else
-                {
-                    if (obj.Value == null)
-                        throw new InvalidOperationException("JqGridRecord.Value can't be null when JqGridJsonReader.RepeatItems is set to false.");
-
-                    Dictionary<string, object> serializedObj = obj.GetValuesAsDictionary();
-
-                    if (!isSubgridResponse)
-                    {
-                        if (adjacencyTreeRecord != null)
-                        {
-                            serializedObj.Add("level", adjacencyTreeRecord.Level);
-                            serializedObj.Add("parent", adjacencyTreeRecord.ParentId);
-                            serializedObj.Add("isLeaf", adjacencyTreeRecord.Leaf);
-                            serializedObj.Add("expanded", adjacencyTreeRecord.Expanded);
-                        }
-                        else if (nestedSetTreeRecord != null)
-                        {
-                            serializedObj.Add("level", nestedSetTreeRecord.Level);
-                            serializedObj.Add("lft", nestedSetTreeRecord.LeftField);
-                            serializedObj.Add("rgt", nestedSetTreeRecord.RightField);
-                            serializedObj.Add("isLeaf", nestedSetTreeRecord.Leaf);
-                            serializedObj.Add("expanded", nestedSetTreeRecord.Expanded);
-                        }
-                    }
-
-                    if (!isSubgridResponse && !isRecordIndexInt && !serializedObj.ContainsKey(jsonReader.RecordId))
-                        serializedObj.Add(jsonReader.RecordId, obj.Id);
-
-                    serializedObjs.Add(serializedObj);
-                }
-            }
-
-            return serializedObjs;
-        }
-
-        private static JqGridRequestSearchingFilters DeserializeJqGridRequestSearchingFilters(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridRequestSearchingFilters obj = new JqGridRequestSearchingFilters();
-
-            obj.GroupingOperator = GetEnumFromSerializedObj<JqGridSearchGroupingOperators>(serializedObj, "groupOp", JqGridSearchGroupingOperators.And);
-            if (serializedObj.ContainsKey("rules") && serializedObj["rules"] is ArrayList)
-            {
-                foreach (object innerSerializedObj in (ArrayList)serializedObj["rules"])
-                {
-                    if (innerSerializedObj is IDictionary<string, object>)
-                    {
-                        JqGridRequestSearchingFilter searchingFilter = DeserializeJqGridRequestSearchingFilter((IDictionary<string, object>)innerSerializedObj, serializer);
-                        obj.Filters.Add(searchingFilter);
-                    }
-                }
-            }
-            if (serializedObj.ContainsKey("groups") && serializedObj["groups"] is ArrayList)
-            {
-                foreach (object innerSerializedObj in (ArrayList)serializedObj["groups"])
-                {
-                    if (innerSerializedObj is IDictionary<string, object>)
-                    {
-                        JqGridRequestSearchingFilters searchingFilters = DeserializeJqGridRequestSearchingFilters((IDictionary<string, object>)innerSerializedObj, serializer);
-                        obj.Groups.Add(searchingFilters);
-                    }
-                }
-            }
-
-            return obj;
-        }
-
-        private static void SerializeJqGridRequestSearchingFilters(JqGridRequestSearchingFilters obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            serializedObj.Add("groupOp", obj.GroupingOperator.ToString().ToUpper());
-
-            if (obj.Filters != null && obj.Filters.Count > 0)
-                serializedObj.Add("rules", obj.Filters);
-
-            if (obj.Groups != null && obj.Groups.Count > 0)
-                serializedObj.Add("groups", obj.Groups);
-        }
-
-        private static JqGridRequestSearchingFilter DeserializeJqGridRequestSearchingFilter(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-        {
-            JqGridRequestSearchingFilter obj = new JqGridRequestSearchingFilter();
-
-            obj.SearchingName = GetStringFromSerializedObj(serializedObj, "field");
-            obj.SearchingOperator = GetEnumFromSerializedObj(serializedObj, "op", JqGridSearchOperators.Eq);
-            obj.SearchingValue = GetStringFromSerializedObj(serializedObj, "data");
-            return obj;
-        }
-
-        private static void SerializeJqGridRequestSearchingFilter(JqGridRequestSearchingFilter obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-        {
-            serializedObj.Add("field", obj.SearchingName);
-            serializedObj.Add("op", obj.SearchingOperator.ToString().ToLower());
-            serializedObj.Add("data", obj.SearchingValue);
-        }
-
-        private static bool? GetBooleanFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-        {
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is Boolean)
-                return (bool)serializedObj[key];
-            else
-                return null;
-        }
-
-        private static bool GetBooleanFromSerializedObj(IDictionary<string, object> serializedObj, string key, bool defaultValue)
-        {
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is Boolean)
-                return (bool)serializedObj[key];
-            else
-                return defaultValue;
-        }
-
-        private static double? GetDoubleFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-        {
-            double value;
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Double.TryParse(serializedObj[key].ToString(), out value))
-                return value;
-            else
-                return null;
-        }
-
-        private static TEnum? GetEnumFromSerializedObj<TEnum>(IDictionary<string, object> serializedObj, string key) where TEnum : struct
-        {
-            TEnum value;
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Enum.TryParse<TEnum>(serializedObj[key].ToString(), true, out value))
-                return value;
-            else
-                return null;
-        }
-
-        private static TEnum GetEnumFromSerializedObj<TEnum>(IDictionary<string, object> serializedObj, string key, TEnum defaultValue) where TEnum : struct
-        {
-            TEnum value = defaultValue;
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Enum.TryParse<TEnum>(serializedObj[key].ToString(), true, out value))
-                return value;
-            else
-                return defaultValue;
-        }
-
-        private static int? GetInt32FromSerializedObj(IDictionary<string, object> serializedObj, string key)
-        {
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is Int32)
-                return (int)serializedObj[key];
-            else
-                return null;
-        }
-
-        private static int GetInt32FromSerializedObj(IDictionary<string, object> serializedObj, string key, int defaultValue)
-        {
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is Int32)
-                return (int)serializedObj[key];
-            else
-                return defaultValue;
-        }
-
-        private static List<int> GetInt32ArrayFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-        {
-            List<int> array = null;
-
-            if (serializedObj.ContainsKey(key) && serializedObj[key] is ArrayList)
-            {
-                array = new List<int>();
-                ArrayList serializedArray = (ArrayList)serializedObj[key];
-                foreach (object serializedItem in serializedArray)
-                {
-                    if (serializedItem is Int32)
-                        array.Add((int)serializedItem);
-                }
-            }
-
-            return array;
-        }
-
-        private static string GetStringFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-        {
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
-                return serializedObj[key].ToString();
-            else
-                return null;
-        }
-
-        private static string GetStringFromSerializedObj(IDictionary<string, object> serializedObj, string key, string defaultValue)
-        {
-            if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
-                return serializedObj[key].ToString();
-            else
-                return defaultValue;
-        }
-        #endregion
-    }
+	internal class JqGridScriptConverter : JavaScriptConverter
+	{
+		#region Fields
+		private static ReadOnlyCollection<Type> _supportedTypes = new ReadOnlyCollection<Type>(new List<Type>()
+		{
+			typeof(JqGridOptions),
+			typeof(JqGridColumnModel),
+			typeof(JqGridJsonReader),
+			typeof(JqGridParametersNames),
+			typeof(JqGridGroupingView),
+			typeof(JqGridColumnEditOptions),
+			typeof(JqGridColumnRules),
+			typeof(JqGridColumnFormOptions),
+			typeof(JqGridColumnFormatterOptions),
+			typeof(JqGridColumnSearchOptions),
+			typeof(JqGridSubgridModel),
+			typeof(JqGridResponse),
+			typeof(JqGridRequestSearchingFilters),
+			typeof(JqGridRequestSearchingFilter)
+		});
+		#endregion
+
+		#region JavaScriptConverter Members
+		public override object Deserialize(IDictionary<string, object> dictionary, Type type, JavaScriptSerializer serializer)
+		{
+			object obj = null;
+
+			if (dictionary != null)
+			{
+				if (type == typeof(JqGridOptions))
+					obj = DeserializeJqGridOptions(dictionary, serializer);
+				else if (type == typeof(JqGridColumnModel))
+					obj = DeserializeJqGridColumnModel(dictionary, serializer);
+				else if (type == typeof(JqGridJsonReader))
+					obj = DeserializeJqGridJsonReader(dictionary, serializer);
+				else if (type == typeof(JqGridParametersNames))
+					obj = DeserializeJqGridParametersNames(dictionary, serializer);
+				else if (type == typeof(JqGridGroupingView))
+					obj = DeserializeJqGridGroupingView(dictionary, serializer);
+				else if (type == typeof(JqGridColumnEditOptions))
+					obj = DeserializeJqGridColumnEditOptions(dictionary, serializer);
+				else if (type == typeof(JqGridColumnRules))
+					obj = DeserializeJqGridColumnRules(dictionary, serializer);
+				else if (type == typeof(JqGridColumnFormOptions))
+					obj = DeserializeJqGridColumnFormOptions(dictionary, serializer);
+				else if (type == typeof(JqGridColumnFormatterOptions))
+					obj = DeserializeJqGridColumnFormatterOptions(dictionary, serializer);
+				else if (type == typeof(JqGridColumnSearchOptions))
+					obj = DeserializeJqGridColumnSearchOptions(dictionary, serializer);
+				else if (type == typeof(JqGridSubgridModel))
+					obj = DeserializeJqGridSubgridModel(dictionary, serializer);
+				else if (type == typeof(JqGridRequestSearchingFilters))
+					obj = DeserializeJqGridRequestSearchingFilters(dictionary, serializer);
+				else if (type == typeof(JqGridRequestSearchingFilter))
+					obj = DeserializeJqGridRequestSearchingFilter(dictionary, serializer);
+			}
+
+			return obj;
+		}
+
+		public override IDictionary<string, object> Serialize(object obj, JavaScriptSerializer serializer)
+		{
+			var serializedObj = new Dictionary<string, object>();
+
+			if (obj != null)
+			{
+				if (obj is JqGridOptions)
+					SerializeJqGridOptions((JqGridOptions)obj, serializer, serializedObj);
+				else if (obj is JqGridColumnModel)
+					SerializeJqGridColumnModel((JqGridColumnModel)obj, serializer, serializedObj);
+				else if (obj is JqGridJsonReader)
+					SerializeJqGridJsonReader((JqGridJsonReader)obj, serializer, serializedObj);
+				else if (obj is JqGridParametersNames)
+					SerializeJqGridParametersNames((JqGridParametersNames)obj, serializer, serializedObj);
+				else if (obj is JqGridGroupingView)
+					SerializeJqGridGroupingView((JqGridGroupingView)obj, serializer, serializedObj);
+				else if (obj is JqGridColumnEditOptions)
+					SerializeJqGridColumnEditOptions((JqGridColumnEditOptions)obj, serializer, serializedObj);
+				else if (obj is JqGridColumnRules)
+					SerializeJqGridColumnRules((JqGridColumnRules)obj, serializer, serializedObj);
+				else if (obj is JqGridColumnFormatterOptions)
+					SerializeJqGridColumnFormatterOptions((JqGridColumnFormatterOptions)obj, serializer, serializedObj);
+				else if (obj is JqGridColumnFormOptions)
+					SerializeJqGridColumnFormOptions((JqGridColumnFormOptions)obj, serializer, serializedObj);
+				else if (obj is JqGridColumnSearchOptions)
+					SerializeJqGridColumnSearchOptions((JqGridColumnSearchOptions)obj, serializer, serializedObj);
+				else if (obj is JqGridSubgridModel)
+					SerializeJqGridSubgridModel((JqGridSubgridModel)obj, serializer, serializedObj);
+				else if (obj is JqGridResponse)
+					SerializeJqGridResponse((JqGridResponse)obj, serializer, serializedObj);
+				else if (obj is JqGridRequestSearchingFilters)
+					SerializeJqGridRequestSearchingFilters((JqGridRequestSearchingFilters)obj, serializer, serializedObj);
+				else if (obj is JqGridRequestSearchingFilter)
+					SerializeJqGridRequestSearchingFilter((JqGridRequestSearchingFilter)obj, serializer, serializedObj);
+			}
+
+			return serializedObj;
+		}
+
+		public override IEnumerable<Type> SupportedTypes => _supportedTypes;
+
+		#endregion
+
+		#region Methods
+		private static JqGridOptions DeserializeJqGridOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var id = GetStringFromSerializedObj(serializedObj, "id");
+			if (!string.IsNullOrWhiteSpace(id))
+			{
+				var obj = new JqGridOptions(id);
+				if (serializedObj.ContainsKey("altclass"))
+					obj.AltClass = serializedObj["altclass"]?.ToString();
+				obj.AltRows = GetBooleanFromSerializedObj(serializedObj, "altRows");
+				obj.AutoEncode = GetBooleanFromSerializedObj(serializedObj, "autoencode");
+				obj.AutoWidth = GetBooleanFromSerializedObj(serializedObj, "autowidth");
+				if (serializedObj.ContainsKey("caption"))
+					obj.Caption = serializedObj["caption"]?.ToString();
+				obj.CellLayout = GetInt32FromSerializedObj(serializedObj, "cellLayout");
+				obj.CellEditingEnabled = GetBooleanFromSerializedObj(serializedObj, "cellEdit");
+				obj.CellEditingSubmitMode = GetEnumFromSerializedObj(serializedObj, "cellsubmit", JqGridCellEditingSubmitModes.Default);
+				if (serializedObj.ContainsKey("cellurl"))
+					obj.CellEditingUrl = serializedObj["cellurl"]?.ToString();
+
+				if (serializedObj.ContainsKey("colModel") && serializedObj["colModel"] is ArrayList)
+				{
+					foreach (var innerSerializedObj in (ArrayList)serializedObj["colModel"])
+					{
+						if (innerSerializedObj is IDictionary<string, object>)
+						{
+							var columnModel = DeserializeJqGridColumnModel((IDictionary<string, object>)innerSerializedObj, serializer);
+							if (columnModel != null)
+								obj.ColumnsModels.Add(columnModel);
+						}
+					}
+				}
+
+				if (serializedObj.ContainsKey("colNames") && serializedObj["colNames"] is ArrayList)
+				{
+					foreach (var innerSerializedObj in (ArrayList)serializedObj["colNames"])
+						obj.ColumnsNames.Add(innerSerializedObj.ToString());
+				}
+
+				if (serializedObj.ContainsKey("datastr"))
+					obj.DataString = serializedObj["datastr"]?.ToString();
+				obj.DataType = GetEnumFromSerializedObj(serializedObj, "datatype", JqGridDataTypes.Default);
+				obj.DeepEmpty = GetBooleanFromSerializedObj(serializedObj, "deepempty");
+				obj.Direction = GetEnumFromSerializedObj(serializedObj, "direction", JqGridLanguageDirections.Default);
+				obj.DynamicScrollingMode = JqGridDynamicScrollingModes.Default;
+				if (serializedObj.ContainsKey("scroll") && serializedObj["scroll"] != null)
+				{
+					if (serializedObj["scroll"] is bool b && b)
+						obj.DynamicScrollingMode = JqGridDynamicScrollingModes.HoldAllRows;
+					else if (serializedObj["scroll"] is int)
+						obj.DynamicScrollingMode = JqGridDynamicScrollingModes.HoldVisibleRows;
+				}
+
+				obj.DynamicScrollingTimeout = GetInt32FromSerializedObj(serializedObj, "scrollTimeout");
+				if (serializedObj.ContainsKey("editurl"))
+					obj.EditingUrl = serializedObj["editurl"]?.ToString();
+				if (serializedObj.ContainsKey("emptyrecords"))
+					obj.EmptyRecords = serializedObj["emptyrecords"]?.ToString();
+				obj.ExpandColumnClick = GetBooleanFromSerializedObj(serializedObj, "ExpandColClick");
+				if (serializedObj.ContainsKey("ExpandColumn"))
+					obj.ExpandColumn = serializedObj["ExpandColumn"]?.ToString();
+				obj.FooterEnabled = GetBooleanFromSerializedObj(serializedObj, "footerrow");
+				obj.UserDataOnFooter = GetBooleanFromSerializedObj(serializedObj, "userDataOnFooter");
+				obj.GridView = GetBooleanFromSerializedObj(serializedObj, "gridview");
+
+				obj.GroupingEnabled = GetBooleanFromSerializedObj(serializedObj, "grouping");
+				if (serializedObj.ContainsKey("groupingView") && serializedObj["groupingView"] is IDictionary<string, object>)
+					obj.GroupingView = DeserializeJqGridGroupingView((IDictionary<string, object>)serializedObj["groupingView"], serializer);
+
+				obj.Height = GetInt32FromSerializedObj(serializedObj, "height");
+				obj.Hidden = GetBooleanFromSerializedObj(serializedObj, "hiddengrid");
+				obj.HiddenEnabled = GetBooleanFromSerializedObj(serializedObj, "hidegrid");
+				obj.HoverRows = GetBooleanFromSerializedObj(serializedObj, "hoverrows");
+				obj.IgnoreCase = GetBooleanFromSerializedObj(serializedObj, "ignoreCase");
+				obj.LoadOnce = GetBooleanFromSerializedObj(serializedObj, "loadonce");
+				obj.MethodType = GetEnumFromSerializedObj(serializedObj, "mtype", JqGridMethodTypes.Default);
+				obj.MultiKey = GetEnumFromSerializedObj(serializedObj, "multikey", JqGridMultiKeys.Default);
+				obj.MultiBoxOnly = GetBooleanFromSerializedObj(serializedObj, "multiboxonly");
+				obj.MultiSelect = GetBooleanFromSerializedObj(serializedObj, "multiselect");
+				obj.MultiSelectWidth = GetInt32FromSerializedObj(serializedObj, "multiselectWidth");
+				obj.MultiSort = GetBooleanFromSerializedObj(serializedObj, "multiSort");
+
+				if (serializedObj.ContainsKey("pager") && serializedObj["pager"] != null)
+					obj.Pager = true;
+
+				if (serializedObj.ContainsKey("jsonReader") && serializedObj["jsonReader"] is IDictionary<string, object>)
+					obj.JsonReader = DeserializeJqGridJsonReader((IDictionary<string, object>)serializedObj["jsonReader"], serializer);
+				else
+					obj.JsonReader = JqGridResponse.JsonReader;
+
+				if (serializedObj.ContainsKey("prmNames") && serializedObj["prmNames"] is IDictionary<string, object>)
+					obj.ParametersNames = DeserializeJqGridParametersNames((IDictionary<string, object>)serializedObj["prmNames"], serializer);
+				else
+					obj.ParametersNames = JqGridRequest.ParameterNames;
+
+				obj.ColumnsRemaping = GetInt32ArrayFromSerializedObj(serializedObj, "remapColumns");
+				obj.RowsList = GetInt32ArrayFromSerializedObj(serializedObj, "rowList");
+				obj.RowsNumber = GetInt32FromSerializedObj(serializedObj, "rowNum");
+				obj.RowsNumbers = GetBooleanFromSerializedObj(serializedObj, "rownumbers");
+				obj.RowsNumbersWidth = GetInt32FromSerializedObj(serializedObj, "rownumWidth");
+				obj.ShrinkToFit = GetBooleanFromSerializedObj(serializedObj, "shrinkToFit");
+				obj.ScrollOffset = GetInt32FromSerializedObj(serializedObj, "scrollOffset");
+				obj.Sortable = GetBooleanFromSerializedObj(serializedObj, "sortable");
+				if (serializedObj.ContainsKey("sortname"))
+					obj.SortingName = serializedObj["sortname"]?.ToString();
+				obj.SortingOrder = GetEnumFromSerializedObj(serializedObj, "sortorder", JqGridSortingOrders.Default);
+				obj.StyleUI = GetEnumFromSerializedObj(serializedObj, "styleUI", JqGridStyleUIOptions.Default);
+				obj.SubgridEnabled = GetBooleanFromSerializedObj(serializedObj, "subGrid");
+
+				if (serializedObj.ContainsKey("subGridModel") && serializedObj["subGridModel"] is IDictionary<string, object>)
+					obj.SubgridModel = DeserializeJqGridSubgridModel((IDictionary<string, object>)serializedObj["subGridModel"], serializer);
+
+				if (serializedObj.ContainsKey("subGridUrl"))
+					obj.SubgridUrl = serializedObj["subGridUrl"]?.ToString();
+				obj.SubgridColumnWidth = GetInt32FromSerializedObj(serializedObj, "subGridWidth");
+				obj.TopPager = GetBooleanFromSerializedObj(serializedObj, "toppager");
+				obj.TreeGridEnabled = GetBooleanFromSerializedObj(serializedObj, "treeGrid");
+				obj.TreeGridModel = GetEnumFromSerializedObj(serializedObj, "treeGridModel", JqGridTreeGridModels.Default);
+				if (serializedObj.ContainsKey("url"))
+					obj.Url = serializedObj["url"]?.ToString();
+				obj.ViewRecords = GetBooleanFromSerializedObj(serializedObj, "viewrecords");
+				obj.Width = GetInt32FromSerializedObj(serializedObj, "width");
+
+				return obj;
+			}
+			return null;
+		}
+
+		private static void SerializeJqGridOptions(JqGridOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			serializedObj.Add("id", obj.Id);
+
+			if (obj.IsAltClassSetted)
+				serializedObj.Add("altclass", obj.AltClass);
+
+			if (obj.AltRows.HasValue)
+				serializedObj.Add("altRows", obj.AltRows.Value);
+
+			if (obj.AutoEncode.HasValue)
+				serializedObj.Add("autoencode", obj.AutoEncode.Value);
+
+			if (obj.AutoWidth.HasValue)
+				serializedObj.Add("autowidth", obj.AutoWidth.Value);
+
+			if (obj.CellLayout.HasValue)
+				serializedObj.Add("cellLayout", obj.CellLayout.Value);
+
+			if (obj.CellEditingEnabled.HasValue)
+				serializedObj.Add("cellEdit", obj.CellEditingEnabled.Value);
+
+			if (obj.CellEditingSubmitMode != JqGridCellEditingSubmitModes.Default)
+				serializedObj.Add("cellsubmit", obj.CellEditingSubmitMode);
+
+			if (obj.IsCellEditingUrlSetted)
+				serializedObj.Add("cellurl", obj.CellEditingUrl);
+
+			serializedObj.Add("colModel", obj.ColumnsModels);
+			serializedObj.Add("colNames", obj.ColumnsNames);
+
+			if (obj.IsCaptionSetted)
+				serializedObj.Add("caption", obj.Caption);
+
+			if (obj.HiddenEnabled.HasValue)
+				serializedObj.Add("hidegrid", obj.HiddenEnabled.Value);
+
+			if (obj.Hidden.HasValue)
+				serializedObj.Add("hiddengrid", obj.Hidden.Value);
+
+			if (obj.IsUsedDataString)
+				serializedObj.Add("datastr", obj.DataString);
+			else
+				serializedObj.Add("url", obj.Url);
+
+			if (obj.DataType != JqGridDataTypes.Default)
+				serializedObj.Add("datatype", obj.DataType.ToString().ToLower());
+
+			if (obj.DeepEmpty.HasValue)
+				serializedObj.Add("deepempty", obj.DeepEmpty.Value);
+
+			if (obj.Direction != JqGridLanguageDirections.Default)
+				serializedObj.Add("direction", obj.Direction.ToString().ToLower());
+
+			if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.Disabled)
+				serializedObj.Add("scroll", false);
+			if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldAllRows)
+				serializedObj.Add("scroll", true);
+			else if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldVisibleRows)
+				serializedObj.Add("scroll", 10);
+
+			if (obj.DynamicScrollingTimeout.HasValue)
+				serializedObj.Add("scrollTimeout", obj.DynamicScrollingTimeout);
+
+			if (obj.IsEmptyRecordsSetted)
+				serializedObj.Add("emptyrecords", obj.EmptyRecords);
+
+			if (obj.IsEditingUrlSetted)
+				serializedObj.Add("editurl", obj.EditingUrl);
+
+			if (obj.FooterEnabled.HasValue)
+			{
+				serializedObj.Add("footerrow", obj.FooterEnabled.Value);
+				if (obj.FooterEnabled.Value && obj.UserDataOnFooter.HasValue)
+					serializedObj.Add("userDataOnFooter", obj.UserDataOnFooter.Value);
+			}
+
+			if (obj.GridView.HasValue)
+				serializedObj.Add("gridview", obj.GridView.Value);
+
+			if (obj.GroupingEnabled.HasValue)
+			{
+				serializedObj.Add("grouping", obj.GroupingEnabled.Value);
+
+				if (obj.GroupingEnabled.Value && obj.GroupingView != null)
+					serializedObj.Add("groupingView", obj.GroupingView);
+			}
+
+			if (obj.Height.HasValue)
+				serializedObj.Add("height", obj.Height.Value);
+			else
+				serializedObj.Add("height", "100%");
+
+			if (obj.HoverRows.HasValue)
+				serializedObj.Add("hoverrows", obj.HoverRows.Value);
+
+			if (obj.IgnoreCase.HasValue)
+				serializedObj.Add("ignoreCase", obj.IgnoreCase.Value);
+
+			if (obj.LoadOnce.HasValue)
+				serializedObj.Add("loadonce", obj.LoadOnce.Value);
+
+			if (obj.MethodType != JqGridMethodTypes.Default)
+				serializedObj.Add("mtype", obj.MethodType.ToString().ToUpper());
+
+			if (obj.MultiKey != JqGridMultiKeys.Default)
+				if (obj.MultiKey == JqGridMultiKeys.Disable)
+					serializedObj.Add("multikey", null);
+				else
+					serializedObj.Add("multikey", $"{obj.MultiKey.ToString().ToLower()}Key");
+
+			if (obj.MultiBoxOnly.HasValue)
+				serializedObj.Add("multiboxonly", obj.MultiBoxOnly.Value);
+
+			if (obj.MultiSelect.HasValue)
+				serializedObj.Add("multiselect", obj.MultiSelect.Value);
+
+			if (obj.MultiSelectWidth.HasValue)
+				serializedObj.Add("multiselectWidth", obj.MultiSelectWidth.Value);
+
+			if (obj.MultiSort.HasValue)
+				serializedObj.Add("multiSort", obj.MultiSort.Value);
+
+			if (obj.Pager)
+				serializedObj.Add("pager", $"#{obj.Id}Pager");
+
+			if (obj.JsonReader != null && !obj.JsonReader.IsGlobal)
+				serializedObj.Add("jsonReader", obj.JsonReader);
+
+			if (obj.ParametersNames != null && !obj.ParametersNames.IsGlobal)
+				serializedObj.Add("prmNames", obj.ParametersNames);
+
+			serializedObj.Add("remapColumns", obj.ColumnsRemaping);
+
+			if (obj.RowsList != null && obj.RowsList.Any())
+				serializedObj.Add("rowList", obj.RowsList);
+
+			if (obj.RowsNumber.HasValue)
+				serializedObj.Add("rowNum", obj.RowsNumber.Value);
+
+			if (obj.RowsNumbers.HasValue)
+				serializedObj.Add("rownumbers", obj.RowsNumbers.Value);
+
+			if (obj.RowsNumbersWidth.HasValue)
+				serializedObj.Add("rownumWidth", obj.RowsNumbersWidth.Value);
+
+			if (obj.ShrinkToFit.HasValue)
+				serializedObj.Add("shrinkToFit", obj.ShrinkToFit.Value);
+
+			if (obj.ScrollOffset.HasValue)
+				serializedObj.Add("scrollOffset", obj.ScrollOffset.Value);
+
+			if (obj.Sortable.HasValue)
+				serializedObj.Add("sortable", obj.Sortable.Value);
+
+			if (obj.IsSortingNameSetted)
+				serializedObj.Add("sortname", obj.SortingName);
+
+			if (obj.SortingOrder != JqGridSortingOrders.Default)
+				serializedObj.Add("sortorder", obj.SortingOrder.ToString().ToLower());
+
+			if (obj.StyleUI != JqGridStyleUIOptions.Default)
+				serializedObj.Add("styleUI", obj.StyleUI.ToString());
+
+			if (obj.SubgridEnabled.HasValue)
+			{
+				serializedObj.Add("subGrid", obj.SubgridEnabled.Value);
+
+				if (obj.SubgridEnabled.Value)
+				{
+					if (obj.SubgridModel != null)
+						serializedObj.Add("subGridModel", obj.SubgridModel);
+
+					if (obj.IsSubgridUrlSetted)
+						serializedObj.Add("subGridUrl", obj.SubgridUrl);
+
+					if (obj.SubgridColumnWidth.HasValue)
+						serializedObj.Add("subGridWidth", obj.SubgridColumnWidth.Value);
+				}
+			}
+
+			if (obj.TopPager.HasValue)
+				serializedObj.Add("toppager", obj.TopPager.Value);
+
+			if (obj.TreeGridEnabled.HasValue)
+			{
+				serializedObj.Add("treeGrid", obj.TreeGridEnabled.Value);
+
+				if (obj.TreeGridEnabled.Value)
+				{
+					if (obj.TreeGridModel != JqGridTreeGridModels.Default)
+						serializedObj.Add("treeGridModel", obj.TreeGridModel.ToString().ToLower());
+
+					if (obj.ExpandColumnClick.HasValue)
+						serializedObj.Add("ExpandColClick", obj.ExpandColumnClick);
+
+					if (obj.IsExpandColumnSetted)
+						serializedObj.Add("ExpandColumn", obj.ExpandColumn);
+				}
+			}
+
+			if (obj.ViewRecords.HasValue)
+				serializedObj.Add("viewrecords", obj.ViewRecords.Value);
+
+			if (obj.Width.HasValue)
+				serializedObj.Add("width", obj.Width.Value);
+		}
+
+		private static JqGridColumnModel DeserializeJqGridColumnModel(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var name = GetStringFromSerializedObj(serializedObj, "name");
+			if (!string.IsNullOrWhiteSpace(name))
+			{
+				var obj = new JqGridColumnModel(name);
+
+				obj.Alignment = GetEnumFromSerializedObj(serializedObj, "align", obj.Alignment);
+				obj.DateFormat = GetSettedStringFromSerializedObj(serializedObj, "datefmt");
+				obj.Classes = GetSettedStringFromSerializedObj(serializedObj, "classes");
+				obj.Editable = GetBooleanFromSerializedObj(serializedObj, "editable");
+				obj.EditType = GetEnumFromSerializedObj(serializedObj, "edittype", JqGridColumnEditTypes.Default);
+
+				if (serializedObj.ContainsKey("editoptions") && serializedObj["editoptions"] is IDictionary<string, object>)
+					obj.EditOptions = DeserializeJqGridColumnEditOptions((IDictionary<string, object>)serializedObj["editoptions"], serializer);
+
+				if (serializedObj.ContainsKey("editrules") && serializedObj["editrules"] is IDictionary<string, object>)
+					obj.EditRules = DeserializeJqGridColumnRules((IDictionary<string, object>)serializedObj["editrules"], serializer);
+
+				obj.Fixed = GetBooleanFromSerializedObj(serializedObj, "fixed");
+				obj.Frozen = GetBooleanFromSerializedObj(serializedObj, "frozen");
+				obj.Hidden = GetBooleanFromSerializedObj(serializedObj, "hidden");
+				obj.HideInDialog = GetBooleanFromSerializedObj(serializedObj, "hidedlg");
+
+				obj.Formatter = GetSettedStringFromSerializedObj(serializedObj, "formatter");
+				if (obj.Formatter?.IsSetted ?? false)
+					obj.Formatter.Value = '\'' + obj.Formatter.Value + '\'';
+
+				if (serializedObj.ContainsKey("formatoptions") && serializedObj["formatoptions"] is IDictionary<string, object>)
+					obj.FormatterOptions = DeserializeJqGridColumnFormatterOptions((IDictionary<string, object>)serializedObj["formatoptions"], serializer);
+				//obj.UnFormatter = GetStringFromSerializedObj(serializedObj, "unformat");
+
+				if (serializedObj.ContainsKey("formoptions") && serializedObj["formoptions"] is IDictionary<string, object>)
+					obj.FormOptions = DeserializeJqGridColumnFormOptions((IDictionary<string, object>)serializedObj["formoptions"], serializer);
+
+				obj.InitialSortingOrder = GetEnumFromSerializedObj(serializedObj, "firstsortorder", JqGridSortingOrders.Default);
+				obj.JsonMapping = GetStringFromSerializedObj(serializedObj, "jsonmap");
+				obj.Key = GetBooleanFromSerializedObj(serializedObj, "key");
+				obj.Resizable = GetBooleanFromSerializedObj(serializedObj, "resizable");
+				obj.SummaryType = GetEnumFromSerializedObj<JqGridColumnSummaryTypes>(serializedObj, "summaryType");
+				if (!obj.SummaryType.HasValue)
+				{
+					obj.SummaryFunction = GetStringFromSerializedObj(serializedObj, "summaryType");
+					if (!string.IsNullOrWhiteSpace(obj.SummaryFunction))
+						obj.SummaryType = JqGridColumnSummaryTypes.Custom;
+				}
+
+				obj.SummaryTemplate = GetSettedStringFromSerializedObj(serializedObj, "summaryTpl");
+				obj.Sortable = GetBooleanFromSerializedObj(serializedObj, "sortable");
+				obj.SortType = GetEnumFromSerializedObj(serializedObj, "sorttype", JqGridColumnSortTypes.Default);
+				obj.Index = GetSettedStringFromSerializedObj(serializedObj, "index");
+				obj.Searchable = GetBooleanFromSerializedObj(serializedObj, "search");
+				obj.SearchType = GetEnumFromSerializedObj(serializedObj, "stype", JqGridColumnSearchTypes.Default);
+
+				if (serializedObj.ContainsKey("searchoptions") && serializedObj["searchoptions"] is IDictionary<string, object>)
+					obj.SearchOptions = DeserializeJqGridColumnSearchOptions((IDictionary<string, object>)serializedObj["searchoptions"], serializer);
+
+				if (serializedObj.ContainsKey("searchrules") && serializedObj["searchrules"] is IDictionary<string, object>)
+					obj.SearchRules = DeserializeJqGridColumnRules((IDictionary<string, object>)serializedObj["searchrules"], serializer);
+
+				obj.Title = GetBooleanFromSerializedObj(serializedObj, "title");
+				obj.Width = GetInt32FromSerializedObj(serializedObj, "width");
+				obj.Viewable = GetBooleanFromSerializedObj(serializedObj, "viewable");
+				obj.XmlMapping = GetStringFromSerializedObj(serializedObj, "xmlmap");
+
+				return obj;
+			}
+			return null;
+		}
+
+		private static void SerializeJqGridColumnModel(JqGridColumnModel obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.Alignment != JqGridAlignments.Default)
+				serializedObj.Add("align", obj.Alignment.ToString().ToLower());
+
+			if (obj.Classes?.IsSetted ?? false)
+				serializedObj.Add("classes", obj.Classes);
+
+			if (obj.DateFormat?.IsSetted ?? false)
+				serializedObj.Add("datefmt", obj.DateFormat);
+
+			if (obj.Editable.HasValue)
+			{
+				serializedObj.Add("editable", obj.Editable.Value);
+				if (obj.Editable.Value)
+				{
+					if (obj.EditType != JqGridColumnEditTypes.Default)
+						serializedObj.Add("edittype", obj.EditType.ToString().ToLower());
+
+					if (obj.EditOptions != null)
+						serializedObj.Add("editoptions", obj.EditOptions);
+
+					if (obj.EditRules != null)
+						serializedObj.Add("editrules", obj.EditRules);
+
+					if (obj.FormOptions != null)
+						serializedObj.Add("formoptions", obj.FormOptions);
+				}
+			}
+
+			if (obj.Fixed.HasValue)
+				serializedObj.Add("fixed", obj.Fixed.Value);
+
+			if (obj.Frozen.HasValue)
+				serializedObj.Add("frozen", obj.Frozen.Value);
+
+			if (obj.InitialSortingOrder != JqGridSortingOrders.Default)
+				serializedObj.Add("firstsortorder", obj.InitialSortingOrder.ToString().ToLower());
+
+			if ((obj.Formatter?.IsSetted ?? false) && obj.Formatter.Value[0] == '\'' && obj.Formatter.Value[obj.Formatter.Value.Length - 1] == '\'')
+			{
+				serializedObj.Add("formatter", obj.Formatter.Value.Substring(1, obj.Formatter.Value.Length - 2));
+
+				if (obj.FormatterOptions != null)
+					serializedObj.Add("formatoptions", obj.FormatterOptions);
+			}
+
+			//if (!String.IsNullOrWhiteSpace(obj.UnFormatter))
+			//    serializedObj.Add("unformat", obj.UnFormatter);
+
+			if (obj.Hidden.HasValue)
+				serializedObj.Add("hidden", obj.Hidden.Value);
+
+			if (obj.HideInDialog.HasValue)
+				serializedObj.Add("hidedlg", obj.HideInDialog.Value);
+
+			if (!string.IsNullOrWhiteSpace(obj.JsonMapping))
+				serializedObj.Add("jsonmap", obj.JsonMapping);
+
+			if (obj.Key.HasValue)
+				serializedObj.Add("key", obj.Key.Value);
+
+			if (obj.Resizable.HasValue)
+				serializedObj.Add("resizable", obj.Resizable.Value);
+
+			if (obj.SummaryType.HasValue)
+			{
+				if (obj.SummaryType.Value != JqGridColumnSummaryTypes.Custom)
+					serializedObj.Add("summaryType", obj.SummaryType.Value.ToString().ToLower());
+				else
+					serializedObj.Add("summaryType", obj.SummaryFunction);
+			}
+
+			if (obj.SummaryTemplate?.IsSetted ?? false)
+				serializedObj.Add("summaryTpl", obj.SummaryTemplate.Value);
+
+			if (obj.Sortable.HasValue)
+				serializedObj.Add("sortable", obj.Sortable.Value);
+
+			if (obj.SortType != JqGridColumnSortTypes.Default && obj.SortType != JqGridColumnSortTypes.Function)
+				serializedObj.Add("sorttype", obj.SortType.ToString().ToLower());
+
+			if (obj.Index?.IsSetted ?? false)
+				serializedObj.Add("index", obj.Index.Value);
+
+			if (obj.Searchable.HasValue)
+			{
+				serializedObj.Add("search", obj.Searchable.Value);
+				if (obj.Searchable.Value)
+				{
+					if (obj.SearchType != JqGridColumnSearchTypes.Default)
+						serializedObj.Add("stype", obj.SearchType.ToString().ToLower());
+
+					if (obj.SearchOptions != null)
+						serializedObj.Add("searchoptions", obj.SearchOptions);
+
+					if (obj.SearchRules != null)
+						serializedObj.Add("searchrules", obj.SearchRules);
+				}
+			}
+
+			serializedObj.Add("name", obj.Name);
+
+			if (obj.Title.HasValue)
+				serializedObj.Add("title", obj.Title.Value);
+
+			if (obj.Width.HasValue)
+				serializedObj.Add("width", obj.Width);
+
+			if (obj.Viewable.HasValue)
+				serializedObj.Add("viewable", obj.Viewable.Value);
+
+			if (!string.IsNullOrWhiteSpace(obj.XmlMapping))
+				serializedObj.Add("xmlmap", obj.XmlMapping);
+		}
+
+		private static JqGridColumnEditOptions DeserializeJqGridColumnEditOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridColumnEditOptions();
+
+			if (serializedObj.ContainsKey("custom_element"))
+				obj.CustomElementFunction = serializedObj["custom_element"]?.ToString();
+			serializedObj.Remove("custom_element");
+			if (serializedObj.ContainsKey("custom_value"))
+				obj.CustomValueFunction = serializedObj["custom_value"]?.ToString();
+			serializedObj.Remove("custom_value");
+			if (serializedObj.ContainsKey("dataUrl"))
+				obj.DataUrl = serializedObj["dataUrl"]?.ToString();
+			serializedObj.Remove("dataUrl");
+			if (serializedObj.ContainsKey("defaultValue"))
+				obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
+			serializedObj.Remove("defaultValue");
+
+			if (serializedObj.ContainsKey("value") && serializedObj["value"] is IDictionary<string, object>)
+				obj.ValueDictionary = ((IDictionary<string, object>)serializedObj["value"]).ToDictionary(k => k.Key, v => v.Value.ToString());
+			else
+				obj.Value = GetStringFromSerializedObj(serializedObj, "value");
+			serializedObj.Remove("value");
+
+			obj.NullIfEmpty = GetBooleanFromSerializedObj(serializedObj, "NullIfEmpty");
+			serializedObj.Remove("NullIfEmpty");
+			obj.HtmlAttributes = serializedObj;
+
+			return obj;
+		}
+
+		private static void SerializeJqGridColumnEditOptions(JqGridColumnEditOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.IsCustomElementFunctionSetted)
+				serializedObj.Add("custom_element", obj.CustomElementFunction);
+
+			if (obj.IsCustomValueFunctionSetted)
+				serializedObj.Add("custom_value", obj.CustomValueFunction);
+
+			SerializeJqGridColumnElementOptions(obj, serializer, serializedObj);
+
+			if (obj.NullIfEmpty.HasValue)
+				serializedObj.Add("NullIfEmpty", obj.NullIfEmpty.Value);
+
+			if (obj.HtmlAttributes != null)
+				foreach (var htmlAttribute in obj.HtmlAttributes)
+					serializedObj.Add(htmlAttribute.Key, htmlAttribute.Value);
+		}
+
+		private static JqGridJsonReader DeserializeJqGridJsonReader(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridJsonReader();
+
+			obj.PageIndex = GetStringFromSerializedObj(serializedObj, "page", JqGridResponse.JsonReader.PageIndex);
+			obj.RecordId = GetStringFromSerializedObj(serializedObj, "id", JqGridResponse.JsonReader.RecordId);
+			obj.Records = GetStringFromSerializedObj(serializedObj, "root", JqGridResponse.JsonReader.Records);
+			obj.RecordValues = GetStringFromSerializedObj(serializedObj, "cell", JqGridResponse.JsonReader.RecordValues);
+			obj.RepeatItems = GetBooleanFromSerializedObj(serializedObj, "repeatitems", JqGridResponse.JsonReader.RepeatItems);
+			obj.TotalPagesCount = GetStringFromSerializedObj(serializedObj, "total", JqGridResponse.JsonReader.TotalPagesCount);
+			obj.TotalRecordsCount = GetStringFromSerializedObj(serializedObj, "records", JqGridResponse.JsonReader.TotalRecordsCount);
+			obj.UserData = GetStringFromSerializedObj(serializedObj, "userdata", JqGridResponse.JsonReader.UserData);
+
+			if (serializedObj.ContainsKey("subgrid") && serializedObj["subgrid"] is IDictionary<string, object>)
+			{
+				var serializedSubgrid = (IDictionary<string, object>)serializedObj["subgrid"];
+				obj.SubgridReader.Records = GetStringFromSerializedObj(serializedSubgrid, "root", JqGridResponse.JsonReader.SubgridReader.Records);
+				obj.SubgridReader.RecordValues = GetStringFromSerializedObj(serializedSubgrid, "cell", JqGridResponse.JsonReader.SubgridReader.RecordValues);
+				obj.SubgridReader.RepeatItems = GetBooleanFromSerializedObj(serializedSubgrid, "repeatitems", JqGridResponse.JsonReader.SubgridReader.RepeatItems);
+			}
+
+			return obj;
+		}
+
+		private static void SerializeJqGridJsonReader(JqGridJsonReader obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.Records != JqGridResponse.JsonReader.Records)
+				serializedObj.Add("root", obj.Records);
+
+			if (obj.PageIndex != JqGridResponse.JsonReader.PageIndex)
+				serializedObj.Add("page", obj.PageIndex);
+
+			if (obj.TotalPagesCount != JqGridResponse.JsonReader.TotalPagesCount)
+				serializedObj.Add("total", obj.TotalPagesCount);
+
+			if (obj.TotalRecordsCount != JqGridResponse.JsonReader.TotalRecordsCount)
+				serializedObj.Add("records", obj.TotalRecordsCount);
+
+			if (!obj.RepeatItems)
+				serializedObj.Add("repeatitems", false);
+
+			if (obj.RecordValues != JqGridResponse.JsonReader.RecordValues)
+				serializedObj.Add("cell", obj.RecordValues);
+
+			if (obj.RecordId != JqGridResponse.JsonReader.RecordId)
+				serializedObj.Add("id", obj.RecordId);
+
+			if (obj.UserData != JqGridResponse.JsonReader.UserData)
+				serializedObj.Add("userdata", obj.UserData);
+
+			if (!obj.SubgridReader.IsDefault())
+			{
+				var serializedSubgrid = new Dictionary<string, object>();
+
+				if (obj.SubgridReader.Records != JqGridResponse.JsonReader.SubgridReader.Records)
+					serializedSubgrid.Add("root", obj.SubgridReader.Records);
+
+				if (!obj.SubgridReader.RepeatItems)
+					serializedSubgrid.Add("repeatitems", false);
+
+				if (obj.SubgridReader.RecordValues != JqGridResponse.JsonReader.SubgridReader.RecordValues)
+					serializedSubgrid.Add("cell", obj.SubgridReader.RecordValues);
+
+				serializedObj.Add("subgrid", serializedSubgrid);
+			}
+		}
+
+		private static JqGridParametersNames DeserializeJqGridParametersNames(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridParametersNames();
+
+			obj.PageIndex = GetStringFromSerializedObj(serializedObj, "page", JqGridRequest.ParameterNames.PageIndex);
+			obj.RecordsCount = GetStringFromSerializedObj(serializedObj, "rows", JqGridRequest.ParameterNames.RecordsCount);
+			obj.SortingName = GetStringFromSerializedObj(serializedObj, "sort", JqGridRequest.ParameterNames.SortingName);
+			obj.SortingOrder = GetStringFromSerializedObj(serializedObj, "order", JqGridRequest.ParameterNames.SortingOrder);
+			obj.Searching = GetStringFromSerializedObj(serializedObj, "search", JqGridRequest.ParameterNames.Searching);
+			obj.Id = GetStringFromSerializedObj(serializedObj, "id", JqGridRequest.ParameterNames.Id);
+			obj.Operator = GetStringFromSerializedObj(serializedObj, "oper", JqGridRequest.ParameterNames.Operator);
+			obj.EditOperator = GetStringFromSerializedObj(serializedObj, "editoper", JqGridRequest.ParameterNames.EditOperator);
+			obj.AddOperator = GetStringFromSerializedObj(serializedObj, "addoper", JqGridRequest.ParameterNames.AddOperator);
+			obj.DeleteOperator = GetStringFromSerializedObj(serializedObj, "deloper", JqGridRequest.ParameterNames.DeleteOperator);
+			obj.SubgridId = GetStringFromSerializedObj(serializedObj, "subgridid", JqGridRequest.ParameterNames.SubgridId);
+			obj.PagesCount = GetStringFromSerializedObj(serializedObj, "npage", JqGridRequest.ParameterNames.PagesCount);
+			obj.TotalRows = GetStringFromSerializedObj(serializedObj, "totalrows", JqGridRequest.ParameterNames.TotalRows);
+
+			return obj;
+		}
+
+		private static void SerializeJqGridParametersNames(JqGridParametersNames obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.PageIndex != JqGridRequest.ParameterNames.PageIndex)
+				serializedObj.Add("page", obj.PageIndex);
+
+			if (obj.RecordsCount != JqGridRequest.ParameterNames.RecordsCount)
+				serializedObj.Add("rows", obj.RecordsCount);
+
+			if (obj.SortingName != JqGridRequest.ParameterNames.SortingName)
+				serializedObj.Add("sort", obj.SortingName);
+
+			if (obj.SortingOrder != JqGridRequest.ParameterNames.SortingOrder)
+				serializedObj.Add("order", obj.SortingOrder);
+
+			if (obj.Searching != JqGridRequest.ParameterNames.Searching)
+				serializedObj.Add("search", obj.Searching);
+
+			if (obj.Id != JqGridRequest.ParameterNames.Id)
+				serializedObj.Add("id", obj.Id);
+
+			if (obj.Operator != JqGridRequest.ParameterNames.Operator)
+				serializedObj.Add("oper", obj.Operator);
+
+			if (obj.EditOperator != JqGridRequest.ParameterNames.EditOperator)
+				serializedObj.Add("editoper", obj.EditOperator);
+
+			if (obj.AddOperator != JqGridRequest.ParameterNames.AddOperator)
+				serializedObj.Add("addoper", obj.AddOperator);
+
+			if (obj.DeleteOperator != JqGridRequest.ParameterNames.DeleteOperator)
+				serializedObj.Add("deloper", obj.DeleteOperator);
+
+			if (obj.SubgridId != JqGridRequest.ParameterNames.SubgridId)
+				serializedObj.Add("subgridid", obj.SubgridId);
+
+			if (obj.PagesCount != JqGridRequest.ParameterNames.PagesCount)
+				serializedObj.Add("npage", obj.PagesCount);
+
+			if (obj.TotalRows != JqGridRequest.ParameterNames.TotalRows)
+				serializedObj.Add("totalrows", obj.TotalRows);
+		}
+
+		private static JqGridGroupingView DeserializeJqGridGroupingView(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridGroupingView();
+
+			if (serializedObj.ContainsKey("groupField") && serializedObj["groupField"] is ArrayList)
+				obj.Fields = (string[])((ArrayList)serializedObj["groupField"]).ToArray(typeof(string));
+
+			if (serializedObj.ContainsKey("groupOrder") && serializedObj["groupOrder"] is ArrayList)
+				obj.Orders = (JqGridSortingOrders[])((ArrayList)serializedObj["groupOrder"]).ToArray(typeof(JqGridSortingOrders));
+
+			if (serializedObj.ContainsKey("groupText") && serializedObj["groupText"] is ArrayList)
+				obj.Texts = (string[])((ArrayList)serializedObj["groupText"]).ToArray(typeof(string));
+
+			if (serializedObj.ContainsKey("groupSummary") && serializedObj["groupSummary"] is ArrayList)
+				obj.Summary = (bool[])((ArrayList)serializedObj["groupSummary"]).ToArray(typeof(bool));
+
+			if (serializedObj.ContainsKey("groupColumnShow") && serializedObj["groupColumnShow"] is ArrayList)
+				obj.ColumnShow = (bool[])((ArrayList)serializedObj["groupColumnShow"]).ToArray(typeof(bool));
+
+			obj.SummaryOnHide = GetBooleanFromSerializedObj(serializedObj, "showSummaryOnHide", false);
+			obj.DataSorted = GetBooleanFromSerializedObj(serializedObj, "groupDataSorted", false);
+			obj.Collapse = GetBooleanFromSerializedObj(serializedObj, "groupCollapse", false);
+			obj.PlusIcon = GetStringFromSerializedObj(serializedObj, "plusicon", JqGridOptionsDefaults.GroupingPlusIcon);
+			obj.MinusIcon = GetStringFromSerializedObj(serializedObj, "minusicon", JqGridOptionsDefaults.GroupingMinusIcon);
+
+			return obj;
+		}
+
+		private static void SerializeJqGridGroupingView(JqGridGroupingView obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.Fields != null && obj.Fields.Length > 0)
+				serializedObj.Add("groupField", obj.Fields);
+
+			if (obj.Orders != null && obj.Orders.Length > 0 && obj.Orders.Contains(JqGridSortingOrders.Desc))
+				serializedObj.Add("groupOrder", obj.Orders);
+
+			if (obj.Texts != null && obj.Texts.Length > 0)
+				serializedObj.Add("groupText", obj.Texts);
+
+			if (obj.Summary != null && obj.Summary.Length > 0 && obj.Summary.Contains(true))
+				serializedObj.Add("groupSummary", obj.Summary);
+
+			if (obj.ColumnShow != null && obj.ColumnShow.Length > 0 && obj.ColumnShow.Contains(false))
+				serializedObj.Add("groupColumnShow", obj.ColumnShow);
+
+			if (obj.SummaryOnHide)
+				serializedObj.Add("showSummaryOnHide", true);
+
+			if (obj.DataSorted)
+				serializedObj.Add("groupDataSorted", true);
+
+			if (obj.Collapse)
+				serializedObj.Add("groupCollapse", true);
+
+			if (obj.PlusIcon != JqGridOptionsDefaults.GroupingPlusIcon)
+				serializedObj.Add("plusicon", obj.PlusIcon);
+
+			if (obj.MinusIcon != JqGridOptionsDefaults.GroupingMinusIcon)
+				serializedObj.Add("minusicon", obj.MinusIcon);
+		}
+
+		private static JqGridColumnRules DeserializeJqGridColumnRules(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridColumnRules();
+
+			obj.Custom = GetBooleanFromSerializedObj(serializedObj, "custom");
+			if (serializedObj.ContainsKey("custom_func"))
+				obj.CustomFunction = serializedObj["custom_func"]?.ToString();
+			obj.Date = GetBooleanFromSerializedObj(serializedObj, "date");
+			obj.EditHidden = GetBooleanFromSerializedObj(serializedObj, "edithidden");
+			obj.Email = GetBooleanFromSerializedObj(serializedObj, "email");
+			obj.Integer = GetBooleanFromSerializedObj(serializedObj, "integer", false);
+			obj.MaxValue = GetDoubleFromSerializedObj(serializedObj, "maxValue");
+			obj.MinValue = GetDoubleFromSerializedObj(serializedObj, "minValue");
+			obj.Number = GetBooleanFromSerializedObj(serializedObj, "number", false);
+			obj.Required = GetBooleanFromSerializedObj(serializedObj, "required");
+			obj.Time = GetBooleanFromSerializedObj(serializedObj, "time");
+			obj.Url = GetBooleanFromSerializedObj(serializedObj, "url");
+
+			return obj;
+		}
+
+		private static void SerializeJqGridColumnRules(JqGridColumnRules obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.Custom.HasValue)
+				serializedObj.Add("custom", obj.Custom.Value);
+
+			if (obj.IsCustomFunctionSetted)
+				serializedObj.Add("custom_func", obj.CustomFunction);
+
+			if (obj.Date.HasValue)
+				serializedObj.Add("date", obj.Date.Value);
+
+			if (obj.EditHidden.HasValue)
+				serializedObj.Add("edithidden", obj.EditHidden.Value);
+
+			if (obj.Email.HasValue)
+				serializedObj.Add("email", obj.Email.Value);
+
+			if (obj.Integer)
+				serializedObj.Add("integer", true);
+
+			if (obj.MaxValue.HasValue)
+				serializedObj.Add("maxValue", obj.MaxValue.Value);
+
+			if (obj.MinValue.HasValue)
+				serializedObj.Add("minValue", obj.MinValue.Value);
+
+			if (obj.Number)
+				serializedObj.Add("number", true);
+
+			if (obj.Required.HasValue)
+				serializedObj.Add("required", obj.Required.Value);
+
+			if (obj.Time.HasValue)
+				serializedObj.Add("time", obj.Time.Value);
+
+			if (obj.Url.HasValue)
+				serializedObj.Add("url", obj.Url.Value);
+		}
+
+		private static JqGridColumnFormOptions DeserializeJqGridColumnFormOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridColumnFormOptions();
+
+			obj.ColumnPosition = GetInt32FromSerializedObj(serializedObj, "colpos");
+			if (serializedObj.ContainsKey("elmprefix"))
+				obj.ElementPrefix = serializedObj["elmprefix"]?.ToString();
+			if (serializedObj.ContainsKey("elmsuffix"))
+				obj.ElementSuffix = serializedObj["elmsuffix"]?.ToString();
+			if (serializedObj.ContainsKey("label"))
+				obj.Label = serializedObj["label"]?.ToString();
+			obj.RowPosition = GetInt32FromSerializedObj(serializedObj, "rowpos");
+
+			return obj;
+		}
+
+		private static void SerializeJqGridColumnFormOptions(JqGridColumnFormOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.ColumnPosition.HasValue)
+				serializedObj.Add("colpos", obj.ColumnPosition.Value);
+
+			if (obj.IsElementPrefixSetted)
+				serializedObj.Add("elmprefix", obj.ElementPrefix);
+
+			if (obj.IsElementSuffixSetted)
+				serializedObj.Add("elmsuffix", obj.ElementSuffix);
+
+			if (obj.IsLabelSetted)
+				serializedObj.Add("label", obj.Label);
+
+			if (obj.RowPosition.HasValue)
+				serializedObj.Add("rowpos", obj.RowPosition.Value);
+		}
+
+		private static JqGridColumnFormatterOptions DeserializeJqGridColumnFormatterOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridColumnFormatterOptions();
+
+			if (serializedObj.ContainsKey("addParam"))
+				obj.AddParam = serializedObj["addParam"]?.ToString();
+			if (serializedObj.ContainsKey("baseLinkUrl"))
+				obj.BaseLinkUrl = serializedObj["baseLinkUrl"]?.ToString();
+			obj.DecimalPlaces = GetInt32FromSerializedObj(serializedObj, "decimalPlaces");
+			if (serializedObj.ContainsKey("decimalSeparator"))
+				obj.DecimalSeparator = serializedObj["decimalSeparator"]?.ToString();
+			if (serializedObj.ContainsKey("defaultValue"))
+				obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
+			obj.Disabled = GetBooleanFromSerializedObj(serializedObj, "disabled");
+			if (serializedObj.ContainsKey("idName"))
+				obj.IdName = serializedObj["idName"]?.ToString();
+			if (serializedObj.ContainsKey("srcformat"))
+				obj.OutputFormat = serializedObj["srcformat"]?.ToString();
+			if (serializedObj.ContainsKey("prefix"))
+				obj.Prefix = serializedObj["prefix"]?.ToString();
+			if (serializedObj.ContainsKey("showAction"))
+				obj.ShowAction = serializedObj["showAction"]?.ToString();
+			if (serializedObj.ContainsKey("newformat"))
+				obj.SourceFormat = serializedObj["newformat"]?.ToString();
+			if (serializedObj.ContainsKey("suffix"))
+				obj.Suffix = serializedObj["suffix"]?.ToString();
+			if (serializedObj.ContainsKey("target"))
+				obj.Target = serializedObj["target"]?.ToString();
+			if (serializedObj.ContainsKey("thousandsSeparator"))
+				obj.ThousandsSeparator = serializedObj["thousandsSeparator"]?.ToString();
+			return obj;
+		}
+
+		private static void SerializeJqGridColumnFormatterOptions(JqGridColumnFormatterOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.IsAddParamSetted)
+				serializedObj.Add("addParam", obj.AddParam);
+			if (obj.IsBaseLinkUrlSetted)
+				serializedObj.Add("baseLinkUrl", obj.BaseLinkUrl);
+			if (obj.DecimalPlaces.HasValue)
+				serializedObj.Add("decimalPlaces", obj.DecimalPlaces.Value);
+			if (obj.IsDecimalSeparatorSetted)
+				serializedObj.Add("decimalSeparator", obj.DecimalSeparator);
+			if (obj.IsDefaultValueSetted)
+				serializedObj.Add("defaultValue", obj.DefaultValue);
+			if (obj.Disabled.HasValue)
+				serializedObj.Add("disabled", obj.Disabled.Value);
+			if (obj.IsIdNameSetted)
+				serializedObj.Add("idName", obj.IdName);
+			if (obj.IsOutputFormatSetted)
+				serializedObj.Add("srcformat", obj.OutputFormat);
+			if (obj.IsPrefixSetted)
+				serializedObj.Add("prefix", obj.Prefix);
+			if (obj.IsShowActionSetted)
+				serializedObj.Add("showAction", obj.ShowAction);
+			if (obj.IsSourceFormatSetted)
+				serializedObj.Add("newformat", obj.SourceFormat);
+			if (obj.IsSuffixSetted)
+				serializedObj.Add("suffix", obj.Suffix);
+			if (obj.IsTargetSetted)
+				serializedObj.Add("target", obj.Target);
+			if (obj.IsThousandsSeparatorSetted)
+				serializedObj.Add("thousandsSeparator", obj.ThousandsSeparator);
+		}
+
+		private static void SerializeJqGridColumnElementOptions(JqGridColumnElementOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			if (obj.IsDataUrlSetted)
+				serializedObj.Add("dataUrl", obj.DataUrl);
+
+			if (obj.IsDefaultValueSetted)
+				serializedObj.Add("defaultValue", obj.DefaultValue);
+
+			if (obj.IsValueSetted)
+				serializedObj.Add("value", obj.Value);
+			else if (obj.ValueDictionary != null)
+				serializedObj.Add("value", obj.ValueDictionary);
+		}
+
+		private static JqGridColumnSearchOptions DeserializeJqGridColumnSearchOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridColumnSearchOptions();
+
+			obj.ClearSearch = GetBooleanFromSerializedObj(serializedObj, "clearSearch");
+			if (serializedObj.ContainsKey("dataUrl"))
+				obj.DataUrl = serializedObj["dataUrl"]?.ToString();
+			if (serializedObj.ContainsKey("defaultValue"))
+				obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
+
+			if (serializedObj.ContainsKey("value") && serializedObj["value"] is IDictionary<string, object>)
+				obj.ValueDictionary = ((IDictionary<string, object>)serializedObj["value"]).ToDictionary(k => k.Key, v => v.Value.ToString());
+			else
+				obj.Value = GetStringFromSerializedObj(serializedObj, "value");
+
+			if (serializedObj.ContainsKey("attr") && serializedObj["attr"] is IDictionary<string, object>)
+				obj.HtmlAttributes = (IDictionary<string, object>)serializedObj["attr"];
+
+			obj.SearchHidden = GetBooleanFromSerializedObj(serializedObj, "searchhidden");
+
+			if (serializedObj.ContainsKey("sopt") && serializedObj["sopt"] is ArrayList)
+			{
+				JqGridSearchOperators? searchOperators = null;
+				foreach (var innerSerializedObj in (ArrayList)serializedObj["sopt"])
+				{
+					if (Enum.TryParse(innerSerializedObj.ToString(), true, out JqGridSearchOperators searchOperator))
+					{
+						if (searchOperators.HasValue)
+							searchOperators = searchOperators | searchOperator;
+						else
+							searchOperators = searchOperator;
+					}
+				}
+
+				if (searchOperators.HasValue)
+					obj.SearchOperators = searchOperators.Value;
+			}
+
+			return obj;
+		}
+
+		private static void SerializeJqGridColumnSearchOptions(JqGridColumnSearchOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			SerializeJqGridColumnElementOptions(obj, serializer, serializedObj);
+
+			if (obj.HtmlAttributes != null && obj.HtmlAttributes.Count > 0)
+				serializedObj.Add("attr", obj.HtmlAttributes);
+
+			if (obj.ClearSearch.HasValue)
+				serializedObj.Add("clearSearch", obj.ClearSearch);
+
+			if (obj.SearchHidden.HasValue)
+				serializedObj.Add("searchhidden", obj.SearchHidden);
+
+			if (obj.SearchOperators != JqGridSearchOperators.Default)
+			{
+				var searchOperators = new List<string>();
+				foreach (JqGridSearchOperators searchOperator in Enum.GetValues(typeof(JqGridSearchOperators)))
+				{
+					if (searchOperator != JqGridSearchOperators.EqualOrNotEqual && searchOperator != JqGridSearchOperators.NoTextOperators && searchOperator != JqGridSearchOperators.TextOperators && (obj.SearchOperators & searchOperator) == searchOperator)
+						searchOperators.Add(Enum.GetName(typeof(JqGridSearchOperators), searchOperator).ToLower());
+				}
+				serializedObj.Add("sopt", searchOperators);
+			}
+		}
+
+		private static JqGridSubgridModel DeserializeJqGridSubgridModel(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridSubgridModel();
+
+			if (serializedObj.ContainsKey("name") && serializedObj["name"] is ArrayList)
+			{
+				foreach (var innerSerializedObj in (ArrayList)serializedObj["name"])
+					obj.ColumnsNames.Add(innerSerializedObj.ToString());
+			}
+
+			if (serializedObj.ContainsKey("align") && serializedObj["align"] is ArrayList)
+			{
+				foreach (var innerSerializedObj in (ArrayList)serializedObj["align"])
+				{
+					Enum.TryParse(innerSerializedObj.ToString(), true, out JqGridAlignments alignment);
+					obj.ColumnsAlignments.Add(alignment);
+				}
+			}
+
+			if (serializedObj.ContainsKey("width") && serializedObj["width"] is ArrayList)
+			{
+				foreach (var innerSerializedObj in (ArrayList)serializedObj["width"])
+				{
+					if (innerSerializedObj is int i)
+						obj.ColumnsWidths.Add(i);
+				}
+			}
+
+			return obj;
+		}
+
+		private static void SerializeJqGridSubgridModel(JqGridSubgridModel obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			serializedObj.Add("name", obj.ColumnsNames);
+
+			var alignments = new List<string>();
+			foreach (var alignment in obj.ColumnsAlignments)
+				alignments.Add(alignment.ToString().ToLower());
+			serializedObj.Add("align", alignments);
+
+			serializedObj.Add("width", obj.ColumnsWidths);
+		}
+
+		private static void SerializeJqGridResponse(JqGridResponse obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			var jsonReader = obj.Reader ?? JqGridResponse.JsonReader;
+
+			if (!obj.IsSubgridResponse)
+			{
+				serializedObj.Add(jsonReader.PageIndex, obj.PageIndex + 1);
+				serializedObj.Add(jsonReader.TotalRecordsCount, obj.TotalRecordsCount);
+				serializedObj.Add(jsonReader.TotalPagesCount, obj.TotalPagesCount);
+
+				if (obj.UserData != null)
+					serializedObj.Add(jsonReader.UserData, obj.UserData);
+			}
+
+			serializedObj.Add(obj.IsSubgridResponse ? jsonReader.SubgridReader.Records : jsonReader.Records, SerializeJqGridRecords(obj.Records, obj.IsSubgridResponse, jsonReader));
+		}
+
+		private static List<object> SerializeJqGridRecords(List<JqGridRecord> objs, bool isSubgridResponse, JqGridJsonReader jsonReader)
+		{
+			var isRecordIndexInt = int.TryParse(jsonReader.RecordId, out var recordIdIndex);
+			var isRecordValuesEmpty = string.IsNullOrWhiteSpace(jsonReader.RecordValues);
+			var repeatItems = isSubgridResponse ? jsonReader.SubgridReader.RepeatItems : jsonReader.RepeatItems;
+
+			if (!isSubgridResponse)
+			{
+				if (repeatItems && isRecordValuesEmpty && !isRecordIndexInt)
+					throw new InvalidOperationException("JqGridJsonReader.RecordId must be a number when JqGridJsonReader.RepeatItems is set to true and JqGridJsonReader.RecordValues is set to empty string.");
+
+				if (repeatItems && !isRecordValuesEmpty && isRecordIndexInt)
+					throw new InvalidOperationException("JqGridJsonReader.RecordValues can't be an empty string when JqGridJsonReader.RepeatItems is set to true and JqGridJsonReader.RecordId is a number.");
+			}
+
+			var serializedObjs = new List<object>();
+
+			foreach (var obj in objs)
+			{
+				var adjacencyTreeRecord = obj as JqGridAdjacencyTreeRecord;
+				var nestedSetTreeRecord = obj as JqGridNestedSetTreeRecord;
+				if (repeatItems)
+				{
+					var values = obj.Values;
+
+					if (!isSubgridResponse)
+					{
+						if (adjacencyTreeRecord != null)
+						{
+							values.Add(adjacencyTreeRecord.Level);
+							values.Add(adjacencyTreeRecord.ParentId);
+							values.Add(adjacencyTreeRecord.Leaf);
+							values.Add(adjacencyTreeRecord.Expanded);
+						}
+						else if (nestedSetTreeRecord != null)
+						{
+							values.Add(nestedSetTreeRecord.Level);
+							values.Add(nestedSetTreeRecord.LeftField);
+							values.Add(nestedSetTreeRecord.RightField);
+							values.Add(nestedSetTreeRecord.Leaf);
+							values.Add(nestedSetTreeRecord.Expanded);
+						}
+					}
+
+					if (isRecordValuesEmpty)
+					{
+						if (!isSubgridResponse && Convert.ToString(values[recordIdIndex]) != obj.Id)
+							values.Insert(recordIdIndex, obj.Id);
+						serializedObjs.Add(values);
+					}
+					else
+					{
+						var serializedObj = new Dictionary<string, object>();
+						serializedObj.Add(isSubgridResponse ? jsonReader.SubgridReader.RecordValues : jsonReader.RecordValues, values);
+						if (!isSubgridResponse)
+							serializedObj.Add(jsonReader.RecordId, obj.Id);
+						serializedObjs.Add(serializedObj);
+					}
+				}
+				else
+				{
+					if (obj.Value == null)
+						throw new InvalidOperationException("JqGridRecord.Value can't be null when JqGridJsonReader.RepeatItems is set to false.");
+
+					var serializedObj = obj.GetValuesAsDictionary();
+
+					if (!isSubgridResponse)
+					{
+						if (adjacencyTreeRecord != null)
+						{
+							serializedObj.Add("level", adjacencyTreeRecord.Level);
+							serializedObj.Add("parent", adjacencyTreeRecord.ParentId);
+							serializedObj.Add("isLeaf", adjacencyTreeRecord.Leaf);
+							serializedObj.Add("expanded", adjacencyTreeRecord.Expanded);
+						}
+						else if (nestedSetTreeRecord != null)
+						{
+							serializedObj.Add("level", nestedSetTreeRecord.Level);
+							serializedObj.Add("lft", nestedSetTreeRecord.LeftField);
+							serializedObj.Add("rgt", nestedSetTreeRecord.RightField);
+							serializedObj.Add("isLeaf", nestedSetTreeRecord.Leaf);
+							serializedObj.Add("expanded", nestedSetTreeRecord.Expanded);
+						}
+					}
+
+					if (!isSubgridResponse && !isRecordIndexInt && !serializedObj.ContainsKey(jsonReader.RecordId))
+						serializedObj.Add(jsonReader.RecordId, obj.Id);
+
+					serializedObjs.Add(serializedObj);
+				}
+			}
+
+			return serializedObjs;
+		}
+
+		private static JqGridRequestSearchingFilters DeserializeJqGridRequestSearchingFilters(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridRequestSearchingFilters();
+
+			obj.GroupingOperator = GetEnumFromSerializedObj<JqGridSearchGroupingOperators>(serializedObj, "groupOp", JqGridSearchGroupingOperators.And);
+			if (serializedObj.ContainsKey("rules") && serializedObj["rules"] is ArrayList)
+			{
+				foreach (var innerSerializedObj in (ArrayList)serializedObj["rules"])
+				{
+					if (innerSerializedObj is IDictionary<string, object>)
+					{
+						var searchingFilter = DeserializeJqGridRequestSearchingFilter((IDictionary<string, object>)innerSerializedObj, serializer);
+						obj.Filters.Add(searchingFilter);
+					}
+				}
+			}
+			if (serializedObj.ContainsKey("groups") && serializedObj["groups"] is ArrayList)
+			{
+				foreach (var innerSerializedObj in (ArrayList)serializedObj["groups"])
+				{
+					if (innerSerializedObj is IDictionary<string, object>)
+					{
+						var searchingFilters = DeserializeJqGridRequestSearchingFilters((IDictionary<string, object>)innerSerializedObj, serializer);
+						obj.Groups.Add(searchingFilters);
+					}
+				}
+			}
+
+			return obj;
+		}
+
+		private static void SerializeJqGridRequestSearchingFilters(JqGridRequestSearchingFilters obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			serializedObj.Add("groupOp", obj.GroupingOperator.ToString().ToUpper());
+
+			if (obj.Filters != null && obj.Filters.Count > 0)
+				serializedObj.Add("rules", obj.Filters);
+
+			if (obj.Groups != null && obj.Groups.Count > 0)
+				serializedObj.Add("groups", obj.Groups);
+		}
+
+		private static JqGridRequestSearchingFilter DeserializeJqGridRequestSearchingFilter(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+		{
+			var obj = new JqGridRequestSearchingFilter();
+
+			obj.SearchingName = GetStringFromSerializedObj(serializedObj, "field");
+			obj.SearchingOperator = GetEnumFromSerializedObj(serializedObj, "op", JqGridSearchOperators.Eq);
+			obj.SearchingValue = GetStringFromSerializedObj(serializedObj, "data");
+			return obj;
+		}
+
+		private static void SerializeJqGridRequestSearchingFilter(JqGridRequestSearchingFilter obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+		{
+			serializedObj.Add("field", obj.SearchingName);
+			serializedObj.Add("op", obj.SearchingOperator.ToString().ToLower());
+			serializedObj.Add("data", obj.SearchingValue);
+		}
+
+		private static bool? GetBooleanFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is bool)
+				return (bool)serializedObj[key];
+			return null;
+		}
+
+		private static bool GetBooleanFromSerializedObj(IDictionary<string, object> serializedObj, string key, bool defaultValue)
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is bool)
+				return (bool)serializedObj[key];
+			return defaultValue;
+		}
+
+		private static double? GetDoubleFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && double.TryParse(serializedObj[key].ToString(), out var value))
+				return value;
+			return null;
+		}
+
+		private static TEnum? GetEnumFromSerializedObj<TEnum>(IDictionary<string, object> serializedObj, string key) where TEnum : struct
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Enum.TryParse<TEnum>(serializedObj[key].ToString(), true, out var value))
+				return value;
+			return null;
+		}
+
+		private static TEnum GetEnumFromSerializedObj<TEnum>(IDictionary<string, object> serializedObj, string key, TEnum defaultValue) where TEnum : struct
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Enum.TryParse(serializedObj[key].ToString(), true, out TEnum value))
+				return value;
+			return defaultValue;
+		}
+
+		private static int? GetInt32FromSerializedObj(IDictionary<string, object> serializedObj, string key)
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is int)
+				return (int)serializedObj[key];
+			return null;
+		}
+
+		private static int GetInt32FromSerializedObj(IDictionary<string, object> serializedObj, string key, int defaultValue)
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is int)
+				return (int)serializedObj[key];
+			return defaultValue;
+		}
+
+		private static List<int> GetInt32ArrayFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+		{
+			List<int> array = null;
+
+			if (serializedObj.ContainsKey(key) && serializedObj[key] is ArrayList)
+			{
+				array = new List<int>();
+				var serializedArray = (ArrayList)serializedObj[key];
+				foreach (var serializedItem in serializedArray)
+				{
+					if (serializedItem is int i)
+						array.Add(i);
+				}
+			}
+
+			return array;
+		}
+
+		private static string GetStringFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
+				return serializedObj[key].ToString();
+			return null;
+		}
+
+		private static string GetStringFromSerializedObj(IDictionary<string, object> serializedObj, string key, string defaultValue)
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
+				return serializedObj[key].ToString();
+			return defaultValue;
+		}
+
+		private static SettedString GetSettedStringFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+		{
+			if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
+				return new SettedString(true, serializedObj[key].ToString());
+			return new SettedString(false, null);
+		}
+		#endregion
+	}
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/Serialization/JqGridScriptConverter.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/Serialization/JqGridScriptConverter.cs
@@ -8,1410 +8,1410 @@ using Lib.Web.Mvc.JQuery.JqGrid.Constants;
 
 namespace Lib.Web.Mvc.JQuery.JqGrid.Serialization
 {
-	internal class JqGridScriptConverter : JavaScriptConverter
-	{
-		#region Fields
-		private static ReadOnlyCollection<Type> _supportedTypes = new ReadOnlyCollection<Type>(new List<Type>()
-		{
-			typeof(JqGridOptions),
-			typeof(JqGridColumnModel),
-			typeof(JqGridJsonReader),
-			typeof(JqGridParametersNames),
-			typeof(JqGridGroupingView),
-			typeof(JqGridColumnEditOptions),
-			typeof(JqGridColumnRules),
-			typeof(JqGridColumnFormOptions),
-			typeof(JqGridColumnFormatterOptions),
-			typeof(JqGridColumnSearchOptions),
-			typeof(JqGridSubgridModel),
-			typeof(JqGridResponse),
-			typeof(JqGridRequestSearchingFilters),
-			typeof(JqGridRequestSearchingFilter)
-		});
-		#endregion
-
-		#region JavaScriptConverter Members
-		public override object Deserialize(IDictionary<string, object> dictionary, Type type, JavaScriptSerializer serializer)
-		{
-			object obj = null;
-
-			if (dictionary != null)
-			{
-				if (type == typeof(JqGridOptions))
-					obj = DeserializeJqGridOptions(dictionary, serializer);
-				else if (type == typeof(JqGridColumnModel))
-					obj = DeserializeJqGridColumnModel(dictionary, serializer);
-				else if (type == typeof(JqGridJsonReader))
-					obj = DeserializeJqGridJsonReader(dictionary, serializer);
-				else if (type == typeof(JqGridParametersNames))
-					obj = DeserializeJqGridParametersNames(dictionary, serializer);
-				else if (type == typeof(JqGridGroupingView))
-					obj = DeserializeJqGridGroupingView(dictionary, serializer);
-				else if (type == typeof(JqGridColumnEditOptions))
-					obj = DeserializeJqGridColumnEditOptions(dictionary, serializer);
-				else if (type == typeof(JqGridColumnRules))
-					obj = DeserializeJqGridColumnRules(dictionary, serializer);
-				else if (type == typeof(JqGridColumnFormOptions))
-					obj = DeserializeJqGridColumnFormOptions(dictionary, serializer);
-				else if (type == typeof(JqGridColumnFormatterOptions))
-					obj = DeserializeJqGridColumnFormatterOptions(dictionary, serializer);
-				else if (type == typeof(JqGridColumnSearchOptions))
-					obj = DeserializeJqGridColumnSearchOptions(dictionary, serializer);
-				else if (type == typeof(JqGridSubgridModel))
-					obj = DeserializeJqGridSubgridModel(dictionary, serializer);
-				else if (type == typeof(JqGridRequestSearchingFilters))
-					obj = DeserializeJqGridRequestSearchingFilters(dictionary, serializer);
-				else if (type == typeof(JqGridRequestSearchingFilter))
-					obj = DeserializeJqGridRequestSearchingFilter(dictionary, serializer);
-			}
-
-			return obj;
-		}
-
-		public override IDictionary<string, object> Serialize(object obj, JavaScriptSerializer serializer)
-		{
-			var serializedObj = new Dictionary<string, object>();
-
-			if (obj != null)
-			{
-				if (obj is JqGridOptions)
-					SerializeJqGridOptions((JqGridOptions)obj, serializer, serializedObj);
-				else if (obj is JqGridColumnModel)
-					SerializeJqGridColumnModel((JqGridColumnModel)obj, serializer, serializedObj);
-				else if (obj is JqGridJsonReader)
-					SerializeJqGridJsonReader((JqGridJsonReader)obj, serializer, serializedObj);
-				else if (obj is JqGridParametersNames)
-					SerializeJqGridParametersNames((JqGridParametersNames)obj, serializer, serializedObj);
-				else if (obj is JqGridGroupingView)
-					SerializeJqGridGroupingView((JqGridGroupingView)obj, serializer, serializedObj);
-				else if (obj is JqGridColumnEditOptions)
-					SerializeJqGridColumnEditOptions((JqGridColumnEditOptions)obj, serializer, serializedObj);
-				else if (obj is JqGridColumnRules)
-					SerializeJqGridColumnRules((JqGridColumnRules)obj, serializer, serializedObj);
-				else if (obj is JqGridColumnFormatterOptions)
-					SerializeJqGridColumnFormatterOptions((JqGridColumnFormatterOptions)obj, serializer, serializedObj);
-				else if (obj is JqGridColumnFormOptions)
-					SerializeJqGridColumnFormOptions((JqGridColumnFormOptions)obj, serializer, serializedObj);
-				else if (obj is JqGridColumnSearchOptions)
-					SerializeJqGridColumnSearchOptions((JqGridColumnSearchOptions)obj, serializer, serializedObj);
-				else if (obj is JqGridSubgridModel)
-					SerializeJqGridSubgridModel((JqGridSubgridModel)obj, serializer, serializedObj);
-				else if (obj is JqGridResponse)
-					SerializeJqGridResponse((JqGridResponse)obj, serializer, serializedObj);
-				else if (obj is JqGridRequestSearchingFilters)
-					SerializeJqGridRequestSearchingFilters((JqGridRequestSearchingFilters)obj, serializer, serializedObj);
-				else if (obj is JqGridRequestSearchingFilter)
-					SerializeJqGridRequestSearchingFilter((JqGridRequestSearchingFilter)obj, serializer, serializedObj);
-			}
-
-			return serializedObj;
-		}
-
-		public override IEnumerable<Type> SupportedTypes => _supportedTypes;
-
-		#endregion
-
-		#region Methods
-		private static JqGridOptions DeserializeJqGridOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var id = GetStringFromSerializedObj(serializedObj, "id");
-			if (!string.IsNullOrWhiteSpace(id))
-			{
-				var obj = new JqGridOptions(id);
-				if (serializedObj.ContainsKey("altclass"))
-					obj.AltClass = serializedObj["altclass"]?.ToString();
-				obj.AltRows = GetBooleanFromSerializedObj(serializedObj, "altRows");
-				obj.AutoEncode = GetBooleanFromSerializedObj(serializedObj, "autoencode");
-				obj.AutoWidth = GetBooleanFromSerializedObj(serializedObj, "autowidth");
-				if (serializedObj.ContainsKey("caption"))
-					obj.Caption = serializedObj["caption"]?.ToString();
-				obj.CellLayout = GetInt32FromSerializedObj(serializedObj, "cellLayout");
-				obj.CellEditingEnabled = GetBooleanFromSerializedObj(serializedObj, "cellEdit");
-				obj.CellEditingSubmitMode = GetEnumFromSerializedObj(serializedObj, "cellsubmit", JqGridCellEditingSubmitModes.Default);
-				if (serializedObj.ContainsKey("cellurl"))
-					obj.CellEditingUrl = serializedObj["cellurl"]?.ToString();
-
-				if (serializedObj.ContainsKey("colModel") && serializedObj["colModel"] is ArrayList)
-				{
-					foreach (var innerSerializedObj in (ArrayList)serializedObj["colModel"])
-					{
-						if (innerSerializedObj is IDictionary<string, object>)
-						{
-							var columnModel = DeserializeJqGridColumnModel((IDictionary<string, object>)innerSerializedObj, serializer);
-							if (columnModel != null)
-								obj.ColumnsModels.Add(columnModel);
-						}
-					}
-				}
-
-				if (serializedObj.ContainsKey("colNames") && serializedObj["colNames"] is ArrayList)
-				{
-					foreach (var innerSerializedObj in (ArrayList)serializedObj["colNames"])
-						obj.ColumnsNames.Add(innerSerializedObj.ToString());
-				}
-
-				if (serializedObj.ContainsKey("datastr"))
-					obj.DataString = serializedObj["datastr"]?.ToString();
-				obj.DataType = GetEnumFromSerializedObj(serializedObj, "datatype", JqGridDataTypes.Default);
-				obj.DeepEmpty = GetBooleanFromSerializedObj(serializedObj, "deepempty");
-				obj.Direction = GetEnumFromSerializedObj(serializedObj, "direction", JqGridLanguageDirections.Default);
-				obj.DynamicScrollingMode = JqGridDynamicScrollingModes.Default;
-				if (serializedObj.ContainsKey("scroll") && serializedObj["scroll"] != null)
-				{
-					if (serializedObj["scroll"] is bool b && b)
-						obj.DynamicScrollingMode = JqGridDynamicScrollingModes.HoldAllRows;
-					else if (serializedObj["scroll"] is int)
-						obj.DynamicScrollingMode = JqGridDynamicScrollingModes.HoldVisibleRows;
-				}
-
-				obj.DynamicScrollingTimeout = GetInt32FromSerializedObj(serializedObj, "scrollTimeout");
-				if (serializedObj.ContainsKey("editurl"))
-					obj.EditingUrl = serializedObj["editurl"]?.ToString();
-				if (serializedObj.ContainsKey("emptyrecords"))
-					obj.EmptyRecords = serializedObj["emptyrecords"]?.ToString();
-				obj.ExpandColumnClick = GetBooleanFromSerializedObj(serializedObj, "ExpandColClick");
-				if (serializedObj.ContainsKey("ExpandColumn"))
-					obj.ExpandColumn = serializedObj["ExpandColumn"]?.ToString();
-				obj.FooterEnabled = GetBooleanFromSerializedObj(serializedObj, "footerrow");
-				obj.UserDataOnFooter = GetBooleanFromSerializedObj(serializedObj, "userDataOnFooter");
-				obj.GridView = GetBooleanFromSerializedObj(serializedObj, "gridview");
-
-				obj.GroupingEnabled = GetBooleanFromSerializedObj(serializedObj, "grouping");
-				if (serializedObj.ContainsKey("groupingView") && serializedObj["groupingView"] is IDictionary<string, object>)
-					obj.GroupingView = DeserializeJqGridGroupingView((IDictionary<string, object>)serializedObj["groupingView"], serializer);
-
-				obj.Height = GetInt32FromSerializedObj(serializedObj, "height");
-				obj.Hidden = GetBooleanFromSerializedObj(serializedObj, "hiddengrid");
-				obj.HiddenEnabled = GetBooleanFromSerializedObj(serializedObj, "hidegrid");
-				obj.HoverRows = GetBooleanFromSerializedObj(serializedObj, "hoverrows");
-				obj.IgnoreCase = GetBooleanFromSerializedObj(serializedObj, "ignoreCase");
-				obj.LoadOnce = GetBooleanFromSerializedObj(serializedObj, "loadonce");
-				obj.MethodType = GetEnumFromSerializedObj(serializedObj, "mtype", JqGridMethodTypes.Default);
-				obj.MultiKey = GetEnumFromSerializedObj(serializedObj, "multikey", JqGridMultiKeys.Default);
-				obj.MultiBoxOnly = GetBooleanFromSerializedObj(serializedObj, "multiboxonly");
-				obj.MultiSelect = GetBooleanFromSerializedObj(serializedObj, "multiselect");
-				obj.MultiSelectWidth = GetInt32FromSerializedObj(serializedObj, "multiselectWidth");
-				obj.MultiSort = GetBooleanFromSerializedObj(serializedObj, "multiSort");
-
-				if (serializedObj.ContainsKey("pager") && serializedObj["pager"] != null)
-					obj.Pager = true;
-
-				if (serializedObj.ContainsKey("jsonReader") && serializedObj["jsonReader"] is IDictionary<string, object>)
-					obj.JsonReader = DeserializeJqGridJsonReader((IDictionary<string, object>)serializedObj["jsonReader"], serializer);
-				else
-					obj.JsonReader = JqGridResponse.JsonReader;
-
-				if (serializedObj.ContainsKey("prmNames") && serializedObj["prmNames"] is IDictionary<string, object>)
-					obj.ParametersNames = DeserializeJqGridParametersNames((IDictionary<string, object>)serializedObj["prmNames"], serializer);
-				else
-					obj.ParametersNames = JqGridRequest.ParameterNames;
-
-				obj.ColumnsRemaping = GetInt32ArrayFromSerializedObj(serializedObj, "remapColumns");
-				obj.RowsList = GetInt32ArrayFromSerializedObj(serializedObj, "rowList");
-				obj.RowsNumber = GetInt32FromSerializedObj(serializedObj, "rowNum");
-				obj.RowsNumbers = GetBooleanFromSerializedObj(serializedObj, "rownumbers");
-				obj.RowsNumbersWidth = GetInt32FromSerializedObj(serializedObj, "rownumWidth");
-				obj.ShrinkToFit = GetBooleanFromSerializedObj(serializedObj, "shrinkToFit");
-				obj.ScrollOffset = GetInt32FromSerializedObj(serializedObj, "scrollOffset");
-				obj.Sortable = GetBooleanFromSerializedObj(serializedObj, "sortable");
-				if (serializedObj.ContainsKey("sortname"))
-					obj.SortingName = serializedObj["sortname"]?.ToString();
-				obj.SortingOrder = GetEnumFromSerializedObj(serializedObj, "sortorder", JqGridSortingOrders.Default);
-				obj.StyleUI = GetEnumFromSerializedObj(serializedObj, "styleUI", JqGridStyleUIOptions.Default);
-				obj.SubgridEnabled = GetBooleanFromSerializedObj(serializedObj, "subGrid");
-
-				if (serializedObj.ContainsKey("subGridModel") && serializedObj["subGridModel"] is IDictionary<string, object>)
-					obj.SubgridModel = DeserializeJqGridSubgridModel((IDictionary<string, object>)serializedObj["subGridModel"], serializer);
-
-				if (serializedObj.ContainsKey("subGridUrl"))
-					obj.SubgridUrl = serializedObj["subGridUrl"]?.ToString();
-				obj.SubgridColumnWidth = GetInt32FromSerializedObj(serializedObj, "subGridWidth");
-				obj.TopPager = GetBooleanFromSerializedObj(serializedObj, "toppager");
-				obj.TreeGridEnabled = GetBooleanFromSerializedObj(serializedObj, "treeGrid");
-				obj.TreeGridModel = GetEnumFromSerializedObj(serializedObj, "treeGridModel", JqGridTreeGridModels.Default);
-				if (serializedObj.ContainsKey("url"))
-					obj.Url = serializedObj["url"]?.ToString();
-				obj.ViewRecords = GetBooleanFromSerializedObj(serializedObj, "viewrecords");
-				obj.Width = GetInt32FromSerializedObj(serializedObj, "width");
-
-				return obj;
-			}
-			return null;
-		}
-
-		private static void SerializeJqGridOptions(JqGridOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			serializedObj.Add("id", obj.Id);
-
-			if (obj.IsAltClassSetted)
-				serializedObj.Add("altclass", obj.AltClass);
-
-			if (obj.AltRows.HasValue)
-				serializedObj.Add("altRows", obj.AltRows.Value);
-
-			if (obj.AutoEncode.HasValue)
-				serializedObj.Add("autoencode", obj.AutoEncode.Value);
-
-			if (obj.AutoWidth.HasValue)
-				serializedObj.Add("autowidth", obj.AutoWidth.Value);
-
-			if (obj.CellLayout.HasValue)
-				serializedObj.Add("cellLayout", obj.CellLayout.Value);
-
-			if (obj.CellEditingEnabled.HasValue)
-				serializedObj.Add("cellEdit", obj.CellEditingEnabled.Value);
-
-			if (obj.CellEditingSubmitMode != JqGridCellEditingSubmitModes.Default)
-				serializedObj.Add("cellsubmit", obj.CellEditingSubmitMode);
-
-			if (obj.IsCellEditingUrlSetted)
-				serializedObj.Add("cellurl", obj.CellEditingUrl);
-
-			serializedObj.Add("colModel", obj.ColumnsModels);
-			serializedObj.Add("colNames", obj.ColumnsNames);
-
-			if (obj.IsCaptionSetted)
-				serializedObj.Add("caption", obj.Caption);
-
-			if (obj.HiddenEnabled.HasValue)
-				serializedObj.Add("hidegrid", obj.HiddenEnabled.Value);
-
-			if (obj.Hidden.HasValue)
-				serializedObj.Add("hiddengrid", obj.Hidden.Value);
-
-			if (obj.IsUsedDataString)
-				serializedObj.Add("datastr", obj.DataString);
-			else
-				serializedObj.Add("url", obj.Url);
-
-			if (obj.DataType != JqGridDataTypes.Default)
-				serializedObj.Add("datatype", obj.DataType.ToString().ToLower());
-
-			if (obj.DeepEmpty.HasValue)
-				serializedObj.Add("deepempty", obj.DeepEmpty.Value);
-
-			if (obj.Direction != JqGridLanguageDirections.Default)
-				serializedObj.Add("direction", obj.Direction.ToString().ToLower());
-
-			if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.Disabled)
-				serializedObj.Add("scroll", false);
-			if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldAllRows)
-				serializedObj.Add("scroll", true);
-			else if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldVisibleRows)
-				serializedObj.Add("scroll", 10);
-
-			if (obj.DynamicScrollingTimeout.HasValue)
-				serializedObj.Add("scrollTimeout", obj.DynamicScrollingTimeout);
-
-			if (obj.IsEmptyRecordsSetted)
-				serializedObj.Add("emptyrecords", obj.EmptyRecords);
-
-			if (obj.IsEditingUrlSetted)
-				serializedObj.Add("editurl", obj.EditingUrl);
-
-			if (obj.FooterEnabled.HasValue)
-			{
-				serializedObj.Add("footerrow", obj.FooterEnabled.Value);
-				if (obj.FooterEnabled.Value && obj.UserDataOnFooter.HasValue)
-					serializedObj.Add("userDataOnFooter", obj.UserDataOnFooter.Value);
-			}
-
-			if (obj.GridView.HasValue)
-				serializedObj.Add("gridview", obj.GridView.Value);
-
-			if (obj.GroupingEnabled.HasValue)
-			{
-				serializedObj.Add("grouping", obj.GroupingEnabled.Value);
-
-				if (obj.GroupingEnabled.Value && obj.GroupingView != null)
-					serializedObj.Add("groupingView", obj.GroupingView);
-			}
-
-			if (obj.Height.HasValue)
-				serializedObj.Add("height", obj.Height.Value);
-			else
-				serializedObj.Add("height", "100%");
-
-			if (obj.HoverRows.HasValue)
-				serializedObj.Add("hoverrows", obj.HoverRows.Value);
-
-			if (obj.IgnoreCase.HasValue)
-				serializedObj.Add("ignoreCase", obj.IgnoreCase.Value);
-
-			if (obj.LoadOnce.HasValue)
-				serializedObj.Add("loadonce", obj.LoadOnce.Value);
-
-			if (obj.MethodType != JqGridMethodTypes.Default)
-				serializedObj.Add("mtype", obj.MethodType.ToString().ToUpper());
-
-			if (obj.MultiKey != JqGridMultiKeys.Default)
-				if (obj.MultiKey == JqGridMultiKeys.Disable)
-					serializedObj.Add("multikey", null);
-				else
-					serializedObj.Add("multikey", $"{obj.MultiKey.ToString().ToLower()}Key");
-
-			if (obj.MultiBoxOnly.HasValue)
-				serializedObj.Add("multiboxonly", obj.MultiBoxOnly.Value);
-
-			if (obj.MultiSelect.HasValue)
-				serializedObj.Add("multiselect", obj.MultiSelect.Value);
-
-			if (obj.MultiSelectWidth.HasValue)
-				serializedObj.Add("multiselectWidth", obj.MultiSelectWidth.Value);
-
-			if (obj.MultiSort.HasValue)
-				serializedObj.Add("multiSort", obj.MultiSort.Value);
-
-			if (obj.Pager)
-				serializedObj.Add("pager", $"#{obj.Id}Pager");
-
-			if (obj.JsonReader != null && !obj.JsonReader.IsGlobal)
-				serializedObj.Add("jsonReader", obj.JsonReader);
-
-			if (obj.ParametersNames != null && !obj.ParametersNames.IsGlobal)
-				serializedObj.Add("prmNames", obj.ParametersNames);
-
-			serializedObj.Add("remapColumns", obj.ColumnsRemaping);
-
-			if (obj.RowsList != null && obj.RowsList.Any())
-				serializedObj.Add("rowList", obj.RowsList);
-
-			if (obj.RowsNumber.HasValue)
-				serializedObj.Add("rowNum", obj.RowsNumber.Value);
-
-			if (obj.RowsNumbers.HasValue)
-				serializedObj.Add("rownumbers", obj.RowsNumbers.Value);
-
-			if (obj.RowsNumbersWidth.HasValue)
-				serializedObj.Add("rownumWidth", obj.RowsNumbersWidth.Value);
-
-			if (obj.ShrinkToFit.HasValue)
-				serializedObj.Add("shrinkToFit", obj.ShrinkToFit.Value);
-
-			if (obj.ScrollOffset.HasValue)
-				serializedObj.Add("scrollOffset", obj.ScrollOffset.Value);
-
-			if (obj.Sortable.HasValue)
-				serializedObj.Add("sortable", obj.Sortable.Value);
-
-			if (obj.IsSortingNameSetted)
-				serializedObj.Add("sortname", obj.SortingName);
-
-			if (obj.SortingOrder != JqGridSortingOrders.Default)
-				serializedObj.Add("sortorder", obj.SortingOrder.ToString().ToLower());
-
-			if (obj.StyleUI != JqGridStyleUIOptions.Default)
-				serializedObj.Add("styleUI", obj.StyleUI.ToString());
-
-			if (obj.SubgridEnabled.HasValue)
-			{
-				serializedObj.Add("subGrid", obj.SubgridEnabled.Value);
-
-				if (obj.SubgridEnabled.Value)
-				{
-					if (obj.SubgridModel != null)
-						serializedObj.Add("subGridModel", obj.SubgridModel);
-
-					if (obj.IsSubgridUrlSetted)
-						serializedObj.Add("subGridUrl", obj.SubgridUrl);
-
-					if (obj.SubgridColumnWidth.HasValue)
-						serializedObj.Add("subGridWidth", obj.SubgridColumnWidth.Value);
-				}
-			}
-
-			if (obj.TopPager.HasValue)
-				serializedObj.Add("toppager", obj.TopPager.Value);
-
-			if (obj.TreeGridEnabled.HasValue)
-			{
-				serializedObj.Add("treeGrid", obj.TreeGridEnabled.Value);
-
-				if (obj.TreeGridEnabled.Value)
-				{
-					if (obj.TreeGridModel != JqGridTreeGridModels.Default)
-						serializedObj.Add("treeGridModel", obj.TreeGridModel.ToString().ToLower());
-
-					if (obj.ExpandColumnClick.HasValue)
-						serializedObj.Add("ExpandColClick", obj.ExpandColumnClick);
-
-					if (obj.IsExpandColumnSetted)
-						serializedObj.Add("ExpandColumn", obj.ExpandColumn);
-				}
-			}
-
-			if (obj.ViewRecords.HasValue)
-				serializedObj.Add("viewrecords", obj.ViewRecords.Value);
-
-			if (obj.Width.HasValue)
-				serializedObj.Add("width", obj.Width.Value);
-		}
-
-		private static JqGridColumnModel DeserializeJqGridColumnModel(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var name = GetStringFromSerializedObj(serializedObj, "name");
-			if (!string.IsNullOrWhiteSpace(name))
-			{
-				var obj = new JqGridColumnModel(name);
-
-				obj.Alignment = GetEnumFromSerializedObj(serializedObj, "align", obj.Alignment);
-				obj.DateFormat = GetSettedStringFromSerializedObj(serializedObj, "datefmt");
-				obj.Classes = GetSettedStringFromSerializedObj(serializedObj, "classes");
-				obj.Editable = GetBooleanFromSerializedObj(serializedObj, "editable");
-				obj.EditType = GetEnumFromSerializedObj(serializedObj, "edittype", JqGridColumnEditTypes.Default);
-
-				if (serializedObj.ContainsKey("editoptions") && serializedObj["editoptions"] is IDictionary<string, object>)
-					obj.EditOptions = DeserializeJqGridColumnEditOptions((IDictionary<string, object>)serializedObj["editoptions"], serializer);
-
-				if (serializedObj.ContainsKey("editrules") && serializedObj["editrules"] is IDictionary<string, object>)
-					obj.EditRules = DeserializeJqGridColumnRules((IDictionary<string, object>)serializedObj["editrules"], serializer);
-
-				obj.Fixed = GetBooleanFromSerializedObj(serializedObj, "fixed");
-				obj.Frozen = GetBooleanFromSerializedObj(serializedObj, "frozen");
-				obj.Hidden = GetBooleanFromSerializedObj(serializedObj, "hidden");
-				obj.HideInDialog = GetBooleanFromSerializedObj(serializedObj, "hidedlg");
-
-				obj.Formatter = GetSettedStringFromSerializedObj(serializedObj, "formatter");
-				if (obj.Formatter?.IsSetted ?? false)
-					obj.Formatter.Value = '\'' + obj.Formatter.Value + '\'';
-
-				if (serializedObj.ContainsKey("formatoptions") && serializedObj["formatoptions"] is IDictionary<string, object>)
-					obj.FormatterOptions = DeserializeJqGridColumnFormatterOptions((IDictionary<string, object>)serializedObj["formatoptions"], serializer);
-				//obj.UnFormatter = GetStringFromSerializedObj(serializedObj, "unformat");
-
-				if (serializedObj.ContainsKey("formoptions") && serializedObj["formoptions"] is IDictionary<string, object>)
-					obj.FormOptions = DeserializeJqGridColumnFormOptions((IDictionary<string, object>)serializedObj["formoptions"], serializer);
-
-				obj.InitialSortingOrder = GetEnumFromSerializedObj(serializedObj, "firstsortorder", JqGridSortingOrders.Default);
-				obj.JsonMapping = GetStringFromSerializedObj(serializedObj, "jsonmap");
-				obj.Key = GetBooleanFromSerializedObj(serializedObj, "key");
-				obj.Resizable = GetBooleanFromSerializedObj(serializedObj, "resizable");
-				obj.SummaryType = GetEnumFromSerializedObj<JqGridColumnSummaryTypes>(serializedObj, "summaryType");
-				if (!obj.SummaryType.HasValue)
-				{
-					obj.SummaryFunction = GetStringFromSerializedObj(serializedObj, "summaryType");
-					if (!string.IsNullOrWhiteSpace(obj.SummaryFunction))
-						obj.SummaryType = JqGridColumnSummaryTypes.Custom;
-				}
-
-				obj.SummaryTemplate = GetSettedStringFromSerializedObj(serializedObj, "summaryTpl");
-				obj.Sortable = GetBooleanFromSerializedObj(serializedObj, "sortable");
-				obj.SortType = GetEnumFromSerializedObj(serializedObj, "sorttype", JqGridColumnSortTypes.Default);
-				obj.Index = GetSettedStringFromSerializedObj(serializedObj, "index");
-				obj.Searchable = GetBooleanFromSerializedObj(serializedObj, "search");
-				obj.SearchType = GetEnumFromSerializedObj(serializedObj, "stype", JqGridColumnSearchTypes.Default);
-
-				if (serializedObj.ContainsKey("searchoptions") && serializedObj["searchoptions"] is IDictionary<string, object>)
-					obj.SearchOptions = DeserializeJqGridColumnSearchOptions((IDictionary<string, object>)serializedObj["searchoptions"], serializer);
-
-				if (serializedObj.ContainsKey("searchrules") && serializedObj["searchrules"] is IDictionary<string, object>)
-					obj.SearchRules = DeserializeJqGridColumnRules((IDictionary<string, object>)serializedObj["searchrules"], serializer);
-
-				obj.Title = GetBooleanFromSerializedObj(serializedObj, "title");
-				obj.Width = GetInt32FromSerializedObj(serializedObj, "width");
-				obj.Viewable = GetBooleanFromSerializedObj(serializedObj, "viewable");
-				obj.XmlMapping = GetStringFromSerializedObj(serializedObj, "xmlmap");
-
-				return obj;
-			}
-			return null;
-		}
-
-		private static void SerializeJqGridColumnModel(JqGridColumnModel obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.Alignment != JqGridAlignments.Default)
-				serializedObj.Add("align", obj.Alignment.ToString().ToLower());
-
-			if (obj.Classes?.IsSetted ?? false)
-				serializedObj.Add("classes", obj.Classes);
-
-			if (obj.DateFormat?.IsSetted ?? false)
-				serializedObj.Add("datefmt", obj.DateFormat);
-
-			if (obj.Editable.HasValue)
-			{
-				serializedObj.Add("editable", obj.Editable.Value);
-				if (obj.Editable.Value)
-				{
-					if (obj.EditType != JqGridColumnEditTypes.Default)
-						serializedObj.Add("edittype", obj.EditType.ToString().ToLower());
-
-					if (obj.EditOptions != null)
-						serializedObj.Add("editoptions", obj.EditOptions);
-
-					if (obj.EditRules != null)
-						serializedObj.Add("editrules", obj.EditRules);
-
-					if (obj.FormOptions != null)
-						serializedObj.Add("formoptions", obj.FormOptions);
-				}
-			}
-
-			if (obj.Fixed.HasValue)
-				serializedObj.Add("fixed", obj.Fixed.Value);
-
-			if (obj.Frozen.HasValue)
-				serializedObj.Add("frozen", obj.Frozen.Value);
-
-			if (obj.InitialSortingOrder != JqGridSortingOrders.Default)
-				serializedObj.Add("firstsortorder", obj.InitialSortingOrder.ToString().ToLower());
-
-			if ((obj.Formatter?.IsSetted ?? false) && obj.Formatter.Value[0] == '\'' && obj.Formatter.Value[obj.Formatter.Value.Length - 1] == '\'')
-			{
-				serializedObj.Add("formatter", obj.Formatter.Value.Substring(1, obj.Formatter.Value.Length - 2));
-
-				if (obj.FormatterOptions != null)
-					serializedObj.Add("formatoptions", obj.FormatterOptions);
-			}
-
-			//if (!String.IsNullOrWhiteSpace(obj.UnFormatter))
-			//    serializedObj.Add("unformat", obj.UnFormatter);
-
-			if (obj.Hidden.HasValue)
-				serializedObj.Add("hidden", obj.Hidden.Value);
-
-			if (obj.HideInDialog.HasValue)
-				serializedObj.Add("hidedlg", obj.HideInDialog.Value);
-
-			if (!string.IsNullOrWhiteSpace(obj.JsonMapping))
-				serializedObj.Add("jsonmap", obj.JsonMapping);
-
-			if (obj.Key.HasValue)
-				serializedObj.Add("key", obj.Key.Value);
-
-			if (obj.Resizable.HasValue)
-				serializedObj.Add("resizable", obj.Resizable.Value);
-
-			if (obj.SummaryType.HasValue)
-			{
-				if (obj.SummaryType.Value != JqGridColumnSummaryTypes.Custom)
-					serializedObj.Add("summaryType", obj.SummaryType.Value.ToString().ToLower());
-				else
-					serializedObj.Add("summaryType", obj.SummaryFunction);
-			}
-
-			if (obj.SummaryTemplate?.IsSetted ?? false)
-				serializedObj.Add("summaryTpl", obj.SummaryTemplate.Value);
-
-			if (obj.Sortable.HasValue)
-				serializedObj.Add("sortable", obj.Sortable.Value);
-
-			if (obj.SortType != JqGridColumnSortTypes.Default && obj.SortType != JqGridColumnSortTypes.Function)
-				serializedObj.Add("sorttype", obj.SortType.ToString().ToLower());
-
-			if (obj.Index?.IsSetted ?? false)
-				serializedObj.Add("index", obj.Index.Value);
-
-			if (obj.Searchable.HasValue)
-			{
-				serializedObj.Add("search", obj.Searchable.Value);
-				if (obj.Searchable.Value)
-				{
-					if (obj.SearchType != JqGridColumnSearchTypes.Default)
-						serializedObj.Add("stype", obj.SearchType.ToString().ToLower());
-
-					if (obj.SearchOptions != null)
-						serializedObj.Add("searchoptions", obj.SearchOptions);
-
-					if (obj.SearchRules != null)
-						serializedObj.Add("searchrules", obj.SearchRules);
-				}
-			}
-
-			serializedObj.Add("name", obj.Name);
-
-			if (obj.Title.HasValue)
-				serializedObj.Add("title", obj.Title.Value);
-
-			if (obj.Width.HasValue)
-				serializedObj.Add("width", obj.Width);
-
-			if (obj.Viewable.HasValue)
-				serializedObj.Add("viewable", obj.Viewable.Value);
-
-			if (!string.IsNullOrWhiteSpace(obj.XmlMapping))
-				serializedObj.Add("xmlmap", obj.XmlMapping);
-		}
-
-		private static JqGridColumnEditOptions DeserializeJqGridColumnEditOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridColumnEditOptions();
-
-			if (serializedObj.ContainsKey("custom_element"))
-				obj.CustomElementFunction = serializedObj["custom_element"]?.ToString();
-			serializedObj.Remove("custom_element");
-			if (serializedObj.ContainsKey("custom_value"))
-				obj.CustomValueFunction = serializedObj["custom_value"]?.ToString();
-			serializedObj.Remove("custom_value");
-			if (serializedObj.ContainsKey("dataUrl"))
-				obj.DataUrl = serializedObj["dataUrl"]?.ToString();
-			serializedObj.Remove("dataUrl");
-			if (serializedObj.ContainsKey("defaultValue"))
-				obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
-			serializedObj.Remove("defaultValue");
-
-			if (serializedObj.ContainsKey("value") && serializedObj["value"] is IDictionary<string, object>)
-				obj.ValueDictionary = ((IDictionary<string, object>)serializedObj["value"]).ToDictionary(k => k.Key, v => v.Value.ToString());
-			else
-				obj.Value = GetStringFromSerializedObj(serializedObj, "value");
-			serializedObj.Remove("value");
-
-			obj.NullIfEmpty = GetBooleanFromSerializedObj(serializedObj, "NullIfEmpty");
-			serializedObj.Remove("NullIfEmpty");
-			obj.HtmlAttributes = serializedObj;
-
-			return obj;
-		}
-
-		private static void SerializeJqGridColumnEditOptions(JqGridColumnEditOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.IsCustomElementFunctionSetted)
-				serializedObj.Add("custom_element", obj.CustomElementFunction);
-
-			if (obj.IsCustomValueFunctionSetted)
-				serializedObj.Add("custom_value", obj.CustomValueFunction);
-
-			SerializeJqGridColumnElementOptions(obj, serializer, serializedObj);
-
-			if (obj.NullIfEmpty.HasValue)
-				serializedObj.Add("NullIfEmpty", obj.NullIfEmpty.Value);
-
-			if (obj.HtmlAttributes != null)
-				foreach (var htmlAttribute in obj.HtmlAttributes)
-					serializedObj.Add(htmlAttribute.Key, htmlAttribute.Value);
-		}
-
-		private static JqGridJsonReader DeserializeJqGridJsonReader(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridJsonReader();
-
-			obj.PageIndex = GetStringFromSerializedObj(serializedObj, "page", JqGridResponse.JsonReader.PageIndex);
-			obj.RecordId = GetStringFromSerializedObj(serializedObj, "id", JqGridResponse.JsonReader.RecordId);
-			obj.Records = GetStringFromSerializedObj(serializedObj, "root", JqGridResponse.JsonReader.Records);
-			obj.RecordValues = GetStringFromSerializedObj(serializedObj, "cell", JqGridResponse.JsonReader.RecordValues);
-			obj.RepeatItems = GetBooleanFromSerializedObj(serializedObj, "repeatitems", JqGridResponse.JsonReader.RepeatItems);
-			obj.TotalPagesCount = GetStringFromSerializedObj(serializedObj, "total", JqGridResponse.JsonReader.TotalPagesCount);
-			obj.TotalRecordsCount = GetStringFromSerializedObj(serializedObj, "records", JqGridResponse.JsonReader.TotalRecordsCount);
-			obj.UserData = GetStringFromSerializedObj(serializedObj, "userdata", JqGridResponse.JsonReader.UserData);
-
-			if (serializedObj.ContainsKey("subgrid") && serializedObj["subgrid"] is IDictionary<string, object>)
-			{
-				var serializedSubgrid = (IDictionary<string, object>)serializedObj["subgrid"];
-				obj.SubgridReader.Records = GetStringFromSerializedObj(serializedSubgrid, "root", JqGridResponse.JsonReader.SubgridReader.Records);
-				obj.SubgridReader.RecordValues = GetStringFromSerializedObj(serializedSubgrid, "cell", JqGridResponse.JsonReader.SubgridReader.RecordValues);
-				obj.SubgridReader.RepeatItems = GetBooleanFromSerializedObj(serializedSubgrid, "repeatitems", JqGridResponse.JsonReader.SubgridReader.RepeatItems);
-			}
-
-			return obj;
-		}
-
-		private static void SerializeJqGridJsonReader(JqGridJsonReader obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.Records != JqGridResponse.JsonReader.Records)
-				serializedObj.Add("root", obj.Records);
-
-			if (obj.PageIndex != JqGridResponse.JsonReader.PageIndex)
-				serializedObj.Add("page", obj.PageIndex);
-
-			if (obj.TotalPagesCount != JqGridResponse.JsonReader.TotalPagesCount)
-				serializedObj.Add("total", obj.TotalPagesCount);
-
-			if (obj.TotalRecordsCount != JqGridResponse.JsonReader.TotalRecordsCount)
-				serializedObj.Add("records", obj.TotalRecordsCount);
-
-			if (!obj.RepeatItems)
-				serializedObj.Add("repeatitems", false);
-
-			if (obj.RecordValues != JqGridResponse.JsonReader.RecordValues)
-				serializedObj.Add("cell", obj.RecordValues);
-
-			if (obj.RecordId != JqGridResponse.JsonReader.RecordId)
-				serializedObj.Add("id", obj.RecordId);
-
-			if (obj.UserData != JqGridResponse.JsonReader.UserData)
-				serializedObj.Add("userdata", obj.UserData);
-
-			if (!obj.SubgridReader.IsDefault())
-			{
-				var serializedSubgrid = new Dictionary<string, object>();
-
-				if (obj.SubgridReader.Records != JqGridResponse.JsonReader.SubgridReader.Records)
-					serializedSubgrid.Add("root", obj.SubgridReader.Records);
-
-				if (!obj.SubgridReader.RepeatItems)
-					serializedSubgrid.Add("repeatitems", false);
-
-				if (obj.SubgridReader.RecordValues != JqGridResponse.JsonReader.SubgridReader.RecordValues)
-					serializedSubgrid.Add("cell", obj.SubgridReader.RecordValues);
-
-				serializedObj.Add("subgrid", serializedSubgrid);
-			}
-		}
-
-		private static JqGridParametersNames DeserializeJqGridParametersNames(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridParametersNames();
-
-			obj.PageIndex = GetStringFromSerializedObj(serializedObj, "page", JqGridRequest.ParameterNames.PageIndex);
-			obj.RecordsCount = GetStringFromSerializedObj(serializedObj, "rows", JqGridRequest.ParameterNames.RecordsCount);
-			obj.SortingName = GetStringFromSerializedObj(serializedObj, "sort", JqGridRequest.ParameterNames.SortingName);
-			obj.SortingOrder = GetStringFromSerializedObj(serializedObj, "order", JqGridRequest.ParameterNames.SortingOrder);
-			obj.Searching = GetStringFromSerializedObj(serializedObj, "search", JqGridRequest.ParameterNames.Searching);
-			obj.Id = GetStringFromSerializedObj(serializedObj, "id", JqGridRequest.ParameterNames.Id);
-			obj.Operator = GetStringFromSerializedObj(serializedObj, "oper", JqGridRequest.ParameterNames.Operator);
-			obj.EditOperator = GetStringFromSerializedObj(serializedObj, "editoper", JqGridRequest.ParameterNames.EditOperator);
-			obj.AddOperator = GetStringFromSerializedObj(serializedObj, "addoper", JqGridRequest.ParameterNames.AddOperator);
-			obj.DeleteOperator = GetStringFromSerializedObj(serializedObj, "deloper", JqGridRequest.ParameterNames.DeleteOperator);
-			obj.SubgridId = GetStringFromSerializedObj(serializedObj, "subgridid", JqGridRequest.ParameterNames.SubgridId);
-			obj.PagesCount = GetStringFromSerializedObj(serializedObj, "npage", JqGridRequest.ParameterNames.PagesCount);
-			obj.TotalRows = GetStringFromSerializedObj(serializedObj, "totalrows", JqGridRequest.ParameterNames.TotalRows);
-
-			return obj;
-		}
-
-		private static void SerializeJqGridParametersNames(JqGridParametersNames obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.PageIndex != JqGridRequest.ParameterNames.PageIndex)
-				serializedObj.Add("page", obj.PageIndex);
-
-			if (obj.RecordsCount != JqGridRequest.ParameterNames.RecordsCount)
-				serializedObj.Add("rows", obj.RecordsCount);
-
-			if (obj.SortingName != JqGridRequest.ParameterNames.SortingName)
-				serializedObj.Add("sort", obj.SortingName);
-
-			if (obj.SortingOrder != JqGridRequest.ParameterNames.SortingOrder)
-				serializedObj.Add("order", obj.SortingOrder);
-
-			if (obj.Searching != JqGridRequest.ParameterNames.Searching)
-				serializedObj.Add("search", obj.Searching);
-
-			if (obj.Id != JqGridRequest.ParameterNames.Id)
-				serializedObj.Add("id", obj.Id);
-
-			if (obj.Operator != JqGridRequest.ParameterNames.Operator)
-				serializedObj.Add("oper", obj.Operator);
-
-			if (obj.EditOperator != JqGridRequest.ParameterNames.EditOperator)
-				serializedObj.Add("editoper", obj.EditOperator);
-
-			if (obj.AddOperator != JqGridRequest.ParameterNames.AddOperator)
-				serializedObj.Add("addoper", obj.AddOperator);
-
-			if (obj.DeleteOperator != JqGridRequest.ParameterNames.DeleteOperator)
-				serializedObj.Add("deloper", obj.DeleteOperator);
-
-			if (obj.SubgridId != JqGridRequest.ParameterNames.SubgridId)
-				serializedObj.Add("subgridid", obj.SubgridId);
-
-			if (obj.PagesCount != JqGridRequest.ParameterNames.PagesCount)
-				serializedObj.Add("npage", obj.PagesCount);
-
-			if (obj.TotalRows != JqGridRequest.ParameterNames.TotalRows)
-				serializedObj.Add("totalrows", obj.TotalRows);
-		}
-
-		private static JqGridGroupingView DeserializeJqGridGroupingView(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridGroupingView();
-
-			if (serializedObj.ContainsKey("groupField") && serializedObj["groupField"] is ArrayList)
-				obj.Fields = (string[])((ArrayList)serializedObj["groupField"]).ToArray(typeof(string));
-
-			if (serializedObj.ContainsKey("groupOrder") && serializedObj["groupOrder"] is ArrayList)
-				obj.Orders = (JqGridSortingOrders[])((ArrayList)serializedObj["groupOrder"]).ToArray(typeof(JqGridSortingOrders));
-
-			if (serializedObj.ContainsKey("groupText") && serializedObj["groupText"] is ArrayList)
-				obj.Texts = (string[])((ArrayList)serializedObj["groupText"]).ToArray(typeof(string));
-
-			if (serializedObj.ContainsKey("groupSummary") && serializedObj["groupSummary"] is ArrayList)
-				obj.Summary = (bool[])((ArrayList)serializedObj["groupSummary"]).ToArray(typeof(bool));
-
-			if (serializedObj.ContainsKey("groupColumnShow") && serializedObj["groupColumnShow"] is ArrayList)
-				obj.ColumnShow = (bool[])((ArrayList)serializedObj["groupColumnShow"]).ToArray(typeof(bool));
-
-			obj.SummaryOnHide = GetBooleanFromSerializedObj(serializedObj, "showSummaryOnHide", false);
-			obj.DataSorted = GetBooleanFromSerializedObj(serializedObj, "groupDataSorted", false);
-			obj.Collapse = GetBooleanFromSerializedObj(serializedObj, "groupCollapse", false);
-			obj.PlusIcon = GetStringFromSerializedObj(serializedObj, "plusicon", JqGridOptionsDefaults.GroupingPlusIcon);
-			obj.MinusIcon = GetStringFromSerializedObj(serializedObj, "minusicon", JqGridOptionsDefaults.GroupingMinusIcon);
-
-			return obj;
-		}
-
-		private static void SerializeJqGridGroupingView(JqGridGroupingView obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.Fields != null && obj.Fields.Length > 0)
-				serializedObj.Add("groupField", obj.Fields);
-
-			if (obj.Orders != null && obj.Orders.Length > 0 && obj.Orders.Contains(JqGridSortingOrders.Desc))
-				serializedObj.Add("groupOrder", obj.Orders);
-
-			if (obj.Texts != null && obj.Texts.Length > 0)
-				serializedObj.Add("groupText", obj.Texts);
-
-			if (obj.Summary != null && obj.Summary.Length > 0 && obj.Summary.Contains(true))
-				serializedObj.Add("groupSummary", obj.Summary);
-
-			if (obj.ColumnShow != null && obj.ColumnShow.Length > 0 && obj.ColumnShow.Contains(false))
-				serializedObj.Add("groupColumnShow", obj.ColumnShow);
-
-			if (obj.SummaryOnHide)
-				serializedObj.Add("showSummaryOnHide", true);
-
-			if (obj.DataSorted)
-				serializedObj.Add("groupDataSorted", true);
-
-			if (obj.Collapse)
-				serializedObj.Add("groupCollapse", true);
-
-			if (obj.PlusIcon != JqGridOptionsDefaults.GroupingPlusIcon)
-				serializedObj.Add("plusicon", obj.PlusIcon);
-
-			if (obj.MinusIcon != JqGridOptionsDefaults.GroupingMinusIcon)
-				serializedObj.Add("minusicon", obj.MinusIcon);
-		}
-
-		private static JqGridColumnRules DeserializeJqGridColumnRules(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridColumnRules();
-
-			obj.Custom = GetBooleanFromSerializedObj(serializedObj, "custom");
-			if (serializedObj.ContainsKey("custom_func"))
-				obj.CustomFunction = serializedObj["custom_func"]?.ToString();
-			obj.Date = GetBooleanFromSerializedObj(serializedObj, "date");
-			obj.EditHidden = GetBooleanFromSerializedObj(serializedObj, "edithidden");
-			obj.Email = GetBooleanFromSerializedObj(serializedObj, "email");
-			obj.Integer = GetBooleanFromSerializedObj(serializedObj, "integer", false);
-			obj.MaxValue = GetDoubleFromSerializedObj(serializedObj, "maxValue");
-			obj.MinValue = GetDoubleFromSerializedObj(serializedObj, "minValue");
-			obj.Number = GetBooleanFromSerializedObj(serializedObj, "number", false);
-			obj.Required = GetBooleanFromSerializedObj(serializedObj, "required");
-			obj.Time = GetBooleanFromSerializedObj(serializedObj, "time");
-			obj.Url = GetBooleanFromSerializedObj(serializedObj, "url");
-
-			return obj;
-		}
-
-		private static void SerializeJqGridColumnRules(JqGridColumnRules obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.Custom.HasValue)
-				serializedObj.Add("custom", obj.Custom.Value);
-
-			if (obj.IsCustomFunctionSetted)
-				serializedObj.Add("custom_func", obj.CustomFunction);
-
-			if (obj.Date.HasValue)
-				serializedObj.Add("date", obj.Date.Value);
-
-			if (obj.EditHidden.HasValue)
-				serializedObj.Add("edithidden", obj.EditHidden.Value);
-
-			if (obj.Email.HasValue)
-				serializedObj.Add("email", obj.Email.Value);
-
-			if (obj.Integer)
-				serializedObj.Add("integer", true);
-
-			if (obj.MaxValue.HasValue)
-				serializedObj.Add("maxValue", obj.MaxValue.Value);
-
-			if (obj.MinValue.HasValue)
-				serializedObj.Add("minValue", obj.MinValue.Value);
-
-			if (obj.Number)
-				serializedObj.Add("number", true);
-
-			if (obj.Required.HasValue)
-				serializedObj.Add("required", obj.Required.Value);
-
-			if (obj.Time.HasValue)
-				serializedObj.Add("time", obj.Time.Value);
-
-			if (obj.Url.HasValue)
-				serializedObj.Add("url", obj.Url.Value);
-		}
-
-		private static JqGridColumnFormOptions DeserializeJqGridColumnFormOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridColumnFormOptions();
-
-			obj.ColumnPosition = GetInt32FromSerializedObj(serializedObj, "colpos");
-			if (serializedObj.ContainsKey("elmprefix"))
-				obj.ElementPrefix = serializedObj["elmprefix"]?.ToString();
-			if (serializedObj.ContainsKey("elmsuffix"))
-				obj.ElementSuffix = serializedObj["elmsuffix"]?.ToString();
-			if (serializedObj.ContainsKey("label"))
-				obj.Label = serializedObj["label"]?.ToString();
-			obj.RowPosition = GetInt32FromSerializedObj(serializedObj, "rowpos");
-
-			return obj;
-		}
-
-		private static void SerializeJqGridColumnFormOptions(JqGridColumnFormOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.ColumnPosition.HasValue)
-				serializedObj.Add("colpos", obj.ColumnPosition.Value);
-
-			if (obj.IsElementPrefixSetted)
-				serializedObj.Add("elmprefix", obj.ElementPrefix);
-
-			if (obj.IsElementSuffixSetted)
-				serializedObj.Add("elmsuffix", obj.ElementSuffix);
-
-			if (obj.IsLabelSetted)
-				serializedObj.Add("label", obj.Label);
-
-			if (obj.RowPosition.HasValue)
-				serializedObj.Add("rowpos", obj.RowPosition.Value);
-		}
-
-		private static JqGridColumnFormatterOptions DeserializeJqGridColumnFormatterOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridColumnFormatterOptions();
-
-			if (serializedObj.ContainsKey("addParam"))
-				obj.AddParam = serializedObj["addParam"]?.ToString();
-			if (serializedObj.ContainsKey("baseLinkUrl"))
-				obj.BaseLinkUrl = serializedObj["baseLinkUrl"]?.ToString();
-			obj.DecimalPlaces = GetInt32FromSerializedObj(serializedObj, "decimalPlaces");
-			if (serializedObj.ContainsKey("decimalSeparator"))
-				obj.DecimalSeparator = serializedObj["decimalSeparator"]?.ToString();
-			if (serializedObj.ContainsKey("defaultValue"))
-				obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
-			obj.Disabled = GetBooleanFromSerializedObj(serializedObj, "disabled");
-			if (serializedObj.ContainsKey("idName"))
-				obj.IdName = serializedObj["idName"]?.ToString();
-			if (serializedObj.ContainsKey("srcformat"))
-				obj.OutputFormat = serializedObj["srcformat"]?.ToString();
-			if (serializedObj.ContainsKey("prefix"))
-				obj.Prefix = serializedObj["prefix"]?.ToString();
-			if (serializedObj.ContainsKey("showAction"))
-				obj.ShowAction = serializedObj["showAction"]?.ToString();
-			if (serializedObj.ContainsKey("newformat"))
-				obj.SourceFormat = serializedObj["newformat"]?.ToString();
-			if (serializedObj.ContainsKey("suffix"))
-				obj.Suffix = serializedObj["suffix"]?.ToString();
-			if (serializedObj.ContainsKey("target"))
-				obj.Target = serializedObj["target"]?.ToString();
-			if (serializedObj.ContainsKey("thousandsSeparator"))
-				obj.ThousandsSeparator = serializedObj["thousandsSeparator"]?.ToString();
-			return obj;
-		}
-
-		private static void SerializeJqGridColumnFormatterOptions(JqGridColumnFormatterOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.IsAddParamSetted)
-				serializedObj.Add("addParam", obj.AddParam);
-			if (obj.IsBaseLinkUrlSetted)
-				serializedObj.Add("baseLinkUrl", obj.BaseLinkUrl);
-			if (obj.DecimalPlaces.HasValue)
-				serializedObj.Add("decimalPlaces", obj.DecimalPlaces.Value);
-			if (obj.IsDecimalSeparatorSetted)
-				serializedObj.Add("decimalSeparator", obj.DecimalSeparator);
-			if (obj.IsDefaultValueSetted)
-				serializedObj.Add("defaultValue", obj.DefaultValue);
-			if (obj.Disabled.HasValue)
-				serializedObj.Add("disabled", obj.Disabled.Value);
-			if (obj.IsIdNameSetted)
-				serializedObj.Add("idName", obj.IdName);
-			if (obj.IsOutputFormatSetted)
-				serializedObj.Add("srcformat", obj.OutputFormat);
-			if (obj.IsPrefixSetted)
-				serializedObj.Add("prefix", obj.Prefix);
-			if (obj.IsShowActionSetted)
-				serializedObj.Add("showAction", obj.ShowAction);
-			if (obj.IsSourceFormatSetted)
-				serializedObj.Add("newformat", obj.SourceFormat);
-			if (obj.IsSuffixSetted)
-				serializedObj.Add("suffix", obj.Suffix);
-			if (obj.IsTargetSetted)
-				serializedObj.Add("target", obj.Target);
-			if (obj.IsThousandsSeparatorSetted)
-				serializedObj.Add("thousandsSeparator", obj.ThousandsSeparator);
-		}
-
-		private static void SerializeJqGridColumnElementOptions(JqGridColumnElementOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			if (obj.IsDataUrlSetted)
-				serializedObj.Add("dataUrl", obj.DataUrl);
-
-			if (obj.IsDefaultValueSetted)
-				serializedObj.Add("defaultValue", obj.DefaultValue);
-
-			if (obj.IsValueSetted)
-				serializedObj.Add("value", obj.Value);
-			else if (obj.ValueDictionary != null)
-				serializedObj.Add("value", obj.ValueDictionary);
-		}
-
-		private static JqGridColumnSearchOptions DeserializeJqGridColumnSearchOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridColumnSearchOptions();
-
-			obj.ClearSearch = GetBooleanFromSerializedObj(serializedObj, "clearSearch");
-			if (serializedObj.ContainsKey("dataUrl"))
-				obj.DataUrl = serializedObj["dataUrl"]?.ToString();
-			if (serializedObj.ContainsKey("defaultValue"))
-				obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
-
-			if (serializedObj.ContainsKey("value") && serializedObj["value"] is IDictionary<string, object>)
-				obj.ValueDictionary = ((IDictionary<string, object>)serializedObj["value"]).ToDictionary(k => k.Key, v => v.Value.ToString());
-			else
-				obj.Value = GetStringFromSerializedObj(serializedObj, "value");
-
-			if (serializedObj.ContainsKey("attr") && serializedObj["attr"] is IDictionary<string, object>)
-				obj.HtmlAttributes = (IDictionary<string, object>)serializedObj["attr"];
-
-			obj.SearchHidden = GetBooleanFromSerializedObj(serializedObj, "searchhidden");
-
-			if (serializedObj.ContainsKey("sopt") && serializedObj["sopt"] is ArrayList)
-			{
-				JqGridSearchOperators? searchOperators = null;
-				foreach (var innerSerializedObj in (ArrayList)serializedObj["sopt"])
-				{
-					if (Enum.TryParse(innerSerializedObj.ToString(), true, out JqGridSearchOperators searchOperator))
-					{
-						if (searchOperators.HasValue)
-							searchOperators = searchOperators | searchOperator;
-						else
-							searchOperators = searchOperator;
-					}
-				}
-
-				if (searchOperators.HasValue)
-					obj.SearchOperators = searchOperators.Value;
-			}
-
-			return obj;
-		}
-
-		private static void SerializeJqGridColumnSearchOptions(JqGridColumnSearchOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			SerializeJqGridColumnElementOptions(obj, serializer, serializedObj);
-
-			if (obj.HtmlAttributes != null && obj.HtmlAttributes.Count > 0)
-				serializedObj.Add("attr", obj.HtmlAttributes);
-
-			if (obj.ClearSearch.HasValue)
-				serializedObj.Add("clearSearch", obj.ClearSearch);
-
-			if (obj.SearchHidden.HasValue)
-				serializedObj.Add("searchhidden", obj.SearchHidden);
-
-			if (obj.SearchOperators != JqGridSearchOperators.Default)
-			{
-				var searchOperators = new List<string>();
-				foreach (JqGridSearchOperators searchOperator in Enum.GetValues(typeof(JqGridSearchOperators)))
-				{
-					if (searchOperator != JqGridSearchOperators.EqualOrNotEqual && searchOperator != JqGridSearchOperators.NoTextOperators && searchOperator != JqGridSearchOperators.TextOperators && (obj.SearchOperators & searchOperator) == searchOperator)
-						searchOperators.Add(Enum.GetName(typeof(JqGridSearchOperators), searchOperator).ToLower());
-				}
-				serializedObj.Add("sopt", searchOperators);
-			}
-		}
-
-		private static JqGridSubgridModel DeserializeJqGridSubgridModel(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridSubgridModel();
-
-			if (serializedObj.ContainsKey("name") && serializedObj["name"] is ArrayList)
-			{
-				foreach (var innerSerializedObj in (ArrayList)serializedObj["name"])
-					obj.ColumnsNames.Add(innerSerializedObj.ToString());
-			}
-
-			if (serializedObj.ContainsKey("align") && serializedObj["align"] is ArrayList)
-			{
-				foreach (var innerSerializedObj in (ArrayList)serializedObj["align"])
-				{
-					Enum.TryParse(innerSerializedObj.ToString(), true, out JqGridAlignments alignment);
-					obj.ColumnsAlignments.Add(alignment);
-				}
-			}
-
-			if (serializedObj.ContainsKey("width") && serializedObj["width"] is ArrayList)
-			{
-				foreach (var innerSerializedObj in (ArrayList)serializedObj["width"])
-				{
-					if (innerSerializedObj is int i)
-						obj.ColumnsWidths.Add(i);
-				}
-			}
-
-			return obj;
-		}
-
-		private static void SerializeJqGridSubgridModel(JqGridSubgridModel obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			serializedObj.Add("name", obj.ColumnsNames);
-
-			var alignments = new List<string>();
-			foreach (var alignment in obj.ColumnsAlignments)
-				alignments.Add(alignment.ToString().ToLower());
-			serializedObj.Add("align", alignments);
-
-			serializedObj.Add("width", obj.ColumnsWidths);
-		}
-
-		private static void SerializeJqGridResponse(JqGridResponse obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			var jsonReader = obj.Reader ?? JqGridResponse.JsonReader;
-
-			if (!obj.IsSubgridResponse)
-			{
-				serializedObj.Add(jsonReader.PageIndex, obj.PageIndex + 1);
-				serializedObj.Add(jsonReader.TotalRecordsCount, obj.TotalRecordsCount);
-				serializedObj.Add(jsonReader.TotalPagesCount, obj.TotalPagesCount);
-
-				if (obj.UserData != null)
-					serializedObj.Add(jsonReader.UserData, obj.UserData);
-			}
-
-			serializedObj.Add(obj.IsSubgridResponse ? jsonReader.SubgridReader.Records : jsonReader.Records, SerializeJqGridRecords(obj.Records, obj.IsSubgridResponse, jsonReader));
-		}
-
-		private static List<object> SerializeJqGridRecords(List<JqGridRecord> objs, bool isSubgridResponse, JqGridJsonReader jsonReader)
-		{
-			var isRecordIndexInt = int.TryParse(jsonReader.RecordId, out var recordIdIndex);
-			var isRecordValuesEmpty = string.IsNullOrWhiteSpace(jsonReader.RecordValues);
-			var repeatItems = isSubgridResponse ? jsonReader.SubgridReader.RepeatItems : jsonReader.RepeatItems;
-
-			if (!isSubgridResponse)
-			{
-				if (repeatItems && isRecordValuesEmpty && !isRecordIndexInt)
-					throw new InvalidOperationException("JqGridJsonReader.RecordId must be a number when JqGridJsonReader.RepeatItems is set to true and JqGridJsonReader.RecordValues is set to empty string.");
-
-				if (repeatItems && !isRecordValuesEmpty && isRecordIndexInt)
-					throw new InvalidOperationException("JqGridJsonReader.RecordValues can't be an empty string when JqGridJsonReader.RepeatItems is set to true and JqGridJsonReader.RecordId is a number.");
-			}
-
-			var serializedObjs = new List<object>();
-
-			foreach (var obj in objs)
-			{
-				var adjacencyTreeRecord = obj as JqGridAdjacencyTreeRecord;
-				var nestedSetTreeRecord = obj as JqGridNestedSetTreeRecord;
-				if (repeatItems)
-				{
-					var values = obj.Values;
-
-					if (!isSubgridResponse)
-					{
-						if (adjacencyTreeRecord != null)
-						{
-							values.Add(adjacencyTreeRecord.Level);
-							values.Add(adjacencyTreeRecord.ParentId);
-							values.Add(adjacencyTreeRecord.Leaf);
-							values.Add(adjacencyTreeRecord.Expanded);
-						}
-						else if (nestedSetTreeRecord != null)
-						{
-							values.Add(nestedSetTreeRecord.Level);
-							values.Add(nestedSetTreeRecord.LeftField);
-							values.Add(nestedSetTreeRecord.RightField);
-							values.Add(nestedSetTreeRecord.Leaf);
-							values.Add(nestedSetTreeRecord.Expanded);
-						}
-					}
-
-					if (isRecordValuesEmpty)
-					{
-						if (!isSubgridResponse && Convert.ToString(values[recordIdIndex]) != obj.Id)
-							values.Insert(recordIdIndex, obj.Id);
-						serializedObjs.Add(values);
-					}
-					else
-					{
-						var serializedObj = new Dictionary<string, object>();
-						serializedObj.Add(isSubgridResponse ? jsonReader.SubgridReader.RecordValues : jsonReader.RecordValues, values);
-						if (!isSubgridResponse)
-							serializedObj.Add(jsonReader.RecordId, obj.Id);
-						serializedObjs.Add(serializedObj);
-					}
-				}
-				else
-				{
-					if (obj.Value == null)
-						throw new InvalidOperationException("JqGridRecord.Value can't be null when JqGridJsonReader.RepeatItems is set to false.");
-
-					var serializedObj = obj.GetValuesAsDictionary();
-
-					if (!isSubgridResponse)
-					{
-						if (adjacencyTreeRecord != null)
-						{
-							serializedObj.Add("level", adjacencyTreeRecord.Level);
-							serializedObj.Add("parent", adjacencyTreeRecord.ParentId);
-							serializedObj.Add("isLeaf", adjacencyTreeRecord.Leaf);
-							serializedObj.Add("expanded", adjacencyTreeRecord.Expanded);
-						}
-						else if (nestedSetTreeRecord != null)
-						{
-							serializedObj.Add("level", nestedSetTreeRecord.Level);
-							serializedObj.Add("lft", nestedSetTreeRecord.LeftField);
-							serializedObj.Add("rgt", nestedSetTreeRecord.RightField);
-							serializedObj.Add("isLeaf", nestedSetTreeRecord.Leaf);
-							serializedObj.Add("expanded", nestedSetTreeRecord.Expanded);
-						}
-					}
-
-					if (!isSubgridResponse && !isRecordIndexInt && !serializedObj.ContainsKey(jsonReader.RecordId))
-						serializedObj.Add(jsonReader.RecordId, obj.Id);
-
-					serializedObjs.Add(serializedObj);
-				}
-			}
-
-			return serializedObjs;
-		}
-
-		private static JqGridRequestSearchingFilters DeserializeJqGridRequestSearchingFilters(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridRequestSearchingFilters();
-
-			obj.GroupingOperator = GetEnumFromSerializedObj<JqGridSearchGroupingOperators>(serializedObj, "groupOp", JqGridSearchGroupingOperators.And);
-			if (serializedObj.ContainsKey("rules") && serializedObj["rules"] is ArrayList)
-			{
-				foreach (var innerSerializedObj in (ArrayList)serializedObj["rules"])
-				{
-					if (innerSerializedObj is IDictionary<string, object>)
-					{
-						var searchingFilter = DeserializeJqGridRequestSearchingFilter((IDictionary<string, object>)innerSerializedObj, serializer);
-						obj.Filters.Add(searchingFilter);
-					}
-				}
-			}
-			if (serializedObj.ContainsKey("groups") && serializedObj["groups"] is ArrayList)
-			{
-				foreach (var innerSerializedObj in (ArrayList)serializedObj["groups"])
-				{
-					if (innerSerializedObj is IDictionary<string, object>)
-					{
-						var searchingFilters = DeserializeJqGridRequestSearchingFilters((IDictionary<string, object>)innerSerializedObj, serializer);
-						obj.Groups.Add(searchingFilters);
-					}
-				}
-			}
-
-			return obj;
-		}
-
-		private static void SerializeJqGridRequestSearchingFilters(JqGridRequestSearchingFilters obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			serializedObj.Add("groupOp", obj.GroupingOperator.ToString().ToUpper());
-
-			if (obj.Filters != null && obj.Filters.Count > 0)
-				serializedObj.Add("rules", obj.Filters);
-
-			if (obj.Groups != null && obj.Groups.Count > 0)
-				serializedObj.Add("groups", obj.Groups);
-		}
-
-		private static JqGridRequestSearchingFilter DeserializeJqGridRequestSearchingFilter(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
-		{
-			var obj = new JqGridRequestSearchingFilter();
-
-			obj.SearchingName = GetStringFromSerializedObj(serializedObj, "field");
-			obj.SearchingOperator = GetEnumFromSerializedObj(serializedObj, "op", JqGridSearchOperators.Eq);
-			obj.SearchingValue = GetStringFromSerializedObj(serializedObj, "data");
-			return obj;
-		}
-
-		private static void SerializeJqGridRequestSearchingFilter(JqGridRequestSearchingFilter obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
-		{
-			serializedObj.Add("field", obj.SearchingName);
-			serializedObj.Add("op", obj.SearchingOperator.ToString().ToLower());
-			serializedObj.Add("data", obj.SearchingValue);
-		}
-
-		private static bool? GetBooleanFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is bool)
-				return (bool)serializedObj[key];
-			return null;
-		}
-
-		private static bool GetBooleanFromSerializedObj(IDictionary<string, object> serializedObj, string key, bool defaultValue)
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is bool)
-				return (bool)serializedObj[key];
-			return defaultValue;
-		}
-
-		private static double? GetDoubleFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && double.TryParse(serializedObj[key].ToString(), out var value))
-				return value;
-			return null;
-		}
-
-		private static TEnum? GetEnumFromSerializedObj<TEnum>(IDictionary<string, object> serializedObj, string key) where TEnum : struct
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Enum.TryParse<TEnum>(serializedObj[key].ToString(), true, out var value))
-				return value;
-			return null;
-		}
-
-		private static TEnum GetEnumFromSerializedObj<TEnum>(IDictionary<string, object> serializedObj, string key, TEnum defaultValue) where TEnum : struct
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Enum.TryParse(serializedObj[key].ToString(), true, out TEnum value))
-				return value;
-			return defaultValue;
-		}
-
-		private static int? GetInt32FromSerializedObj(IDictionary<string, object> serializedObj, string key)
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is int)
-				return (int)serializedObj[key];
-			return null;
-		}
-
-		private static int GetInt32FromSerializedObj(IDictionary<string, object> serializedObj, string key, int defaultValue)
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is int)
-				return (int)serializedObj[key];
-			return defaultValue;
-		}
-
-		private static List<int> GetInt32ArrayFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-		{
-			List<int> array = null;
-
-			if (serializedObj.ContainsKey(key) && serializedObj[key] is ArrayList)
-			{
-				array = new List<int>();
-				var serializedArray = (ArrayList)serializedObj[key];
-				foreach (var serializedItem in serializedArray)
-				{
-					if (serializedItem is int i)
-						array.Add(i);
-				}
-			}
-
-			return array;
-		}
-
-		private static string GetStringFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
-				return serializedObj[key].ToString();
-			return null;
-		}
-
-		private static string GetStringFromSerializedObj(IDictionary<string, object> serializedObj, string key, string defaultValue)
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
-				return serializedObj[key].ToString();
-			return defaultValue;
-		}
-
-		private static SettedString GetSettedStringFromSerializedObj(IDictionary<string, object> serializedObj, string key)
-		{
-			if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
-				return new SettedString(true, serializedObj[key].ToString());
-			return new SettedString(false, null);
-		}
-		#endregion
-	}
+    internal class JqGridScriptConverter : JavaScriptConverter
+    {
+        #region Fields
+        private static ReadOnlyCollection<Type> _supportedTypes = new ReadOnlyCollection<Type>(new List<Type>()
+        {
+            typeof(JqGridOptions),
+            typeof(JqGridColumnModel),
+            typeof(JqGridJsonReader),
+            typeof(JqGridParametersNames),
+            typeof(JqGridGroupingView),
+            typeof(JqGridColumnEditOptions),
+            typeof(JqGridColumnRules),
+            typeof(JqGridColumnFormOptions),
+            typeof(JqGridColumnFormatterOptions),
+            typeof(JqGridColumnSearchOptions),
+            typeof(JqGridSubgridModel),
+            typeof(JqGridResponse),
+            typeof(JqGridRequestSearchingFilters),
+            typeof(JqGridRequestSearchingFilter)
+        });
+        #endregion
+
+        #region JavaScriptConverter Members
+        public override object Deserialize(IDictionary<string, object> dictionary, Type type, JavaScriptSerializer serializer)
+        {
+            object obj = null;
+
+            if (dictionary != null)
+            {
+                if (type == typeof(JqGridOptions))
+                    obj = DeserializeJqGridOptions(dictionary, serializer);
+                else if (type == typeof(JqGridColumnModel))
+                    obj = DeserializeJqGridColumnModel(dictionary, serializer);
+                else if (type == typeof(JqGridJsonReader))
+                    obj = DeserializeJqGridJsonReader(dictionary, serializer);
+                else if (type == typeof(JqGridParametersNames))
+                    obj = DeserializeJqGridParametersNames(dictionary, serializer);
+                else if (type == typeof(JqGridGroupingView))
+                    obj = DeserializeJqGridGroupingView(dictionary, serializer);
+                else if (type == typeof(JqGridColumnEditOptions))
+                    obj = DeserializeJqGridColumnEditOptions(dictionary, serializer);
+                else if (type == typeof(JqGridColumnRules))
+                    obj = DeserializeJqGridColumnRules(dictionary, serializer);
+                else if (type == typeof(JqGridColumnFormOptions))
+                    obj = DeserializeJqGridColumnFormOptions(dictionary, serializer);
+                else if (type == typeof(JqGridColumnFormatterOptions))
+                    obj = DeserializeJqGridColumnFormatterOptions(dictionary, serializer);
+                else if (type == typeof(JqGridColumnSearchOptions))
+                    obj = DeserializeJqGridColumnSearchOptions(dictionary, serializer);
+                else if (type == typeof(JqGridSubgridModel))
+                    obj = DeserializeJqGridSubgridModel(dictionary, serializer);
+                else if (type == typeof(JqGridRequestSearchingFilters))
+                    obj = DeserializeJqGridRequestSearchingFilters(dictionary, serializer);
+                else if (type == typeof(JqGridRequestSearchingFilter))
+                    obj = DeserializeJqGridRequestSearchingFilter(dictionary, serializer);
+            }
+
+            return obj;
+        }
+
+        public override IDictionary<string, object> Serialize(object obj, JavaScriptSerializer serializer)
+        {
+            Dictionary<string, object> serializedObj = new Dictionary<string, object>();
+
+            if (obj != null)
+            {
+                if (obj is JqGridOptions)
+                    SerializeJqGridOptions((JqGridOptions)obj, serializer, serializedObj);
+                else if (obj is JqGridColumnModel)
+                    SerializeJqGridColumnModel((JqGridColumnModel)obj, serializer, serializedObj);
+                else if (obj is JqGridJsonReader)
+                    SerializeJqGridJsonReader((JqGridJsonReader)obj, serializer, serializedObj);
+                else if (obj is JqGridParametersNames)
+                    SerializeJqGridParametersNames((JqGridParametersNames)obj, serializer, serializedObj);
+                else if (obj is JqGridGroupingView)
+                    SerializeJqGridGroupingView((JqGridGroupingView)obj, serializer, serializedObj);
+                else if (obj is JqGridColumnEditOptions)
+                    SerializeJqGridColumnEditOptions((JqGridColumnEditOptions)obj, serializer, serializedObj);
+                else if (obj is JqGridColumnRules)
+                    SerializeJqGridColumnRules((JqGridColumnRules)obj, serializer, serializedObj);
+                else if (obj is JqGridColumnFormatterOptions)
+                    SerializeJqGridColumnFormatterOptions((JqGridColumnFormatterOptions)obj, serializer, serializedObj);
+                else if (obj is JqGridColumnFormOptions)
+                    SerializeJqGridColumnFormOptions((JqGridColumnFormOptions)obj, serializer, serializedObj);
+                else if (obj is JqGridColumnSearchOptions)
+                    SerializeJqGridColumnSearchOptions((JqGridColumnSearchOptions)obj, serializer, serializedObj);
+                else if (obj is JqGridSubgridModel)
+                    SerializeJqGridSubgridModel((JqGridSubgridModel)obj, serializer, serializedObj);
+                else if (obj is JqGridResponse)
+                    SerializeJqGridResponse((JqGridResponse)obj, serializer, serializedObj);
+                else if (obj is JqGridRequestSearchingFilters)
+                    SerializeJqGridRequestSearchingFilters((JqGridRequestSearchingFilters)obj, serializer, serializedObj);
+                else if (obj is JqGridRequestSearchingFilter)
+                    SerializeJqGridRequestSearchingFilter((JqGridRequestSearchingFilter)obj, serializer, serializedObj);
+            }
+
+            return serializedObj;
+        }
+
+        public override IEnumerable<Type> SupportedTypes => _supportedTypes;
+
+        #endregion
+
+        #region Methods
+        private static JqGridOptions DeserializeJqGridOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            string id = GetStringFromSerializedObj(serializedObj, "id");
+            if (!string.IsNullOrWhiteSpace(id))
+            {
+                JqGridOptions obj = new JqGridOptions(id);
+                if (serializedObj.ContainsKey("altclass"))
+                    obj.AltClass = serializedObj["altclass"]?.ToString();
+                obj.AltRows = GetBooleanFromSerializedObj(serializedObj, "altRows");
+                obj.AutoEncode = GetBooleanFromSerializedObj(serializedObj, "autoencode");
+                obj.AutoWidth = GetBooleanFromSerializedObj(serializedObj, "autowidth");
+                if (serializedObj.ContainsKey("caption"))
+                    obj.Caption = serializedObj["caption"]?.ToString();
+                obj.CellLayout = GetInt32FromSerializedObj(serializedObj, "cellLayout");
+                obj.CellEditingEnabled = GetBooleanFromSerializedObj(serializedObj, "cellEdit");
+                obj.CellEditingSubmitMode = GetEnumFromSerializedObj(serializedObj, "cellsubmit", JqGridCellEditingSubmitModes.Default);
+                if (serializedObj.ContainsKey("cellurl"))
+                    obj.CellEditingUrl = serializedObj["cellurl"]?.ToString();
+
+                if (serializedObj.ContainsKey("colModel") && serializedObj["colModel"] is ArrayList)
+                {
+                    foreach (object innerSerializedObj in (ArrayList)serializedObj["colModel"])
+                    {
+                        if (innerSerializedObj is IDictionary<string, object>)
+                        {
+                            JqGridColumnModel columnModel = DeserializeJqGridColumnModel((IDictionary<string, object>)innerSerializedObj, serializer);
+                            if (columnModel != null)
+                                obj.ColumnsModels.Add(columnModel);
+                        }
+                    }
+                }
+
+                if (serializedObj.ContainsKey("colNames") && serializedObj["colNames"] is ArrayList)
+                {
+                    foreach (object innerSerializedObj in (ArrayList)serializedObj["colNames"])
+                        obj.ColumnsNames.Add(innerSerializedObj.ToString());
+                }
+
+                if (serializedObj.ContainsKey("datastr"))
+                    obj.DataString = serializedObj["datastr"]?.ToString();
+                obj.DataType = GetEnumFromSerializedObj(serializedObj, "datatype", JqGridDataTypes.Default);
+                obj.DeepEmpty = GetBooleanFromSerializedObj(serializedObj, "deepempty");
+                obj.Direction = GetEnumFromSerializedObj(serializedObj, "direction", JqGridLanguageDirections.Default);
+                obj.DynamicScrollingMode = JqGridDynamicScrollingModes.Default;
+                if (serializedObj.ContainsKey("scroll") && serializedObj["scroll"] != null)
+                {
+                    if (serializedObj["scroll"] is bool b && b)
+                        obj.DynamicScrollingMode = JqGridDynamicScrollingModes.HoldAllRows;
+                    else if (serializedObj["scroll"] is int)
+                        obj.DynamicScrollingMode = JqGridDynamicScrollingModes.HoldVisibleRows;
+                }
+
+                obj.DynamicScrollingTimeout = GetInt32FromSerializedObj(serializedObj, "scrollTimeout");
+                if (serializedObj.ContainsKey("editurl"))
+                    obj.EditingUrl = serializedObj["editurl"]?.ToString();
+                if (serializedObj.ContainsKey("emptyrecords"))
+                    obj.EmptyRecords = serializedObj["emptyrecords"]?.ToString();
+                obj.ExpandColumnClick = GetBooleanFromSerializedObj(serializedObj, "ExpandColClick");
+                if (serializedObj.ContainsKey("ExpandColumn"))
+                    obj.ExpandColumn = serializedObj["ExpandColumn"]?.ToString();
+                obj.FooterEnabled = GetBooleanFromSerializedObj(serializedObj, "footerrow");
+                obj.UserDataOnFooter = GetBooleanFromSerializedObj(serializedObj, "userDataOnFooter");
+                obj.GridView = GetBooleanFromSerializedObj(serializedObj, "gridview");
+
+                obj.GroupingEnabled = GetBooleanFromSerializedObj(serializedObj, "grouping");
+                if (serializedObj.ContainsKey("groupingView") && serializedObj["groupingView"] is IDictionary<string, object>)
+                    obj.GroupingView = DeserializeJqGridGroupingView((IDictionary<string, object>)serializedObj["groupingView"], serializer);
+
+                obj.Height = GetInt32FromSerializedObj(serializedObj, "height");
+                obj.Hidden = GetBooleanFromSerializedObj(serializedObj, "hiddengrid");
+                obj.HiddenEnabled = GetBooleanFromSerializedObj(serializedObj, "hidegrid");
+                obj.HoverRows = GetBooleanFromSerializedObj(serializedObj, "hoverrows");
+                obj.IgnoreCase = GetBooleanFromSerializedObj(serializedObj, "ignoreCase");
+                obj.LoadOnce = GetBooleanFromSerializedObj(serializedObj, "loadonce");
+                obj.MethodType = GetEnumFromSerializedObj(serializedObj, "mtype", JqGridMethodTypes.Default);
+                obj.MultiKey = GetEnumFromSerializedObj(serializedObj, "multikey", JqGridMultiKeys.Default);
+                obj.MultiBoxOnly = GetBooleanFromSerializedObj(serializedObj, "multiboxonly");
+                obj.MultiSelect = GetBooleanFromSerializedObj(serializedObj, "multiselect");
+                obj.MultiSelectWidth = GetInt32FromSerializedObj(serializedObj, "multiselectWidth");
+                obj.MultiSort = GetBooleanFromSerializedObj(serializedObj, "multiSort");
+
+                if (serializedObj.ContainsKey("pager") && serializedObj["pager"] != null)
+                    obj.Pager = true;
+
+                if (serializedObj.ContainsKey("jsonReader") && serializedObj["jsonReader"] is IDictionary<string, object>)
+                    obj.JsonReader = DeserializeJqGridJsonReader((IDictionary<string, object>)serializedObj["jsonReader"], serializer);
+                else
+                    obj.JsonReader = JqGridResponse.JsonReader;
+
+                if (serializedObj.ContainsKey("prmNames") && serializedObj["prmNames"] is IDictionary<string, object>)
+                    obj.ParametersNames = DeserializeJqGridParametersNames((IDictionary<string, object>)serializedObj["prmNames"], serializer);
+                else
+                    obj.ParametersNames = JqGridRequest.ParameterNames;
+
+                obj.ColumnsRemaping = GetInt32ArrayFromSerializedObj(serializedObj, "remapColumns");
+                obj.RowsList = GetInt32ArrayFromSerializedObj(serializedObj, "rowList");
+                obj.RowsNumber = GetInt32FromSerializedObj(serializedObj, "rowNum");
+                obj.RowsNumbers = GetBooleanFromSerializedObj(serializedObj, "rownumbers");
+                obj.RowsNumbersWidth = GetInt32FromSerializedObj(serializedObj, "rownumWidth");
+                obj.ShrinkToFit = GetBooleanFromSerializedObj(serializedObj, "shrinkToFit");
+                obj.ScrollOffset = GetInt32FromSerializedObj(serializedObj, "scrollOffset");
+                obj.Sortable = GetBooleanFromSerializedObj(serializedObj, "sortable");
+                if (serializedObj.ContainsKey("sortname"))
+                    obj.SortingName = serializedObj["sortname"]?.ToString();
+                obj.SortingOrder = GetEnumFromSerializedObj(serializedObj, "sortorder", JqGridSortingOrders.Default);
+                obj.StyleUI = GetEnumFromSerializedObj(serializedObj, "styleUI", JqGridStyleUIOptions.Default);
+                obj.SubgridEnabled = GetBooleanFromSerializedObj(serializedObj, "subGrid");
+
+                if (serializedObj.ContainsKey("subGridModel") && serializedObj["subGridModel"] is IDictionary<string, object>)
+                    obj.SubgridModel = DeserializeJqGridSubgridModel((IDictionary<string, object>)serializedObj["subGridModel"], serializer);
+
+                if (serializedObj.ContainsKey("subGridUrl"))
+                    obj.SubgridUrl = serializedObj["subGridUrl"]?.ToString();
+                obj.SubgridColumnWidth = GetInt32FromSerializedObj(serializedObj, "subGridWidth");
+                obj.TopPager = GetBooleanFromSerializedObj(serializedObj, "toppager");
+                obj.TreeGridEnabled = GetBooleanFromSerializedObj(serializedObj, "treeGrid");
+                obj.TreeGridModel = GetEnumFromSerializedObj(serializedObj, "treeGridModel", JqGridTreeGridModels.Default);
+                if (serializedObj.ContainsKey("url"))
+                    obj.Url = serializedObj["url"]?.ToString();
+                obj.ViewRecords = GetBooleanFromSerializedObj(serializedObj, "viewrecords");
+                obj.Width = GetInt32FromSerializedObj(serializedObj, "width");
+
+                return obj;
+            }
+            return null;
+        }
+
+        private static void SerializeJqGridOptions(JqGridOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            serializedObj.Add("id", obj.Id);
+
+            if (obj.IsAltClassSetted)
+                serializedObj.Add("altclass", obj.AltClass);
+
+            if (obj.AltRows.HasValue)
+                serializedObj.Add("altRows", obj.AltRows.Value);
+
+            if (obj.AutoEncode.HasValue)
+                serializedObj.Add("autoencode", obj.AutoEncode.Value);
+
+            if (obj.AutoWidth.HasValue)
+                serializedObj.Add("autowidth", obj.AutoWidth.Value);
+
+            if (obj.CellLayout.HasValue)
+                serializedObj.Add("cellLayout", obj.CellLayout.Value);
+
+            if (obj.CellEditingEnabled.HasValue)
+                serializedObj.Add("cellEdit", obj.CellEditingEnabled.Value);
+
+            if (obj.CellEditingSubmitMode != JqGridCellEditingSubmitModes.Default)
+                serializedObj.Add("cellsubmit", obj.CellEditingSubmitMode);
+
+            if (obj.IsCellEditingUrlSetted)
+                serializedObj.Add("cellurl", obj.CellEditingUrl);
+
+            serializedObj.Add("colModel", obj.ColumnsModels);
+            serializedObj.Add("colNames", obj.ColumnsNames);
+
+            if (obj.IsCaptionSetted)
+                serializedObj.Add("caption", obj.Caption);
+
+            if (obj.HiddenEnabled.HasValue)
+                serializedObj.Add("hidegrid", obj.HiddenEnabled.Value);
+
+            if (obj.Hidden.HasValue)
+                serializedObj.Add("hiddengrid", obj.Hidden.Value);
+
+            if (obj.IsUsedDataString)
+                serializedObj.Add("datastr", obj.DataString);
+            else
+                serializedObj.Add("url", obj.Url);
+
+            if (obj.DataType != JqGridDataTypes.Default)
+                serializedObj.Add("datatype", obj.DataType.ToString().ToLower());
+
+            if (obj.DeepEmpty.HasValue)
+                serializedObj.Add("deepempty", obj.DeepEmpty.Value);
+
+            if (obj.Direction != JqGridLanguageDirections.Default)
+                serializedObj.Add("direction", obj.Direction.ToString().ToLower());
+
+            if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.Disabled)
+                serializedObj.Add("scroll", false);
+            if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldAllRows)
+                serializedObj.Add("scroll", true);
+            else if (obj.DynamicScrollingMode == JqGridDynamicScrollingModes.HoldVisibleRows)
+                serializedObj.Add("scroll", 10);
+
+            if (obj.DynamicScrollingTimeout.HasValue)
+                serializedObj.Add("scrollTimeout", obj.DynamicScrollingTimeout);
+
+            if (obj.IsEmptyRecordsSetted)
+                serializedObj.Add("emptyrecords", obj.EmptyRecords);
+
+            if (obj.IsEditingUrlSetted)
+                serializedObj.Add("editurl", obj.EditingUrl);
+
+            if (obj.FooterEnabled.HasValue)
+            {
+                serializedObj.Add("footerrow", obj.FooterEnabled.Value);
+                if (obj.FooterEnabled.Value && obj.UserDataOnFooter.HasValue)
+                    serializedObj.Add("userDataOnFooter", obj.UserDataOnFooter.Value);
+            }
+
+            if (obj.GridView.HasValue)
+                serializedObj.Add("gridview", obj.GridView.Value);
+
+            if (obj.GroupingEnabled.HasValue)
+            {
+                serializedObj.Add("grouping", obj.GroupingEnabled.Value);
+
+                if (obj.GroupingEnabled.Value && obj.GroupingView != null)
+                    serializedObj.Add("groupingView", obj.GroupingView);
+            }
+
+            if (obj.Height.HasValue)
+                serializedObj.Add("height", obj.Height.Value);
+            else
+                serializedObj.Add("height", "100%");
+
+            if (obj.HoverRows.HasValue)
+                serializedObj.Add("hoverrows", obj.HoverRows.Value);
+
+            if (obj.IgnoreCase.HasValue)
+                serializedObj.Add("ignoreCase", obj.IgnoreCase.Value);
+
+            if (obj.LoadOnce.HasValue)
+                serializedObj.Add("loadonce", obj.LoadOnce.Value);
+
+            if (obj.MethodType != JqGridMethodTypes.Default)
+                serializedObj.Add("mtype", obj.MethodType.ToString().ToUpper());
+
+            if (obj.MultiKey != JqGridMultiKeys.Default)
+                if (obj.MultiKey == JqGridMultiKeys.Disable)
+                    serializedObj.Add("multikey", null);
+                else
+                    serializedObj.Add("multikey", $"{obj.MultiKey.ToString().ToLower()}Key");
+
+            if (obj.MultiBoxOnly.HasValue)
+                serializedObj.Add("multiboxonly", obj.MultiBoxOnly.Value);
+
+            if (obj.MultiSelect.HasValue)
+                serializedObj.Add("multiselect", obj.MultiSelect.Value);
+
+            if (obj.MultiSelectWidth.HasValue)
+                serializedObj.Add("multiselectWidth", obj.MultiSelectWidth.Value);
+
+            if (obj.MultiSort.HasValue)
+                serializedObj.Add("multiSort", obj.MultiSort.Value);
+
+            if (obj.Pager)
+                serializedObj.Add("pager", $"#{obj.Id}Pager");
+
+            if (obj.JsonReader != null && !obj.JsonReader.IsGlobal)
+                serializedObj.Add("jsonReader", obj.JsonReader);
+
+            if (obj.ParametersNames != null && !obj.ParametersNames.IsGlobal)
+                serializedObj.Add("prmNames", obj.ParametersNames);
+
+            serializedObj.Add("remapColumns", obj.ColumnsRemaping);
+
+            if (obj.RowsList != null && obj.RowsList.Any())
+                serializedObj.Add("rowList", obj.RowsList);
+
+            if (obj.RowsNumber.HasValue)
+                serializedObj.Add("rowNum", obj.RowsNumber.Value);
+
+            if (obj.RowsNumbers.HasValue)
+                serializedObj.Add("rownumbers", obj.RowsNumbers.Value);
+
+            if (obj.RowsNumbersWidth.HasValue)
+                serializedObj.Add("rownumWidth", obj.RowsNumbersWidth.Value);
+
+            if (obj.ShrinkToFit.HasValue)
+                serializedObj.Add("shrinkToFit", obj.ShrinkToFit.Value);
+
+            if (obj.ScrollOffset.HasValue)
+                serializedObj.Add("scrollOffset", obj.ScrollOffset.Value);
+
+            if (obj.Sortable.HasValue)
+                serializedObj.Add("sortable", obj.Sortable.Value);
+
+            if (obj.IsSortingNameSetted)
+                serializedObj.Add("sortname", obj.SortingName);
+
+            if (obj.SortingOrder != JqGridSortingOrders.Default)
+                serializedObj.Add("sortorder", obj.SortingOrder.ToString().ToLower());
+
+            if (obj.StyleUI != JqGridStyleUIOptions.Default)
+                serializedObj.Add("styleUI", obj.StyleUI.ToString());
+
+            if (obj.SubgridEnabled.HasValue)
+            {
+                serializedObj.Add("subGrid", obj.SubgridEnabled.Value);
+
+                if (obj.SubgridEnabled.Value)
+                {
+                    if (obj.SubgridModel != null)
+                        serializedObj.Add("subGridModel", obj.SubgridModel);
+
+                    if (obj.IsSubgridUrlSetted)
+                        serializedObj.Add("subGridUrl", obj.SubgridUrl);
+
+                    if (obj.SubgridColumnWidth.HasValue)
+                        serializedObj.Add("subGridWidth", obj.SubgridColumnWidth.Value);
+                }
+            }
+
+            if (obj.TopPager.HasValue)
+                serializedObj.Add("toppager", obj.TopPager.Value);
+
+            if (obj.TreeGridEnabled.HasValue)
+            {
+                serializedObj.Add("treeGrid", obj.TreeGridEnabled.Value);
+
+                if (obj.TreeGridEnabled.Value)
+                {
+                    if (obj.TreeGridModel != JqGridTreeGridModels.Default)
+                        serializedObj.Add("treeGridModel", obj.TreeGridModel.ToString().ToLower());
+
+                    if (obj.ExpandColumnClick.HasValue)
+                        serializedObj.Add("ExpandColClick", obj.ExpandColumnClick);
+
+                    if (obj.IsExpandColumnSetted)
+                        serializedObj.Add("ExpandColumn", obj.ExpandColumn);
+                }
+            }
+
+            if (obj.ViewRecords.HasValue)
+                serializedObj.Add("viewrecords", obj.ViewRecords.Value);
+
+            if (obj.Width.HasValue)
+                serializedObj.Add("width", obj.Width.Value);
+        }
+
+        private static JqGridColumnModel DeserializeJqGridColumnModel(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            string name = GetStringFromSerializedObj(serializedObj, "name");
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                JqGridColumnModel obj = new JqGridColumnModel(name);
+
+                obj.Alignment = GetEnumFromSerializedObj(serializedObj, "align", obj.Alignment);
+                obj.DateFormat = GetSettedStringFromSerializedObj(serializedObj, "datefmt");
+                obj.Classes = GetSettedStringFromSerializedObj(serializedObj, "classes");
+                obj.Editable = GetBooleanFromSerializedObj(serializedObj, "editable");
+                obj.EditType = GetEnumFromSerializedObj(serializedObj, "edittype", JqGridColumnEditTypes.Default);
+
+                if (serializedObj.ContainsKey("editoptions") && serializedObj["editoptions"] is IDictionary<string, object>)
+                    obj.EditOptions = DeserializeJqGridColumnEditOptions((IDictionary<string, object>)serializedObj["editoptions"], serializer);
+
+                if (serializedObj.ContainsKey("editrules") && serializedObj["editrules"] is IDictionary<string, object>)
+                    obj.EditRules = DeserializeJqGridColumnRules((IDictionary<string, object>)serializedObj["editrules"], serializer);
+
+                obj.Fixed = GetBooleanFromSerializedObj(serializedObj, "fixed");
+                obj.Frozen = GetBooleanFromSerializedObj(serializedObj, "frozen");
+                obj.Hidden = GetBooleanFromSerializedObj(serializedObj, "hidden");
+                obj.HideInDialog = GetBooleanFromSerializedObj(serializedObj, "hidedlg");
+
+                obj.Formatter = GetSettedStringFromSerializedObj(serializedObj, "formatter");
+                if (obj.Formatter?.IsSetted ?? false)
+                    obj.Formatter.Value = '\'' + obj.Formatter.Value + '\'';
+
+                if (serializedObj.ContainsKey("formatoptions") && serializedObj["formatoptions"] is IDictionary<string, object>)
+                    obj.FormatterOptions = DeserializeJqGridColumnFormatterOptions((IDictionary<string, object>)serializedObj["formatoptions"], serializer);
+                //obj.UnFormatter = GetStringFromSerializedObj(serializedObj, "unformat");
+
+                if (serializedObj.ContainsKey("formoptions") && serializedObj["formoptions"] is IDictionary<string, object>)
+                    obj.FormOptions = DeserializeJqGridColumnFormOptions((IDictionary<string, object>)serializedObj["formoptions"], serializer);
+
+                obj.InitialSortingOrder = GetEnumFromSerializedObj(serializedObj, "firstsortorder", JqGridSortingOrders.Default);
+                obj.JsonMapping = GetStringFromSerializedObj(serializedObj, "jsonmap");
+                obj.Key = GetBooleanFromSerializedObj(serializedObj, "key");
+                obj.Resizable = GetBooleanFromSerializedObj(serializedObj, "resizable");
+                obj.SummaryType = GetEnumFromSerializedObj<JqGridColumnSummaryTypes>(serializedObj, "summaryType");
+                if (!obj.SummaryType.HasValue)
+                {
+                    obj.SummaryFunction = GetStringFromSerializedObj(serializedObj, "summaryType");
+                    if (!string.IsNullOrWhiteSpace(obj.SummaryFunction))
+                        obj.SummaryType = JqGridColumnSummaryTypes.Custom;
+                }
+
+                obj.SummaryTemplate = GetSettedStringFromSerializedObj(serializedObj, "summaryTpl");
+                obj.Sortable = GetBooleanFromSerializedObj(serializedObj, "sortable");
+                obj.SortType = GetEnumFromSerializedObj(serializedObj, "sorttype", JqGridColumnSortTypes.Default);
+                obj.Index = GetSettedStringFromSerializedObj(serializedObj, "index");
+                obj.Searchable = GetBooleanFromSerializedObj(serializedObj, "search");
+                obj.SearchType = GetEnumFromSerializedObj(serializedObj, "stype", JqGridColumnSearchTypes.Default);
+
+                if (serializedObj.ContainsKey("searchoptions") && serializedObj["searchoptions"] is IDictionary<string, object>)
+                    obj.SearchOptions = DeserializeJqGridColumnSearchOptions((IDictionary<string, object>)serializedObj["searchoptions"], serializer);
+
+                if (serializedObj.ContainsKey("searchrules") && serializedObj["searchrules"] is IDictionary<string, object>)
+                    obj.SearchRules = DeserializeJqGridColumnRules((IDictionary<string, object>)serializedObj["searchrules"], serializer);
+
+                obj.Title = GetBooleanFromSerializedObj(serializedObj, "title");
+                obj.Width = GetInt32FromSerializedObj(serializedObj, "width");
+                obj.Viewable = GetBooleanFromSerializedObj(serializedObj, "viewable");
+                obj.XmlMapping = GetStringFromSerializedObj(serializedObj, "xmlmap");
+
+                return obj;
+            }
+            return null;
+        }
+
+        private static void SerializeJqGridColumnModel(JqGridColumnModel obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.Alignment != JqGridAlignments.Default)
+                serializedObj.Add("align", obj.Alignment.ToString().ToLower());
+
+            if (obj.Classes?.IsSetted ?? false)
+                serializedObj.Add("classes", obj.Classes);
+
+            if (obj.DateFormat?.IsSetted ?? false)
+                serializedObj.Add("datefmt", obj.DateFormat);
+
+            if (obj.Editable.HasValue)
+            {
+                serializedObj.Add("editable", obj.Editable.Value);
+                if (obj.Editable.Value)
+                {
+                    if (obj.EditType != JqGridColumnEditTypes.Default)
+                        serializedObj.Add("edittype", obj.EditType.ToString().ToLower());
+
+                    if (obj.EditOptions != null)
+                        serializedObj.Add("editoptions", obj.EditOptions);
+
+                    if (obj.EditRules != null)
+                        serializedObj.Add("editrules", obj.EditRules);
+
+                    if (obj.FormOptions != null)
+                        serializedObj.Add("formoptions", obj.FormOptions);
+                }
+            }
+
+            if (obj.Fixed.HasValue)
+                serializedObj.Add("fixed", obj.Fixed.Value);
+
+            if (obj.Frozen.HasValue)
+                serializedObj.Add("frozen", obj.Frozen.Value);
+
+            if (obj.InitialSortingOrder != JqGridSortingOrders.Default)
+                serializedObj.Add("firstsortorder", obj.InitialSortingOrder.ToString().ToLower());
+
+            if ((obj.Formatter?.IsSetted ?? false) && obj.Formatter.Value[0] == '\'' && obj.Formatter.Value[obj.Formatter.Value.Length - 1] == '\'')
+            {
+                serializedObj.Add("formatter", obj.Formatter.Value.Substring(1, obj.Formatter.Value.Length - 2));
+
+                if (obj.FormatterOptions != null)
+                    serializedObj.Add("formatoptions", obj.FormatterOptions);
+            }
+
+            //if (!String.IsNullOrWhiteSpace(obj.UnFormatter))
+            //    serializedObj.Add("unformat", obj.UnFormatter);
+
+            if (obj.Hidden.HasValue)
+                serializedObj.Add("hidden", obj.Hidden.Value);
+
+            if (obj.HideInDialog.HasValue)
+                serializedObj.Add("hidedlg", obj.HideInDialog.Value);
+
+            if (!string.IsNullOrWhiteSpace(obj.JsonMapping))
+                serializedObj.Add("jsonmap", obj.JsonMapping);
+
+            if (obj.Key.HasValue)
+                serializedObj.Add("key", obj.Key.Value);
+
+            if (obj.Resizable.HasValue)
+                serializedObj.Add("resizable", obj.Resizable.Value);
+
+            if (obj.SummaryType.HasValue)
+            {
+                if (obj.SummaryType.Value != JqGridColumnSummaryTypes.Custom)
+                    serializedObj.Add("summaryType", obj.SummaryType.Value.ToString().ToLower());
+                else
+                    serializedObj.Add("summaryType", obj.SummaryFunction);
+            }
+
+            if (obj.SummaryTemplate?.IsSetted ?? false)
+                serializedObj.Add("summaryTpl", obj.SummaryTemplate.Value);
+
+            if (obj.Sortable.HasValue)
+                serializedObj.Add("sortable", obj.Sortable.Value);
+
+            if (obj.SortType != JqGridColumnSortTypes.Default && obj.SortType != JqGridColumnSortTypes.Function)
+                serializedObj.Add("sorttype", obj.SortType.ToString().ToLower());
+
+            if (obj.Index?.IsSetted ?? false)
+                serializedObj.Add("index", obj.Index.Value);
+
+            if (obj.Searchable.HasValue)
+            {
+                serializedObj.Add("search", obj.Searchable.Value);
+                if (obj.Searchable.Value)
+                {
+                    if (obj.SearchType != JqGridColumnSearchTypes.Default)
+                        serializedObj.Add("stype", obj.SearchType.ToString().ToLower());
+
+                    if (obj.SearchOptions != null)
+                        serializedObj.Add("searchoptions", obj.SearchOptions);
+
+                    if (obj.SearchRules != null)
+                        serializedObj.Add("searchrules", obj.SearchRules);
+                }
+            }
+
+            serializedObj.Add("name", obj.Name);
+
+            if (obj.Title.HasValue)
+                serializedObj.Add("title", obj.Title.Value);
+
+            if (obj.Width.HasValue)
+                serializedObj.Add("width", obj.Width);
+
+            if (obj.Viewable.HasValue)
+                serializedObj.Add("viewable", obj.Viewable.Value);
+
+            if (!string.IsNullOrWhiteSpace(obj.XmlMapping))
+                serializedObj.Add("xmlmap", obj.XmlMapping);
+        }
+
+        private static JqGridColumnEditOptions DeserializeJqGridColumnEditOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridColumnEditOptions obj = new JqGridColumnEditOptions();
+
+            if (serializedObj.ContainsKey("custom_element"))
+                obj.CustomElementFunction = serializedObj["custom_element"]?.ToString();
+            serializedObj.Remove("custom_element");
+            if (serializedObj.ContainsKey("custom_value"))
+                obj.CustomValueFunction = serializedObj["custom_value"]?.ToString();
+            serializedObj.Remove("custom_value");
+            if (serializedObj.ContainsKey("dataUrl"))
+                obj.DataUrl = serializedObj["dataUrl"]?.ToString();
+            serializedObj.Remove("dataUrl");
+            if (serializedObj.ContainsKey("defaultValue"))
+                obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
+            serializedObj.Remove("defaultValue");
+
+            if (serializedObj.ContainsKey("value") && serializedObj["value"] is IDictionary<string, object>)
+                obj.ValueDictionary = ((IDictionary<string, object>)serializedObj["value"]).ToDictionary(k => k.Key, v => v.Value.ToString());
+            else
+                obj.Value = GetStringFromSerializedObj(serializedObj, "value");
+            serializedObj.Remove("value");
+
+            obj.NullIfEmpty = GetBooleanFromSerializedObj(serializedObj, "NullIfEmpty");
+            serializedObj.Remove("NullIfEmpty");
+            obj.HtmlAttributes = serializedObj;
+
+            return obj;
+        }
+
+        private static void SerializeJqGridColumnEditOptions(JqGridColumnEditOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.IsCustomElementFunctionSetted)
+                serializedObj.Add("custom_element", obj.CustomElementFunction);
+
+            if (obj.IsCustomValueFunctionSetted)
+                serializedObj.Add("custom_value", obj.CustomValueFunction);
+
+            SerializeJqGridColumnElementOptions(obj, serializer, serializedObj);
+
+            if (obj.NullIfEmpty.HasValue)
+                serializedObj.Add("NullIfEmpty", obj.NullIfEmpty.Value);
+
+            if (obj.HtmlAttributes != null)
+                foreach (KeyValuePair<string, object> htmlAttribute in obj.HtmlAttributes)
+                    serializedObj.Add(htmlAttribute.Key, htmlAttribute.Value);
+        }
+
+        private static JqGridJsonReader DeserializeJqGridJsonReader(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridJsonReader obj = new JqGridJsonReader();
+
+            obj.PageIndex = GetStringFromSerializedObj(serializedObj, "page", JqGridResponse.JsonReader.PageIndex);
+            obj.RecordId = GetStringFromSerializedObj(serializedObj, "id", JqGridResponse.JsonReader.RecordId);
+            obj.Records = GetStringFromSerializedObj(serializedObj, "root", JqGridResponse.JsonReader.Records);
+            obj.RecordValues = GetStringFromSerializedObj(serializedObj, "cell", JqGridResponse.JsonReader.RecordValues);
+            obj.RepeatItems = GetBooleanFromSerializedObj(serializedObj, "repeatitems", JqGridResponse.JsonReader.RepeatItems);
+            obj.TotalPagesCount = GetStringFromSerializedObj(serializedObj, "total", JqGridResponse.JsonReader.TotalPagesCount);
+            obj.TotalRecordsCount = GetStringFromSerializedObj(serializedObj, "records", JqGridResponse.JsonReader.TotalRecordsCount);
+            obj.UserData = GetStringFromSerializedObj(serializedObj, "userdata", JqGridResponse.JsonReader.UserData);
+
+            if (serializedObj.ContainsKey("subgrid") && serializedObj["subgrid"] is IDictionary<string, object>)
+            {
+                IDictionary<string, object> serializedSubgrid = (IDictionary<string, object>)serializedObj["subgrid"];
+                obj.SubgridReader.Records = GetStringFromSerializedObj(serializedSubgrid, "root", JqGridResponse.JsonReader.SubgridReader.Records);
+                obj.SubgridReader.RecordValues = GetStringFromSerializedObj(serializedSubgrid, "cell", JqGridResponse.JsonReader.SubgridReader.RecordValues);
+                obj.SubgridReader.RepeatItems = GetBooleanFromSerializedObj(serializedSubgrid, "repeatitems", JqGridResponse.JsonReader.SubgridReader.RepeatItems);
+            }
+
+            return obj;
+        }
+
+        private static void SerializeJqGridJsonReader(JqGridJsonReader obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.Records != JqGridResponse.JsonReader.Records)
+                serializedObj.Add("root", obj.Records);
+
+            if (obj.PageIndex != JqGridResponse.JsonReader.PageIndex)
+                serializedObj.Add("page", obj.PageIndex);
+
+            if (obj.TotalPagesCount != JqGridResponse.JsonReader.TotalPagesCount)
+                serializedObj.Add("total", obj.TotalPagesCount);
+
+            if (obj.TotalRecordsCount != JqGridResponse.JsonReader.TotalRecordsCount)
+                serializedObj.Add("records", obj.TotalRecordsCount);
+
+            if (!obj.RepeatItems)
+                serializedObj.Add("repeatitems", false);
+
+            if (obj.RecordValues != JqGridResponse.JsonReader.RecordValues)
+                serializedObj.Add("cell", obj.RecordValues);
+
+            if (obj.RecordId != JqGridResponse.JsonReader.RecordId)
+                serializedObj.Add("id", obj.RecordId);
+
+            if (obj.UserData != JqGridResponse.JsonReader.UserData)
+                serializedObj.Add("userdata", obj.UserData);
+
+            if (!obj.SubgridReader.IsDefault())
+            {
+                Dictionary<string, object> serializedSubgrid = new Dictionary<string, object>();
+
+                if (obj.SubgridReader.Records != JqGridResponse.JsonReader.SubgridReader.Records)
+                    serializedSubgrid.Add("root", obj.SubgridReader.Records);
+
+                if (!obj.SubgridReader.RepeatItems)
+                    serializedSubgrid.Add("repeatitems", false);
+
+                if (obj.SubgridReader.RecordValues != JqGridResponse.JsonReader.SubgridReader.RecordValues)
+                    serializedSubgrid.Add("cell", obj.SubgridReader.RecordValues);
+
+                serializedObj.Add("subgrid", serializedSubgrid);
+            }
+        }
+
+        private static JqGridParametersNames DeserializeJqGridParametersNames(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridParametersNames obj = new JqGridParametersNames();
+
+            obj.PageIndex = GetStringFromSerializedObj(serializedObj, "page", JqGridRequest.ParameterNames.PageIndex);
+            obj.RecordsCount = GetStringFromSerializedObj(serializedObj, "rows", JqGridRequest.ParameterNames.RecordsCount);
+            obj.SortingName = GetStringFromSerializedObj(serializedObj, "sort", JqGridRequest.ParameterNames.SortingName);
+            obj.SortingOrder = GetStringFromSerializedObj(serializedObj, "order", JqGridRequest.ParameterNames.SortingOrder);
+            obj.Searching = GetStringFromSerializedObj(serializedObj, "search", JqGridRequest.ParameterNames.Searching);
+            obj.Id = GetStringFromSerializedObj(serializedObj, "id", JqGridRequest.ParameterNames.Id);
+            obj.Operator = GetStringFromSerializedObj(serializedObj, "oper", JqGridRequest.ParameterNames.Operator);
+            obj.EditOperator = GetStringFromSerializedObj(serializedObj, "editoper", JqGridRequest.ParameterNames.EditOperator);
+            obj.AddOperator = GetStringFromSerializedObj(serializedObj, "addoper", JqGridRequest.ParameterNames.AddOperator);
+            obj.DeleteOperator = GetStringFromSerializedObj(serializedObj, "deloper", JqGridRequest.ParameterNames.DeleteOperator);
+            obj.SubgridId = GetStringFromSerializedObj(serializedObj, "subgridid", JqGridRequest.ParameterNames.SubgridId);
+            obj.PagesCount = GetStringFromSerializedObj(serializedObj, "npage", JqGridRequest.ParameterNames.PagesCount);
+            obj.TotalRows = GetStringFromSerializedObj(serializedObj, "totalrows", JqGridRequest.ParameterNames.TotalRows);
+
+            return obj;
+        }
+
+        private static void SerializeJqGridParametersNames(JqGridParametersNames obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.PageIndex != JqGridRequest.ParameterNames.PageIndex)
+                serializedObj.Add("page", obj.PageIndex);
+
+            if (obj.RecordsCount != JqGridRequest.ParameterNames.RecordsCount)
+                serializedObj.Add("rows", obj.RecordsCount);
+
+            if (obj.SortingName != JqGridRequest.ParameterNames.SortingName)
+                serializedObj.Add("sort", obj.SortingName);
+
+            if (obj.SortingOrder != JqGridRequest.ParameterNames.SortingOrder)
+                serializedObj.Add("order", obj.SortingOrder);
+
+            if (obj.Searching != JqGridRequest.ParameterNames.Searching)
+                serializedObj.Add("search", obj.Searching);
+
+            if (obj.Id != JqGridRequest.ParameterNames.Id)
+                serializedObj.Add("id", obj.Id);
+
+            if (obj.Operator != JqGridRequest.ParameterNames.Operator)
+                serializedObj.Add("oper", obj.Operator);
+
+            if (obj.EditOperator != JqGridRequest.ParameterNames.EditOperator)
+                serializedObj.Add("editoper", obj.EditOperator);
+
+            if (obj.AddOperator != JqGridRequest.ParameterNames.AddOperator)
+                serializedObj.Add("addoper", obj.AddOperator);
+
+            if (obj.DeleteOperator != JqGridRequest.ParameterNames.DeleteOperator)
+                serializedObj.Add("deloper", obj.DeleteOperator);
+
+            if (obj.SubgridId != JqGridRequest.ParameterNames.SubgridId)
+                serializedObj.Add("subgridid", obj.SubgridId);
+
+            if (obj.PagesCount != JqGridRequest.ParameterNames.PagesCount)
+                serializedObj.Add("npage", obj.PagesCount);
+
+            if (obj.TotalRows != JqGridRequest.ParameterNames.TotalRows)
+                serializedObj.Add("totalrows", obj.TotalRows);
+        }
+
+        private static JqGridGroupingView DeserializeJqGridGroupingView(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridGroupingView obj = new JqGridGroupingView();
+
+            if (serializedObj.ContainsKey("groupField") && serializedObj["groupField"] is ArrayList)
+                obj.Fields = (string[])((ArrayList)serializedObj["groupField"]).ToArray(typeof(string));
+
+            if (serializedObj.ContainsKey("groupOrder") && serializedObj["groupOrder"] is ArrayList)
+                obj.Orders = (JqGridSortingOrders[])((ArrayList)serializedObj["groupOrder"]).ToArray(typeof(JqGridSortingOrders));
+
+            if (serializedObj.ContainsKey("groupText") && serializedObj["groupText"] is ArrayList)
+                obj.Texts = (string[])((ArrayList)serializedObj["groupText"]).ToArray(typeof(string));
+
+            if (serializedObj.ContainsKey("groupSummary") && serializedObj["groupSummary"] is ArrayList)
+                obj.Summary = (bool[])((ArrayList)serializedObj["groupSummary"]).ToArray(typeof(bool));
+
+            if (serializedObj.ContainsKey("groupColumnShow") && serializedObj["groupColumnShow"] is ArrayList)
+                obj.ColumnShow = (bool[])((ArrayList)serializedObj["groupColumnShow"]).ToArray(typeof(bool));
+
+            obj.SummaryOnHide = GetBooleanFromSerializedObj(serializedObj, "showSummaryOnHide", false);
+            obj.DataSorted = GetBooleanFromSerializedObj(serializedObj, "groupDataSorted", false);
+            obj.Collapse = GetBooleanFromSerializedObj(serializedObj, "groupCollapse", false);
+            obj.PlusIcon = GetStringFromSerializedObj(serializedObj, "plusicon", JqGridOptionsDefaults.GroupingPlusIcon);
+            obj.MinusIcon = GetStringFromSerializedObj(serializedObj, "minusicon", JqGridOptionsDefaults.GroupingMinusIcon);
+
+            return obj;
+        }
+
+        private static void SerializeJqGridGroupingView(JqGridGroupingView obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.Fields != null && obj.Fields.Length > 0)
+                serializedObj.Add("groupField", obj.Fields);
+
+            if (obj.Orders != null && obj.Orders.Length > 0 && obj.Orders.Contains(JqGridSortingOrders.Desc))
+                serializedObj.Add("groupOrder", obj.Orders);
+
+            if (obj.Texts != null && obj.Texts.Length > 0)
+                serializedObj.Add("groupText", obj.Texts);
+
+            if (obj.Summary != null && obj.Summary.Length > 0 && obj.Summary.Contains(true))
+                serializedObj.Add("groupSummary", obj.Summary);
+
+            if (obj.ColumnShow != null && obj.ColumnShow.Length > 0 && obj.ColumnShow.Contains(false))
+                serializedObj.Add("groupColumnShow", obj.ColumnShow);
+
+            if (obj.SummaryOnHide)
+                serializedObj.Add("showSummaryOnHide", true);
+
+            if (obj.DataSorted)
+                serializedObj.Add("groupDataSorted", true);
+
+            if (obj.Collapse)
+                serializedObj.Add("groupCollapse", true);
+
+            if (obj.PlusIcon != JqGridOptionsDefaults.GroupingPlusIcon)
+                serializedObj.Add("plusicon", obj.PlusIcon);
+
+            if (obj.MinusIcon != JqGridOptionsDefaults.GroupingMinusIcon)
+                serializedObj.Add("minusicon", obj.MinusIcon);
+        }
+
+        private static JqGridColumnRules DeserializeJqGridColumnRules(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridColumnRules obj = new JqGridColumnRules();
+
+            obj.Custom = GetBooleanFromSerializedObj(serializedObj, "custom");
+            if (serializedObj.ContainsKey("custom_func"))
+                obj.CustomFunction = serializedObj["custom_func"]?.ToString();
+            obj.Date = GetBooleanFromSerializedObj(serializedObj, "date");
+            obj.EditHidden = GetBooleanFromSerializedObj(serializedObj, "edithidden");
+            obj.Email = GetBooleanFromSerializedObj(serializedObj, "email");
+            obj.Integer = GetBooleanFromSerializedObj(serializedObj, "integer", false);
+            obj.MaxValue = GetDoubleFromSerializedObj(serializedObj, "maxValue");
+            obj.MinValue = GetDoubleFromSerializedObj(serializedObj, "minValue");
+            obj.Number = GetBooleanFromSerializedObj(serializedObj, "number", false);
+            obj.Required = GetBooleanFromSerializedObj(serializedObj, "required");
+            obj.Time = GetBooleanFromSerializedObj(serializedObj, "time");
+            obj.Url = GetBooleanFromSerializedObj(serializedObj, "url");
+
+            return obj;
+        }
+
+        private static void SerializeJqGridColumnRules(JqGridColumnRules obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.Custom.HasValue)
+                serializedObj.Add("custom", obj.Custom.Value);
+
+            if (obj.IsCustomFunctionSetted)
+                serializedObj.Add("custom_func", obj.CustomFunction);
+
+            if (obj.Date.HasValue)
+                serializedObj.Add("date", obj.Date.Value);
+
+            if (obj.EditHidden.HasValue)
+                serializedObj.Add("edithidden", obj.EditHidden.Value);
+
+            if (obj.Email.HasValue)
+                serializedObj.Add("email", obj.Email.Value);
+
+            if (obj.Integer)
+                serializedObj.Add("integer", true);
+
+            if (obj.MaxValue.HasValue)
+                serializedObj.Add("maxValue", obj.MaxValue.Value);
+
+            if (obj.MinValue.HasValue)
+                serializedObj.Add("minValue", obj.MinValue.Value);
+
+            if (obj.Number)
+                serializedObj.Add("number", true);
+
+            if (obj.Required.HasValue)
+                serializedObj.Add("required", obj.Required.Value);
+
+            if (obj.Time.HasValue)
+                serializedObj.Add("time", obj.Time.Value);
+
+            if (obj.Url.HasValue)
+                serializedObj.Add("url", obj.Url.Value);
+        }
+
+        private static JqGridColumnFormOptions DeserializeJqGridColumnFormOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridColumnFormOptions obj = new JqGridColumnFormOptions();
+
+            obj.ColumnPosition = GetInt32FromSerializedObj(serializedObj, "colpos");
+            if (serializedObj.ContainsKey("elmprefix"))
+                obj.ElementPrefix = serializedObj["elmprefix"]?.ToString();
+            if (serializedObj.ContainsKey("elmsuffix"))
+                obj.ElementSuffix = serializedObj["elmsuffix"]?.ToString();
+            if (serializedObj.ContainsKey("label"))
+                obj.Label = serializedObj["label"]?.ToString();
+            obj.RowPosition = GetInt32FromSerializedObj(serializedObj, "rowpos");
+
+            return obj;
+        }
+
+        private static void SerializeJqGridColumnFormOptions(JqGridColumnFormOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.ColumnPosition.HasValue)
+                serializedObj.Add("colpos", obj.ColumnPosition.Value);
+
+            if (obj.IsElementPrefixSetted)
+                serializedObj.Add("elmprefix", obj.ElementPrefix);
+
+            if (obj.IsElementSuffixSetted)
+                serializedObj.Add("elmsuffix", obj.ElementSuffix);
+
+            if (obj.IsLabelSetted)
+                serializedObj.Add("label", obj.Label);
+
+            if (obj.RowPosition.HasValue)
+                serializedObj.Add("rowpos", obj.RowPosition.Value);
+        }
+
+        private static JqGridColumnFormatterOptions DeserializeJqGridColumnFormatterOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridColumnFormatterOptions obj = new JqGridColumnFormatterOptions();
+
+            if (serializedObj.ContainsKey("addParam"))
+                obj.AddParam = serializedObj["addParam"]?.ToString();
+            if (serializedObj.ContainsKey("baseLinkUrl"))
+                obj.BaseLinkUrl = serializedObj["baseLinkUrl"]?.ToString();
+            obj.DecimalPlaces = GetInt32FromSerializedObj(serializedObj, "decimalPlaces");
+            if (serializedObj.ContainsKey("decimalSeparator"))
+                obj.DecimalSeparator = serializedObj["decimalSeparator"]?.ToString();
+            if (serializedObj.ContainsKey("defaultValue"))
+                obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
+            obj.Disabled = GetBooleanFromSerializedObj(serializedObj, "disabled");
+            if (serializedObj.ContainsKey("idName"))
+                obj.IdName = serializedObj["idName"]?.ToString();
+            if (serializedObj.ContainsKey("srcformat"))
+                obj.OutputFormat = serializedObj["srcformat"]?.ToString();
+            if (serializedObj.ContainsKey("prefix"))
+                obj.Prefix = serializedObj["prefix"]?.ToString();
+            if (serializedObj.ContainsKey("showAction"))
+                obj.ShowAction = serializedObj["showAction"]?.ToString();
+            if (serializedObj.ContainsKey("newformat"))
+                obj.SourceFormat = serializedObj["newformat"]?.ToString();
+            if (serializedObj.ContainsKey("suffix"))
+                obj.Suffix = serializedObj["suffix"]?.ToString();
+            if (serializedObj.ContainsKey("target"))
+                obj.Target = serializedObj["target"]?.ToString();
+            if (serializedObj.ContainsKey("thousandsSeparator"))
+                obj.ThousandsSeparator = serializedObj["thousandsSeparator"]?.ToString();
+            return obj;
+        }
+
+        private static void SerializeJqGridColumnFormatterOptions(JqGridColumnFormatterOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.IsAddParamSetted)
+                serializedObj.Add("addParam", obj.AddParam);
+            if (obj.IsBaseLinkUrlSetted)
+                serializedObj.Add("baseLinkUrl", obj.BaseLinkUrl);
+            if (obj.DecimalPlaces.HasValue)
+                serializedObj.Add("decimalPlaces", obj.DecimalPlaces.Value);
+            if (obj.IsDecimalSeparatorSetted)
+                serializedObj.Add("decimalSeparator", obj.DecimalSeparator);
+            if (obj.IsDefaultValueSetted)
+                serializedObj.Add("defaultValue", obj.DefaultValue);
+            if (obj.Disabled.HasValue)
+                serializedObj.Add("disabled", obj.Disabled.Value);
+            if (obj.IsIdNameSetted)
+                serializedObj.Add("idName", obj.IdName);
+            if (obj.IsOutputFormatSetted)
+                serializedObj.Add("srcformat", obj.OutputFormat);
+            if (obj.IsPrefixSetted)
+                serializedObj.Add("prefix", obj.Prefix);
+            if (obj.IsShowActionSetted)
+                serializedObj.Add("showAction", obj.ShowAction);
+            if (obj.IsSourceFormatSetted)
+                serializedObj.Add("newformat", obj.SourceFormat);
+            if (obj.IsSuffixSetted)
+                serializedObj.Add("suffix", obj.Suffix);
+            if (obj.IsTargetSetted)
+                serializedObj.Add("target", obj.Target);
+            if (obj.IsThousandsSeparatorSetted)
+                serializedObj.Add("thousandsSeparator", obj.ThousandsSeparator);
+        }
+
+        private static void SerializeJqGridColumnElementOptions(JqGridColumnElementOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            if (obj.IsDataUrlSetted)
+                serializedObj.Add("dataUrl", obj.DataUrl);
+
+            if (obj.IsDefaultValueSetted)
+                serializedObj.Add("defaultValue", obj.DefaultValue);
+
+            if (obj.IsValueSetted)
+                serializedObj.Add("value", obj.Value);
+            else if (obj.ValueDictionary != null)
+                serializedObj.Add("value", obj.ValueDictionary);
+        }
+
+        private static JqGridColumnSearchOptions DeserializeJqGridColumnSearchOptions(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridColumnSearchOptions obj = new JqGridColumnSearchOptions();
+
+            obj.ClearSearch = GetBooleanFromSerializedObj(serializedObj, "clearSearch");
+            if (serializedObj.ContainsKey("dataUrl"))
+                obj.DataUrl = serializedObj["dataUrl"]?.ToString();
+            if (serializedObj.ContainsKey("defaultValue"))
+                obj.DefaultValue = serializedObj["defaultValue"]?.ToString();
+
+            if (serializedObj.ContainsKey("value") && serializedObj["value"] is IDictionary<string, object>)
+                obj.ValueDictionary = ((IDictionary<string, object>)serializedObj["value"]).ToDictionary(k => k.Key, v => v.Value.ToString());
+            else
+                obj.Value = GetStringFromSerializedObj(serializedObj, "value");
+
+            if (serializedObj.ContainsKey("attr") && serializedObj["attr"] is IDictionary<string, object>)
+                obj.HtmlAttributes = (IDictionary<string, object>)serializedObj["attr"];
+
+            obj.SearchHidden = GetBooleanFromSerializedObj(serializedObj, "searchhidden");
+
+            if (serializedObj.ContainsKey("sopt") && serializedObj["sopt"] is ArrayList)
+            {
+                JqGridSearchOperators? searchOperators = null;
+                foreach (object innerSerializedObj in (ArrayList)serializedObj["sopt"])
+                {
+                    if (Enum.TryParse(innerSerializedObj.ToString(), true, out JqGridSearchOperators searchOperator))
+                    {
+                        if (searchOperators.HasValue)
+                            searchOperators = searchOperators | searchOperator;
+                        else
+                            searchOperators = searchOperator;
+                    }
+                }
+
+                if (searchOperators.HasValue)
+                    obj.SearchOperators = searchOperators.Value;
+            }
+
+            return obj;
+        }
+
+        private static void SerializeJqGridColumnSearchOptions(JqGridColumnSearchOptions obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            SerializeJqGridColumnElementOptions(obj, serializer, serializedObj);
+
+            if (obj.HtmlAttributes != null && obj.HtmlAttributes.Count > 0)
+                serializedObj.Add("attr", obj.HtmlAttributes);
+
+            if (obj.ClearSearch.HasValue)
+                serializedObj.Add("clearSearch", obj.ClearSearch);
+
+            if (obj.SearchHidden.HasValue)
+                serializedObj.Add("searchhidden", obj.SearchHidden);
+
+            if (obj.SearchOperators != JqGridSearchOperators.Default)
+            {
+                List<string> searchOperators = new List<string>();
+                foreach (JqGridSearchOperators searchOperator in Enum.GetValues(typeof(JqGridSearchOperators)))
+                {
+                    if (searchOperator != JqGridSearchOperators.EqualOrNotEqual && searchOperator != JqGridSearchOperators.NoTextOperators && searchOperator != JqGridSearchOperators.TextOperators && (obj.SearchOperators & searchOperator) == searchOperator)
+                        searchOperators.Add(Enum.GetName(typeof(JqGridSearchOperators), searchOperator).ToLower());
+                }
+                serializedObj.Add("sopt", searchOperators);
+            }
+        }
+
+        private static JqGridSubgridModel DeserializeJqGridSubgridModel(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridSubgridModel obj = new JqGridSubgridModel();
+
+            if (serializedObj.ContainsKey("name") && serializedObj["name"] is ArrayList)
+            {
+                foreach (object innerSerializedObj in (ArrayList)serializedObj["name"])
+                    obj.ColumnsNames.Add(innerSerializedObj.ToString());
+            }
+
+            if (serializedObj.ContainsKey("align") && serializedObj["align"] is ArrayList)
+            {
+                foreach (object innerSerializedObj in (ArrayList)serializedObj["align"])
+                {
+                    Enum.TryParse(innerSerializedObj.ToString(), true, out JqGridAlignments alignment);
+                    obj.ColumnsAlignments.Add(alignment);
+                }
+            }
+
+            if (serializedObj.ContainsKey("width") && serializedObj["width"] is ArrayList)
+            {
+                foreach (object innerSerializedObj in (ArrayList)serializedObj["width"])
+                {
+                    if (innerSerializedObj is int i)
+                        obj.ColumnsWidths.Add(i);
+                }
+            }
+
+            return obj;
+        }
+
+        private static void SerializeJqGridSubgridModel(JqGridSubgridModel obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            serializedObj.Add("name", obj.ColumnsNames);
+
+            List<string> alignments = new List<string>();
+            foreach (JqGridAlignments alignment in obj.ColumnsAlignments)
+                alignments.Add(alignment.ToString().ToLower());
+            serializedObj.Add("align", alignments);
+
+            serializedObj.Add("width", obj.ColumnsWidths);
+        }
+
+        private static void SerializeJqGridResponse(JqGridResponse obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            JqGridJsonReader jsonReader = obj.Reader ?? JqGridResponse.JsonReader;
+
+            if (!obj.IsSubgridResponse)
+            {
+                serializedObj.Add(jsonReader.PageIndex, obj.PageIndex + 1);
+                serializedObj.Add(jsonReader.TotalRecordsCount, obj.TotalRecordsCount);
+                serializedObj.Add(jsonReader.TotalPagesCount, obj.TotalPagesCount);
+
+                if (obj.UserData != null)
+                    serializedObj.Add(jsonReader.UserData, obj.UserData);
+            }
+
+            serializedObj.Add(obj.IsSubgridResponse ? jsonReader.SubgridReader.Records : jsonReader.Records, SerializeJqGridRecords(obj.Records, obj.IsSubgridResponse, jsonReader));
+        }
+
+        private static List<object> SerializeJqGridRecords(List<JqGridRecord> objs, bool isSubgridResponse, JqGridJsonReader jsonReader)
+        {
+            bool isRecordIndexInt = int.TryParse(jsonReader.RecordId, out int recordIdIndex);
+            bool isRecordValuesEmpty = string.IsNullOrWhiteSpace(jsonReader.RecordValues);
+            bool repeatItems = isSubgridResponse ? jsonReader.SubgridReader.RepeatItems : jsonReader.RepeatItems;
+
+            if (!isSubgridResponse)
+            {
+                if (repeatItems && isRecordValuesEmpty && !isRecordIndexInt)
+                    throw new InvalidOperationException("JqGridJsonReader.RecordId must be a number when JqGridJsonReader.RepeatItems is set to true and JqGridJsonReader.RecordValues is set to empty string.");
+
+                if (repeatItems && !isRecordValuesEmpty && isRecordIndexInt)
+                    throw new InvalidOperationException("JqGridJsonReader.RecordValues can't be an empty string when JqGridJsonReader.RepeatItems is set to true and JqGridJsonReader.RecordId is a number.");
+            }
+
+            List<object> serializedObjs = new List<object>();
+
+            foreach (JqGridRecord obj in objs)
+            {
+                JqGridAdjacencyTreeRecord adjacencyTreeRecord = obj as JqGridAdjacencyTreeRecord;
+                JqGridNestedSetTreeRecord nestedSetTreeRecord = obj as JqGridNestedSetTreeRecord;
+                if (repeatItems)
+                {
+                    List<object> values = obj.Values;
+
+                    if (!isSubgridResponse)
+                    {
+                        if (adjacencyTreeRecord != null)
+                        {
+                            values.Add(adjacencyTreeRecord.Level);
+                            values.Add(adjacencyTreeRecord.ParentId);
+                            values.Add(adjacencyTreeRecord.Leaf);
+                            values.Add(adjacencyTreeRecord.Expanded);
+                        }
+                        else if (nestedSetTreeRecord != null)
+                        {
+                            values.Add(nestedSetTreeRecord.Level);
+                            values.Add(nestedSetTreeRecord.LeftField);
+                            values.Add(nestedSetTreeRecord.RightField);
+                            values.Add(nestedSetTreeRecord.Leaf);
+                            values.Add(nestedSetTreeRecord.Expanded);
+                        }
+                    }
+
+                    if (isRecordValuesEmpty)
+                    {
+                        if (!isSubgridResponse && Convert.ToString(values[recordIdIndex]) != obj.Id)
+                            values.Insert(recordIdIndex, obj.Id);
+                        serializedObjs.Add(values);
+                    }
+                    else
+                    {
+                        Dictionary<string, object> serializedObj = new Dictionary<string, object>();
+                        serializedObj.Add(isSubgridResponse ? jsonReader.SubgridReader.RecordValues : jsonReader.RecordValues, values);
+                        if (!isSubgridResponse)
+                            serializedObj.Add(jsonReader.RecordId, obj.Id);
+                        serializedObjs.Add(serializedObj);
+                    }
+                }
+                else
+                {
+                    if (obj.Value == null)
+                        throw new InvalidOperationException("JqGridRecord.Value can't be null when JqGridJsonReader.RepeatItems is set to false.");
+
+                    Dictionary<string, object> serializedObj = obj.GetValuesAsDictionary();
+
+                    if (!isSubgridResponse)
+                    {
+                        if (adjacencyTreeRecord != null)
+                        {
+                            serializedObj.Add("level", adjacencyTreeRecord.Level);
+                            serializedObj.Add("parent", adjacencyTreeRecord.ParentId);
+                            serializedObj.Add("isLeaf", adjacencyTreeRecord.Leaf);
+                            serializedObj.Add("expanded", adjacencyTreeRecord.Expanded);
+                        }
+                        else if (nestedSetTreeRecord != null)
+                        {
+                            serializedObj.Add("level", nestedSetTreeRecord.Level);
+                            serializedObj.Add("lft", nestedSetTreeRecord.LeftField);
+                            serializedObj.Add("rgt", nestedSetTreeRecord.RightField);
+                            serializedObj.Add("isLeaf", nestedSetTreeRecord.Leaf);
+                            serializedObj.Add("expanded", nestedSetTreeRecord.Expanded);
+                        }
+                    }
+
+                    if (!isSubgridResponse && !isRecordIndexInt && !serializedObj.ContainsKey(jsonReader.RecordId))
+                        serializedObj.Add(jsonReader.RecordId, obj.Id);
+
+                    serializedObjs.Add(serializedObj);
+                }
+            }
+
+            return serializedObjs;
+        }
+
+        private static JqGridRequestSearchingFilters DeserializeJqGridRequestSearchingFilters(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridRequestSearchingFilters obj = new JqGridRequestSearchingFilters();
+
+            obj.GroupingOperator = GetEnumFromSerializedObj<JqGridSearchGroupingOperators>(serializedObj, "groupOp", JqGridSearchGroupingOperators.And);
+            if (serializedObj.ContainsKey("rules") && serializedObj["rules"] is ArrayList)
+            {
+                foreach (object innerSerializedObj in (ArrayList)serializedObj["rules"])
+                {
+                    if (innerSerializedObj is IDictionary<string, object>)
+                    {
+                        JqGridRequestSearchingFilter searchingFilter = DeserializeJqGridRequestSearchingFilter((IDictionary<string, object>)innerSerializedObj, serializer);
+                        obj.Filters.Add(searchingFilter);
+                    }
+                }
+            }
+            if (serializedObj.ContainsKey("groups") && serializedObj["groups"] is ArrayList)
+            {
+                foreach (object innerSerializedObj in (ArrayList)serializedObj["groups"])
+                {
+                    if (innerSerializedObj is IDictionary<string, object>)
+                    {
+                        JqGridRequestSearchingFilters searchingFilters = DeserializeJqGridRequestSearchingFilters((IDictionary<string, object>)innerSerializedObj, serializer);
+                        obj.Groups.Add(searchingFilters);
+                    }
+                }
+            }
+
+            return obj;
+        }
+
+        private static void SerializeJqGridRequestSearchingFilters(JqGridRequestSearchingFilters obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            serializedObj.Add("groupOp", obj.GroupingOperator.ToString().ToUpper());
+
+            if (obj.Filters != null && obj.Filters.Count > 0)
+                serializedObj.Add("rules", obj.Filters);
+
+            if (obj.Groups != null && obj.Groups.Count > 0)
+                serializedObj.Add("groups", obj.Groups);
+        }
+
+        private static JqGridRequestSearchingFilter DeserializeJqGridRequestSearchingFilter(IDictionary<string, object> serializedObj, JavaScriptSerializer serializer)
+        {
+            JqGridRequestSearchingFilter obj = new JqGridRequestSearchingFilter();
+
+            obj.SearchingName = GetStringFromSerializedObj(serializedObj, "field");
+            obj.SearchingOperator = GetEnumFromSerializedObj(serializedObj, "op", JqGridSearchOperators.Eq);
+            obj.SearchingValue = GetStringFromSerializedObj(serializedObj, "data");
+            return obj;
+        }
+
+        private static void SerializeJqGridRequestSearchingFilter(JqGridRequestSearchingFilter obj, JavaScriptSerializer serializer, Dictionary<string, object> serializedObj)
+        {
+            serializedObj.Add("field", obj.SearchingName);
+            serializedObj.Add("op", obj.SearchingOperator.ToString().ToLower());
+            serializedObj.Add("data", obj.SearchingValue);
+        }
+
+        private static bool? GetBooleanFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is bool)
+                return (bool)serializedObj[key];
+            return null;
+        }
+
+        private static bool GetBooleanFromSerializedObj(IDictionary<string, object> serializedObj, string key, bool defaultValue)
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is bool)
+                return (bool)serializedObj[key];
+            return defaultValue;
+        }
+
+        private static double? GetDoubleFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && double.TryParse(serializedObj[key].ToString(), out double value))
+                return value;
+            return null;
+        }
+
+        private static TEnum? GetEnumFromSerializedObj<TEnum>(IDictionary<string, object> serializedObj, string key) where TEnum : struct
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Enum.TryParse<TEnum>(serializedObj[key].ToString(), true, out TEnum value))
+                return value;
+            return null;
+        }
+
+        private static TEnum GetEnumFromSerializedObj<TEnum>(IDictionary<string, object> serializedObj, string key, TEnum defaultValue) where TEnum : struct
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && Enum.TryParse(serializedObj[key].ToString(), true, out TEnum value))
+                return value;
+            return defaultValue;
+        }
+
+        private static int? GetInt32FromSerializedObj(IDictionary<string, object> serializedObj, string key)
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is int)
+                return (int)serializedObj[key];
+            return null;
+        }
+
+        private static int GetInt32FromSerializedObj(IDictionary<string, object> serializedObj, string key, int defaultValue)
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null && serializedObj[key] is int)
+                return (int)serializedObj[key];
+            return defaultValue;
+        }
+
+        private static List<int> GetInt32ArrayFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+        {
+            List<int> array = null;
+
+            if (serializedObj.ContainsKey(key) && serializedObj[key] is ArrayList)
+            {
+                array = new List<int>();
+                ArrayList serializedArray = (ArrayList)serializedObj[key];
+                foreach (object serializedItem in serializedArray)
+                {
+                    if (serializedItem is int i)
+                        array.Add(i);
+                }
+            }
+
+            return array;
+        }
+
+        private static string GetStringFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
+                return serializedObj[key].ToString();
+            return null;
+        }
+
+        private static string GetStringFromSerializedObj(IDictionary<string, object> serializedObj, string key, string defaultValue)
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
+                return serializedObj[key].ToString();
+            return defaultValue;
+        }
+
+        private static SettedString GetSettedStringFromSerializedObj(IDictionary<string, object> serializedObj, string key)
+        {
+            if (serializedObj.ContainsKey(key) && serializedObj[key] != null)
+                return new SettedString(true, serializedObj[key].ToString());
+            return new SettedString(false, null);
+        }
+        #endregion
+    }
 }

--- a/Lib.Web.Mvc/JQuery/JqGrid/SettedString.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/SettedString.cs
@@ -1,0 +1,42 @@
+﻿namespace Lib.Web.Mvc.JQuery.JqGrid
+{
+	/// <summary>
+	/// Represent string with state setted or not setted
+	/// </summary>
+	public class SettedString
+	{
+		private string _value;
+		/// <summary>
+		/// Is string was setted
+		/// </summary>
+		public bool IsSetted { get; }
+		/// <summary>
+		/// Return value. If string is null or empty it returns string "null"
+		/// </summary>
+		public string Value
+		{
+			get => string.IsNullOrWhiteSpace(_value) ? "null" : _value;
+			set => _value = value;
+		}
+
+		/// <summary>
+		/// Initialize new instance of SettedString
+		/// </summary>
+		/// <param name="isSetted">Is string setted</param>
+		/// <param name="value">String value</param>
+		public SettedString(bool isSetted, string value)
+		{
+			IsSetted = isSetted;
+			Value = value;
+		}
+
+		/// <summary>
+		/// Return Value
+		/// </summary>
+		/// <returns></returns>
+		public override string ToString()
+		{
+			return Value;
+		}
+	}
+}

--- a/Lib.Web.Mvc/JQuery/JqGrid/SettedString.cs
+++ b/Lib.Web.Mvc/JQuery/JqGrid/SettedString.cs
@@ -1,42 +1,42 @@
 ﻿namespace Lib.Web.Mvc.JQuery.JqGrid
 {
-	/// <summary>
-	/// Represent string with state setted or not setted
-	/// </summary>
-	public class SettedString
-	{
-		private string _value;
-		/// <summary>
-		/// Is string was setted
-		/// </summary>
-		public bool IsSetted { get; }
-		/// <summary>
-		/// Return value. If string is null or empty it returns string "null"
-		/// </summary>
-		public string Value
-		{
-			get => string.IsNullOrWhiteSpace(_value) ? "null" : _value;
-			set => _value = value;
-		}
+    /// <summary>
+    /// Represent string with state setted or not setted
+    /// </summary>
+    public class SettedString
+    {
+        private string _value;
+        /// <summary>
+        /// Is string was setted
+        /// </summary>
+        public bool IsSetted { get; }
+        /// <summary>
+        /// Return value. If string is null or empty it returns string "null"
+        /// </summary>
+        public string Value
+        {
+            get => string.IsNullOrWhiteSpace(_value) ? "null" : _value;
+            set => _value = value;
+        }
 
-		/// <summary>
-		/// Initialize new instance of SettedString
-		/// </summary>
-		/// <param name="isSetted">Is string setted</param>
-		/// <param name="value">String value</param>
-		public SettedString(bool isSetted, string value)
-		{
-			IsSetted = isSetted;
-			Value = value;
-		}
+        /// <summary>
+        /// Initialize new instance of SettedString
+        /// </summary>
+        /// <param name="isSetted">Is string setted</param>
+        /// <param name="value">String value</param>
+        public SettedString(bool isSetted, string value)
+        {
+            IsSetted = isSetted;
+            Value = value;
+        }
 
-		/// <summary>
-		/// Return Value
-		/// </summary>
-		/// <returns></returns>
-		public override string ToString()
-		{
-			return Value;
-		}
-	}
+        /// <summary>
+        /// Return Value
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
 }

--- a/Lib.Web.Mvc/JetBrains.Annotations.cs
+++ b/Lib.Web.Mvc/JetBrains.Annotations.cs
@@ -1,0 +1,1065 @@
+﻿/* MIT License
+
+Copyright (c) 2016 JetBrains http://www.jetbrains.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+using System;
+
+#pragma warning disable 1591
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable IntroduceOptionalParameters.Global
+// ReSharper disable MemberCanBeProtected.Global
+// ReSharper disable InconsistentNaming
+
+namespace JetBrains.Annotations
+{
+	/// <summary>
+	/// Indicates that the value of the marked element could be <c>null</c> sometimes,
+	/// so the check for <c>null</c> is necessary before its usage.
+	/// </summary>
+	/// <example><code>
+	/// [CanBeNull] object Test() => null;
+	/// 
+	/// void UseTest() {
+	///   var p = Test();
+	///   var s = p.ToString(); // Warning: Possible 'System.NullReferenceException'
+	/// }
+	/// </code></example>
+	[AttributeUsage(
+	  AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+	  AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event |
+	  AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.GenericParameter)]
+	internal sealed class CanBeNullAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that the value of the marked element could never be <c>null</c>.
+	/// </summary>
+	/// <example><code>
+	/// [NotNull] object Foo() {
+	///   return null; // Warning: Possible 'null' assignment
+	/// }
+	/// </code></example>
+	[AttributeUsage(
+	  AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+	  AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event |
+	  AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.GenericParameter)]
+	internal sealed class NotNullAttribute : Attribute { }
+
+	/// <summary>
+	/// Can be appplied to symbols of types derived from IEnumerable as well as to symbols of Task
+	/// and Lazy classes to indicate that the value of a collection item, of the Task.Result property
+	/// or of the Lazy.Value property can never be null.
+	/// </summary>
+	[AttributeUsage(
+	  AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+	  AttributeTargets.Delegate | AttributeTargets.Field)]
+	internal sealed class ItemNotNullAttribute : Attribute { }
+
+	/// <summary>
+	/// Can be appplied to symbols of types derived from IEnumerable as well as to symbols of Task
+	/// and Lazy classes to indicate that the value of a collection item, of the Task.Result property
+	/// or of the Lazy.Value property can be null.
+	/// </summary>
+	[AttributeUsage(
+	  AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+	  AttributeTargets.Delegate | AttributeTargets.Field)]
+	internal sealed class ItemCanBeNullAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that the marked method builds string by format pattern and (optional) arguments.
+	/// Parameter, which contains format string, should be given in constructor. The format string
+	/// should be in <see cref="string.Format(IFormatProvider,string,object[])"/>-like form.
+	/// </summary>
+	/// <example><code>
+	/// [StringFormatMethod("message")]
+	/// void ShowError(string message, params object[] args) { /* do something */ }
+	/// 
+	/// void Foo() {
+	///   ShowError("Failed: {0}"); // Warning: Non-existing argument in format string
+	/// }
+	/// </code></example>
+	[AttributeUsage(
+	  AttributeTargets.Constructor | AttributeTargets.Method |
+	  AttributeTargets.Property | AttributeTargets.Delegate)]
+	internal sealed class StringFormatMethodAttribute : Attribute
+	{
+		/// <param name="formatParameterName">
+		/// Specifies which parameter of an annotated method should be treated as format-string
+		/// </param>
+		public StringFormatMethodAttribute([NotNull] string formatParameterName)
+		{
+			FormatParameterName = formatParameterName;
+		}
+
+		[NotNull] public string FormatParameterName { get; private set; }
+	}
+
+	/// <summary>
+	/// For a parameter that is expected to be one of the limited set of values.
+	/// Specify fields of which type should be used as values for this parameter.
+	/// </summary>
+	[AttributeUsage(
+	  AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Field,
+	  AllowMultiple = true)]
+	internal sealed class ValueProviderAttribute : Attribute
+	{
+		public ValueProviderAttribute([NotNull] string name)
+		{
+			Name = name;
+		}
+
+		[NotNull] public string Name { get; private set; }
+	}
+
+	/// <summary>
+	/// Indicates that the function argument should be string literal and match one
+	/// of the parameters of the caller function. For example, ReSharper annotates
+	/// the parameter of <see cref="System.ArgumentNullException"/>.
+	/// </summary>
+	/// <example><code>
+	/// void Foo(string param) {
+	///   if (param == null)
+	///     throw new ArgumentNullException("par"); // Warning: Cannot resolve symbol
+	/// }
+	/// </code></example>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class InvokerParameterNameAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that the method is contained in a type that implements
+	/// <c>System.ComponentModel.INotifyPropertyChanged</c> interface and this method
+	/// is used to notify that some property value changed.
+	/// </summary>
+	/// <remarks>
+	/// The method should be non-static and conform to one of the supported signatures:
+	/// <list>
+	/// <item><c>NotifyChanged(string)</c></item>
+	/// <item><c>NotifyChanged(params string[])</c></item>
+	/// <item><c>NotifyChanged{T}(Expression{Func{T}})</c></item>
+	/// <item><c>NotifyChanged{T,U}(Expression{Func{T,U}})</c></item>
+	/// <item><c>SetProperty{T}(ref T, T, string)</c></item>
+	/// </list>
+	/// </remarks>
+	/// <example><code>
+	/// public class Foo : INotifyPropertyChanged {
+	///   public event PropertyChangedEventHandler PropertyChanged;
+	/// 
+	///   [NotifyPropertyChangedInvocator]
+	///   protected virtual void NotifyChanged(string propertyName) { ... }
+	///
+	///   string _name;
+	/// 
+	///   public string Name {
+	///     get { return _name; }
+	///     set { _name = value; NotifyChanged("LastName"); /* Warning */ }
+	///   }
+	/// }
+	/// </code>
+	/// Examples of generated notifications:
+	/// <list>
+	/// <item><c>NotifyChanged("Property")</c></item>
+	/// <item><c>NotifyChanged(() =&gt; Property)</c></item>
+	/// <item><c>NotifyChanged((VM x) =&gt; x.Property)</c></item>
+	/// <item><c>SetProperty(ref myField, value, "Property")</c></item>
+	/// </list>
+	/// </example>
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class NotifyPropertyChangedInvocatorAttribute : Attribute
+	{
+		public NotifyPropertyChangedInvocatorAttribute() { }
+		public NotifyPropertyChangedInvocatorAttribute([NotNull] string parameterName)
+		{
+			ParameterName = parameterName;
+		}
+
+		[CanBeNull] public string ParameterName { get; private set; }
+	}
+
+	/// <summary>
+	/// Describes dependency between method input and output.
+	/// </summary>
+	/// <syntax>
+	/// <p>Function Definition Table syntax:</p>
+	/// <list>
+	/// <item>FDT      ::= FDTRow [;FDTRow]*</item>
+	/// <item>FDTRow   ::= Input =&gt; Output | Output &lt;= Input</item>
+	/// <item>Input    ::= ParameterName: Value [, Input]*</item>
+	/// <item>Output   ::= [ParameterName: Value]* {halt|stop|void|nothing|Value}</item>
+	/// <item>Value    ::= true | false | null | notnull | canbenull</item>
+	/// </list>
+	/// If method has single input parameter, it's name could be omitted.<br/>
+	/// Using <c>halt</c> (or <c>void</c>/<c>nothing</c>, which is the same) for method output
+	/// means that the methos doesn't return normally (throws or terminates the process).<br/>
+	/// Value <c>canbenull</c> is only applicable for output parameters.<br/>
+	/// You can use multiple <c>[ContractAnnotation]</c> for each FDT row, or use single attribute
+	/// with rows separated by semicolon. There is no notion of order rows, all rows are checked
+	/// for applicability and applied per each program state tracked by R# analysis.<br/>
+	/// </syntax>
+	/// <examples><list>
+	/// <item><code>
+	/// [ContractAnnotation("=&gt; halt")]
+	/// public void TerminationMethod()
+	/// </code></item>
+	/// <item><code>
+	/// [ContractAnnotation("halt &lt;= condition: false")]
+	/// public void Assert(bool condition, string text) // regular assertion method
+	/// </code></item>
+	/// <item><code>
+	/// [ContractAnnotation("s:null =&gt; true")]
+	/// public bool IsNullOrEmpty(string s) // string.IsNullOrEmpty()
+	/// </code></item>
+	/// <item><code>
+	/// // A method that returns null if the parameter is null,
+	/// // and not null if the parameter is not null
+	/// [ContractAnnotation("null =&gt; null; notnull =&gt; notnull")]
+	/// public object Transform(object data) 
+	/// </code></item>
+	/// <item><code>
+	/// [ContractAnnotation("=&gt; true, result: notnull; =&gt; false, result: null")]
+	/// public bool TryParse(string s, out Person result)
+	/// </code></item>
+	/// </list></examples>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	internal sealed class ContractAnnotationAttribute : Attribute
+	{
+		public ContractAnnotationAttribute([NotNull] string contract)
+		  : this(contract, false) { }
+
+		public ContractAnnotationAttribute([NotNull] string contract, bool forceFullStates)
+		{
+			Contract = contract;
+			ForceFullStates = forceFullStates;
+		}
+
+		[NotNull] public string Contract { get; private set; }
+
+		public bool ForceFullStates { get; private set; }
+	}
+
+	/// <summary>
+	/// Indicates that marked element should be localized or not.
+	/// </summary>
+	/// <example><code>
+	/// [LocalizationRequiredAttribute(true)]
+	/// class Foo {
+	///   string str = "my string"; // Warning: Localizable string
+	/// }
+	/// </code></example>
+	[AttributeUsage(AttributeTargets.All)]
+	internal sealed class LocalizationRequiredAttribute : Attribute
+	{
+		public LocalizationRequiredAttribute() : this(true) { }
+
+		public LocalizationRequiredAttribute(bool required)
+		{
+			Required = required;
+		}
+
+		public bool Required { get; private set; }
+	}
+
+	/// <summary>
+	/// Indicates that the value of the marked type (or its derivatives)
+	/// cannot be compared using '==' or '!=' operators and <c>Equals()</c>
+	/// should be used instead. However, using '==' or '!=' for comparison
+	/// with <c>null</c> is always permitted.
+	/// </summary>
+	/// <example><code>
+	/// [CannotApplyEqualityOperator]
+	/// class NoEquality { }
+	/// 
+	/// class UsesNoEquality {
+	///   void Test() {
+	///     var ca1 = new NoEquality();
+	///     var ca2 = new NoEquality();
+	///     if (ca1 != null) { // OK
+	///       bool condition = ca1 == ca2; // Warning
+	///     }
+	///   }
+	/// }
+	/// </code></example>
+	[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class | AttributeTargets.Struct)]
+	internal sealed class CannotApplyEqualityOperatorAttribute : Attribute { }
+
+	/// <summary>
+	/// When applied to a target attribute, specifies a requirement for any type marked
+	/// with the target attribute to implement or inherit specific type or types.
+	/// </summary>
+	/// <example><code>
+	/// [BaseTypeRequired(typeof(IComponent)] // Specify requirement
+	/// class ComponentAttribute : Attribute { }
+	/// 
+	/// [Component] // ComponentAttribute requires implementing IComponent interface
+	/// class MyComponent : IComponent { }
+	/// </code></example>
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+	[BaseTypeRequired(typeof(Attribute))]
+	internal sealed class BaseTypeRequiredAttribute : Attribute
+	{
+		public BaseTypeRequiredAttribute([NotNull] Type baseType)
+		{
+			BaseType = baseType;
+		}
+
+		[NotNull] public Type BaseType { get; private set; }
+	}
+
+	/// <summary>
+	/// Indicates that the marked symbol is used implicitly (e.g. via reflection, in external library),
+	/// so this symbol will not be marked as unused (as well as by other usage inspections).
+	/// </summary>
+	[AttributeUsage(AttributeTargets.All)]
+	internal sealed class UsedImplicitlyAttribute : Attribute
+	{
+		public UsedImplicitlyAttribute()
+		  : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+		public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags)
+		  : this(useKindFlags, ImplicitUseTargetFlags.Default) { }
+
+		public UsedImplicitlyAttribute(ImplicitUseTargetFlags targetFlags)
+		  : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+		public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+		{
+			UseKindFlags = useKindFlags;
+			TargetFlags = targetFlags;
+		}
+
+		public ImplicitUseKindFlags UseKindFlags { get; private set; }
+
+		public ImplicitUseTargetFlags TargetFlags { get; private set; }
+	}
+
+	/// <summary>
+	/// Should be used on attributes and causes ReSharper to not mark symbols marked with such attributes
+	/// as unused (as well as by other usage inspections)
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.GenericParameter)]
+	internal sealed class MeansImplicitUseAttribute : Attribute
+	{
+		public MeansImplicitUseAttribute()
+		  : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+		public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags)
+		  : this(useKindFlags, ImplicitUseTargetFlags.Default) { }
+
+		public MeansImplicitUseAttribute(ImplicitUseTargetFlags targetFlags)
+		  : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+		public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+		{
+			UseKindFlags = useKindFlags;
+			TargetFlags = targetFlags;
+		}
+
+		[UsedImplicitly] public ImplicitUseKindFlags UseKindFlags { get; private set; }
+
+		[UsedImplicitly] public ImplicitUseTargetFlags TargetFlags { get; private set; }
+	}
+
+	[Flags]
+	internal enum ImplicitUseKindFlags
+	{
+		Default = Access | Assign | InstantiatedWithFixedConstructorSignature,
+		/// <summary>Only entity marked with attribute considered used.</summary>
+		Access = 1,
+		/// <summary>Indicates implicit assignment to a member.</summary>
+		Assign = 2,
+		/// <summary>
+		/// Indicates implicit instantiation of a type with fixed constructor signature.
+		/// That means any unused constructor parameters won't be reported as such.
+		/// </summary>
+		InstantiatedWithFixedConstructorSignature = 4,
+		/// <summary>Indicates implicit instantiation of a type.</summary>
+		InstantiatedNoFixedConstructorSignature = 8,
+	}
+
+	/// <summary>
+	/// Specify what is considered used implicitly when marked
+	/// with <see cref="MeansImplicitUseAttribute"/> or <see cref="UsedImplicitlyAttribute"/>.
+	/// </summary>
+	[Flags]
+	internal enum ImplicitUseTargetFlags
+	{
+		Default = Itself,
+		Itself = 1,
+		/// <summary>Members of entity marked with attribute are considered used.</summary>
+		Members = 2,
+		/// <summary>Entity marked with attribute and all its members considered used.</summary>
+		WithMembers = Itself | Members
+	}
+
+	/// <summary>
+	/// This attribute is intended to mark publicly available API
+	/// which should not be removed and so is treated as used.
+	/// </summary>
+	[MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
+	internal sealed class PublicAPIAttribute : Attribute
+	{
+		public PublicAPIAttribute() { }
+
+		public PublicAPIAttribute([NotNull] string comment)
+		{
+			Comment = comment;
+		}
+
+		[CanBeNull] public string Comment { get; private set; }
+	}
+
+	/// <summary>
+	/// Tells code analysis engine if the parameter is completely handled when the invoked method is on stack.
+	/// If the parameter is a delegate, indicates that delegate is executed while the method is executed.
+	/// If the parameter is an enumerable, indicates that it is enumerated while the method is executed.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class InstantHandleAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that a method does not make any observable state changes.
+	/// The same as <c>System.Diagnostics.Contracts.PureAttribute</c>.
+	/// </summary>
+	/// <example><code>
+	/// [Pure] int Multiply(int x, int y) => x * y;
+	/// 
+	/// void M() {
+	///   Multiply(123, 42); // Waring: Return value of pure method is not used
+	/// }
+	/// </code></example>
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class PureAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that the return value of method invocation must be used.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class MustUseReturnValueAttribute : Attribute
+	{
+		public MustUseReturnValueAttribute() { }
+
+		public MustUseReturnValueAttribute([NotNull] string justification)
+		{
+			Justification = justification;
+		}
+
+		[CanBeNull] public string Justification { get; private set; }
+	}
+
+	/// <summary>
+	/// Indicates the type member or parameter of some type, that should be used instead of all other ways
+	/// to get the value that type. This annotation is useful when you have some "context" value evaluated
+	/// and stored somewhere, meaning that all other ways to get this value must be consolidated with existing one.
+	/// </summary>
+	/// <example><code>
+	/// class Foo {
+	///   [ProvidesContext] IBarService _barService = ...;
+	/// 
+	///   void ProcessNode(INode node) {
+	///     DoSomething(node, node.GetGlobalServices().Bar);
+	///     //              ^ Warning: use value of '_barService' field
+	///   }
+	/// }
+	/// </code></example>
+	[AttributeUsage(
+	  AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.Method |
+	  AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.GenericParameter)]
+	internal sealed class ProvidesContextAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that a parameter is a path to a file or a folder within a web project.
+	/// Path can be relative or absolute, starting from web root (~).
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class PathReferenceAttribute : Attribute
+	{
+		public PathReferenceAttribute() { }
+
+		public PathReferenceAttribute([NotNull, PathReference] string basePath)
+		{
+			BasePath = basePath;
+		}
+
+		[CanBeNull] public string BasePath { get; private set; }
+	}
+
+	/// <summary>
+	/// An extension method marked with this attribute is processed by ReSharper code completion
+	/// as a 'Source Template'. When extension method is completed over some expression, it's source code
+	/// is automatically expanded like a template at call site.
+	/// </summary>
+	/// <remarks>
+	/// Template method body can contain valid source code and/or special comments starting with '$'.
+	/// Text inside these comments is added as source code when the template is applied. Template parameters
+	/// can be used either as additional method parameters or as identifiers wrapped in two '$' signs.
+	/// Use the <see cref="MacroAttribute"/> attribute to specify macros for parameters.
+	/// </remarks>
+	/// <example>
+	/// In this example, the 'forEach' method is a source template available over all values
+	/// of enumerable types, producing ordinary C# 'foreach' statement and placing caret inside block:
+	/// <code>
+	/// [SourceTemplate]
+	/// public static void forEach&lt;T&gt;(this IEnumerable&lt;T&gt; xs) {
+	///   foreach (var x in xs) {
+	///      //$ $END$
+	///   }
+	/// }
+	/// </code>
+	/// </example>
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class SourceTemplateAttribute : Attribute { }
+
+	/// <summary>
+	/// Allows specifying a macro for a parameter of a <see cref="SourceTemplateAttribute">source template</see>.
+	/// </summary>
+	/// <remarks>
+	/// You can apply the attribute on the whole method or on any of its additional parameters. The macro expression
+	/// is defined in the <see cref="MacroAttribute.Expression"/> property. When applied on a method, the target
+	/// template parameter is defined in the <see cref="MacroAttribute.Target"/> property. To apply the macro silently
+	/// for the parameter, set the <see cref="MacroAttribute.Editable"/> property value = -1.
+	/// </remarks>
+	/// <example>
+	/// Applying the attribute on a source template method:
+	/// <code>
+	/// [SourceTemplate, Macro(Target = "item", Expression = "suggestVariableName()")]
+	/// public static void forEach&lt;T&gt;(this IEnumerable&lt;T&gt; collection) {
+	///   foreach (var item in collection) {
+	///     //$ $END$
+	///   }
+	/// }
+	/// </code>
+	/// Applying the attribute on a template method parameter:
+	/// <code>
+	/// [SourceTemplate]
+	/// public static void something(this Entity x, [Macro(Expression = "guid()", Editable = -1)] string newguid) {
+	///   /*$ var $x$Id = "$newguid$" + x.ToString();
+	///   x.DoSomething($x$Id); */
+	/// }
+	/// </code>
+	/// </example>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method, AllowMultiple = true)]
+	internal sealed class MacroAttribute : Attribute
+	{
+		/// <summary>
+		/// Allows specifying a macro that will be executed for a <see cref="SourceTemplateAttribute">source template</see>
+		/// parameter when the template is expanded.
+		/// </summary>
+		[CanBeNull] public string Expression { get; set; }
+
+		/// <summary>
+		/// Allows specifying which occurrence of the target parameter becomes editable when the template is deployed.
+		/// </summary>
+		/// <remarks>
+		/// If the target parameter is used several times in the template, only one occurrence becomes editable;
+		/// other occurrences are changed synchronously. To specify the zero-based index of the editable occurrence,
+		/// use values >= 0. To make the parameter non-editable when the template is expanded, use -1.
+		/// </remarks>>
+		public int Editable { get; set; }
+
+		/// <summary>
+		/// Identifies the target parameter of a <see cref="SourceTemplateAttribute">source template</see> if the
+		/// <see cref="MacroAttribute"/> is applied on a template method.
+		/// </summary>
+		[CanBeNull] public string Target { get; set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+	internal sealed class AspMvcAreaMasterLocationFormatAttribute : Attribute
+	{
+		public AspMvcAreaMasterLocationFormatAttribute([NotNull] string format)
+		{
+			Format = format;
+		}
+
+		[NotNull] public string Format { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+	internal sealed class AspMvcAreaPartialViewLocationFormatAttribute : Attribute
+	{
+		public AspMvcAreaPartialViewLocationFormatAttribute([NotNull] string format)
+		{
+			Format = format;
+		}
+
+		[NotNull] public string Format { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+	internal sealed class AspMvcAreaViewLocationFormatAttribute : Attribute
+	{
+		public AspMvcAreaViewLocationFormatAttribute([NotNull] string format)
+		{
+			Format = format;
+		}
+
+		[NotNull] public string Format { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+	internal sealed class AspMvcMasterLocationFormatAttribute : Attribute
+	{
+		public AspMvcMasterLocationFormatAttribute([NotNull] string format)
+		{
+			Format = format;
+		}
+
+		[NotNull] public string Format { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+	internal sealed class AspMvcPartialViewLocationFormatAttribute : Attribute
+	{
+		public AspMvcPartialViewLocationFormatAttribute([NotNull] string format)
+		{
+			Format = format;
+		}
+
+		[NotNull] public string Format { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+	internal sealed class AspMvcViewLocationFormatAttribute : Attribute
+	{
+		public AspMvcViewLocationFormatAttribute([NotNull] string format)
+		{
+			Format = format;
+		}
+
+		[NotNull] public string Format { get; private set; }
+	}
+
+	/// <summary>
+	/// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+	/// is an MVC action. If applied to a method, the MVC action name is calculated
+	/// implicitly from the context. Use this attribute for custom wrappers similar to
+	/// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+	internal sealed class AspMvcActionAttribute : Attribute
+	{
+		public AspMvcActionAttribute() { }
+
+		public AspMvcActionAttribute([NotNull] string anonymousProperty)
+		{
+			AnonymousProperty = anonymousProperty;
+		}
+
+		[CanBeNull] public string AnonymousProperty { get; private set; }
+	}
+
+	/// <summary>
+	/// ASP.NET MVC attribute. Indicates that a parameter is an MVC area.
+	/// Use this attribute for custom wrappers similar to
+	/// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class AspMvcAreaAttribute : Attribute
+	{
+		public AspMvcAreaAttribute() { }
+
+		public AspMvcAreaAttribute([NotNull] string anonymousProperty)
+		{
+			AnonymousProperty = anonymousProperty;
+		}
+
+		[CanBeNull] public string AnonymousProperty { get; private set; }
+	}
+
+	/// <summary>
+	/// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter is
+	/// an MVC controller. If applied to a method, the MVC controller name is calculated
+	/// implicitly from the context. Use this attribute for custom wrappers similar to
+	/// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String, String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+	internal sealed class AspMvcControllerAttribute : Attribute
+	{
+		public AspMvcControllerAttribute() { }
+
+		public AspMvcControllerAttribute([NotNull] string anonymousProperty)
+		{
+			AnonymousProperty = anonymousProperty;
+		}
+
+		[CanBeNull] public string AnonymousProperty { get; private set; }
+	}
+
+	/// <summary>
+	/// ASP.NET MVC attribute. Indicates that a parameter is an MVC Master. Use this attribute
+	/// for custom wrappers similar to <c>System.Web.Mvc.Controller.View(String, String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class AspMvcMasterAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. Indicates that a parameter is an MVC model type. Use this attribute
+	/// for custom wrappers similar to <c>System.Web.Mvc.Controller.View(String, Object)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class AspMvcModelTypeAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter is an MVC
+	/// partial view. If applied to a method, the MVC partial view name is calculated implicitly
+	/// from the context. Use this attribute for custom wrappers similar to
+	/// <c>System.Web.Mvc.Html.RenderPartialExtensions.RenderPartial(HtmlHelper, String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+	internal sealed class AspMvcPartialViewAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. Allows disabling inspections for MVC views within a class or a method.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+	internal sealed class AspMvcSuppressViewErrorAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. Indicates that a parameter is an MVC display template.
+	/// Use this attribute for custom wrappers similar to 
+	/// <c>System.Web.Mvc.Html.DisplayExtensions.DisplayForModel(HtmlHelper, String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class AspMvcDisplayTemplateAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. Indicates that a parameter is an MVC editor template.
+	/// Use this attribute for custom wrappers similar to
+	/// <c>System.Web.Mvc.Html.EditorExtensions.EditorForModel(HtmlHelper, String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class AspMvcEditorTemplateAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. Indicates that a parameter is an MVC template.
+	/// Use this attribute for custom wrappers similar to
+	/// <c>System.ComponentModel.DataAnnotations.UIHintAttribute(System.String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class AspMvcTemplateAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+	/// is an MVC view component. If applied to a method, the MVC view name is calculated implicitly
+	/// from the context. Use this attribute for custom wrappers similar to
+	/// <c>System.Web.Mvc.Controller.View(Object)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+	internal sealed class AspMvcViewAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+	/// is an MVC view component name.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class AspMvcViewComponentAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+	/// is an MVC view component view. If applied to a method, the MVC view component view name is default.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+	internal sealed class AspMvcViewComponentViewAttribute : Attribute { }
+
+	/// <summary>
+	/// ASP.NET MVC attribute. When applied to a parameter of an attribute,
+	/// indicates that this parameter is an MVC action name.
+	/// </summary>
+	/// <example><code>
+	/// [ActionName("Foo")]
+	/// public ActionResult Login(string returnUrl) {
+	///   ViewBag.ReturnUrl = Url.Action("Foo"); // OK
+	///   return RedirectToAction("Bar"); // Error: Cannot resolve action
+	/// }
+	/// </code></example>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+	internal sealed class AspMvcActionSelectorAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Field)]
+	internal sealed class HtmlElementAttributesAttribute : Attribute
+	{
+		public HtmlElementAttributesAttribute() { }
+
+		public HtmlElementAttributesAttribute([NotNull] string name)
+		{
+			Name = name;
+		}
+
+		[CanBeNull] public string Name { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property)]
+	internal sealed class HtmlAttributeValueAttribute : Attribute
+	{
+		public HtmlAttributeValueAttribute([NotNull] string name)
+		{
+			Name = name;
+		}
+
+		[NotNull] public string Name { get; private set; }
+	}
+
+	/// <summary>
+	/// Razor attribute. Indicates that a parameter or a method is a Razor section.
+	/// Use this attribute for custom wrappers similar to 
+	/// <c>System.Web.WebPages.WebPageBase.RenderSection(String)</c>.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+	internal sealed class RazorSectionAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates how method, constructor invocation or property access
+	/// over collection type affects content of the collection.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property)]
+	internal sealed class CollectionAccessAttribute : Attribute
+	{
+		public CollectionAccessAttribute(CollectionAccessType collectionAccessType)
+		{
+			CollectionAccessType = collectionAccessType;
+		}
+
+		public CollectionAccessType CollectionAccessType { get; private set; }
+	}
+
+	[Flags]
+	internal enum CollectionAccessType
+	{
+		/// <summary>Method does not use or modify content of the collection.</summary>
+		None = 0,
+		/// <summary>Method only reads content of the collection but does not modify it.</summary>
+		Read = 1,
+		/// <summary>Method can change content of the collection but does not add new elements.</summary>
+		ModifyExistingContent = 2,
+		/// <summary>Method can add new elements to the collection.</summary>
+		UpdatedContent = ModifyExistingContent | 4
+	}
+
+	/// <summary>
+	/// Indicates that the marked method is assertion method, i.e. it halts control flow if
+	/// one of the conditions is satisfied. To set the condition, mark one of the parameters with 
+	/// <see cref="AssertionConditionAttribute"/> attribute.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class AssertionMethodAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates the condition parameter of the assertion method. The method itself should be
+	/// marked by <see cref="AssertionMethodAttribute"/> attribute. The mandatory argument of
+	/// the attribute is the assertion type.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class AssertionConditionAttribute : Attribute
+	{
+		public AssertionConditionAttribute(AssertionConditionType conditionType)
+		{
+			ConditionType = conditionType;
+		}
+
+		public AssertionConditionType ConditionType { get; private set; }
+	}
+
+	/// <summary>
+	/// Specifies assertion type. If the assertion method argument satisfies the condition,
+	/// then the execution continues. Otherwise, execution is assumed to be halted.
+	/// </summary>
+	internal enum AssertionConditionType
+	{
+		/// <summary>Marked parameter should be evaluated to true.</summary>
+		IS_TRUE = 0,
+		/// <summary>Marked parameter should be evaluated to false.</summary>
+		IS_FALSE = 1,
+		/// <summary>Marked parameter should be evaluated to null value.</summary>
+		IS_NULL = 2,
+		/// <summary>Marked parameter should be evaluated to not null value.</summary>
+		IS_NOT_NULL = 3,
+	}
+
+	/// <summary>
+	/// Indicates that the marked method unconditionally terminates control flow execution.
+	/// For example, it could unconditionally throw exception.
+	/// </summary>
+	[Obsolete("Use [ContractAnnotation('=> halt')] instead")]
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class TerminatesProgramAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that method is pure LINQ method, with postponed enumeration (like Enumerable.Select,
+	/// .Where). This annotation allows inference of [InstantHandle] annotation for parameters
+	/// of delegate type by analyzing LINQ method chains.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class LinqTunnelAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that IEnumerable, passed as parameter, is not enumerated.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class NoEnumerationAttribute : Attribute { }
+
+	/// <summary>
+	/// Indicates that parameter is regular expression pattern.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class RegexPatternAttribute : Attribute { }
+
+	/// <summary>
+	/// Prevents the Member Reordering feature from tossing members of the marked class.
+	/// </summary>
+	/// <remarks>
+	/// The attribute must be mentioned in your member reordering patterns
+	/// </remarks>
+	[AttributeUsage(
+	  AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Enum)]
+	internal sealed class NoReorderAttribute : Attribute { }
+
+	/// <summary>
+	/// XAML attribute. Indicates the type that has <c>ItemsSource</c> property and should be treated
+	/// as <c>ItemsControl</c>-derived type, to enable inner items <c>DataContext</c> type resolve.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class)]
+	internal sealed class XamlItemsControlAttribute : Attribute { }
+
+	/// <summary>
+	/// XAML attribute. Indicates the property of some <c>BindingBase</c>-derived type, that
+	/// is used to bind some item of <c>ItemsControl</c>-derived type. This annotation will
+	/// enable the <c>DataContext</c> type resolve for XAML bindings for such properties.
+	/// </summary>
+	/// <remarks>
+	/// Property should have the tree ancestor of the <c>ItemsControl</c> type or
+	/// marked with the <see cref="XamlItemsControlAttribute"/> attribute.
+	/// </remarks>
+	[AttributeUsage(AttributeTargets.Property)]
+	internal sealed class XamlItemBindingOfItemsControlAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+	internal sealed class AspChildControlTypeAttribute : Attribute
+	{
+		public AspChildControlTypeAttribute([NotNull] string tagName, [NotNull] Type controlType)
+		{
+			TagName = tagName;
+			ControlType = controlType;
+		}
+
+		[NotNull] public string TagName { get; private set; }
+
+		[NotNull] public Type ControlType { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
+	internal sealed class AspDataFieldAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
+	internal sealed class AspDataFieldsAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Property)]
+	internal sealed class AspMethodPropertyAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+	internal sealed class AspRequiredAttributeAttribute : Attribute
+	{
+		public AspRequiredAttributeAttribute([NotNull] string attribute)
+		{
+			Attribute = attribute;
+		}
+
+		[NotNull] public string Attribute { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Property)]
+	internal sealed class AspTypePropertyAttribute : Attribute
+	{
+		public bool CreateConstructorReferences { get; private set; }
+
+		public AspTypePropertyAttribute(bool createConstructorReferences)
+		{
+			CreateConstructorReferences = createConstructorReferences;
+		}
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	internal sealed class RazorImportNamespaceAttribute : Attribute
+	{
+		public RazorImportNamespaceAttribute([NotNull] string name)
+		{
+			Name = name;
+		}
+
+		[NotNull] public string Name { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	internal sealed class RazorInjectionAttribute : Attribute
+	{
+		public RazorInjectionAttribute([NotNull] string type, [NotNull] string fieldName)
+		{
+			Type = type;
+			FieldName = fieldName;
+		}
+
+		[NotNull] public string Type { get; private set; }
+
+		[NotNull] public string FieldName { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	internal sealed class RazorDirectiveAttribute : Attribute
+	{
+		public RazorDirectiveAttribute([NotNull] string directive)
+		{
+			Directive = directive;
+		}
+
+		[NotNull] public string Directive { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	internal sealed class RazorPageBaseTypeAttribute : Attribute
+	{
+		public RazorPageBaseTypeAttribute([NotNull] string baseType)
+		{
+			BaseType = baseType;
+		}
+		public RazorPageBaseTypeAttribute([NotNull] string baseType, string pageName)
+		{
+			BaseType = baseType;
+			PageName = pageName;
+		}
+
+		[NotNull] public string BaseType { get; private set; }
+		[CanBeNull] public string PageName { get; private set; }
+	}
+
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class RazorHelperCommonAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Property)]
+	internal sealed class RazorLayoutAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class RazorWriteLiteralMethodAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Method)]
+	internal sealed class RazorWriteMethodAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Parameter)]
+	internal sealed class RazorWriteMethodParameterAttribute : Attribute { }
+}

--- a/Lib.Web.Mvc/Lib.Web.Mvc.csproj
+++ b/Lib.Web.Mvc/Lib.Web.Mvc.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Http\CacheDigestValue.cs" />
     <Compile Include="Http\EntityTagGenerator.cs" />
     <Compile Include="Http\RequestHeaders.cs" />
+    <Compile Include="JetBrains.Annotations.cs" />
     <Compile Include="JQuery\JqGrid\Constants\JqGridColumnPredefinedFormatters.cs" />
     <Compile Include="JQuery\JqGrid\Constants\JqGridFilterToolbarDefaults.cs" />
     <Compile Include="JQuery\JqGrid\Constants\JqGridNavigatorDefaults.cs" />
@@ -63,8 +64,10 @@
     <Compile Include="JQuery\JqGrid\Constants\JQueryUIWidgetsDefaults.cs" />
     <Compile Include="JQuery\JqGrid\IJqGridHelper.cs" />
     <Compile Include="JQuery\JqGrid\IJqGridNavigatorPageableFormActionOptions.cs" />
+    <Compile Include="JQuery\JqGrid\JqGridBootstrap4IconSet.cs" />
     <Compile Include="JQuery\JqGrid\JqGridColumnSortTypes.cs" />
     <Compile Include="JQuery\JqGrid\JqGridCompatibilityModes.cs" />
+    <Compile Include="JQuery\JqGrid\JqGridExtendColumnModel.cs" />
     <Compile Include="JQuery\JqGrid\JqGridFormButtonIcon.cs" />
     <Compile Include="JQuery\JqGrid\JqGridFormButtonIconPositions.cs" />
     <Compile Include="JQuery\JqGrid\JqGridFormKeyboardNavigation.cs" />
@@ -152,6 +155,7 @@
     <Compile Include="JQuery\JqGrid\ModelBinders\JqGridRequestModelBinder.cs" />
     <Compile Include="JQuery\JqGrid\JqGridColumnEditTypes.cs" />
     <Compile Include="JQuery\JqGrid\Serialization\JqGridScriptConverter.cs" />
+    <Compile Include="JQuery\JqGrid\SettedString.cs" />
     <Compile Include="JQuery\TreeView\TreeViewNode.cs" />
     <Compile Include="NoCacheAttribute.cs" />
     <Compile Include="NoAjaxRequestAttribute.cs" />
@@ -166,9 +170,8 @@
     <Compile Include="XmlActionResult.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Projekty\TPeczek.Blog.ContentSecurityPolicy\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Web.Infrastructure">
+      <HintPath>..\..\..\Lib.Web.Mvc\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -177,28 +180,22 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Projekty\Demo.AspNet.Mvc.Http2\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.4\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Projekty\Demo.AspNet.Mvc.Http2\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Mvc, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.4\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Projekty\Demo.AspNet.Mvc.Http2\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.4\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Projekty\Demo.AspNet.Mvc.Http2\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.4\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Projekty\Demo.AspNet.Mvc.Http2\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.4\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Projekty\Demo.AspNet.Mvc.Http2\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.4\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.XML" />
   </ItemGroup>

--- a/Lib.Web.Mvc/packages.config
+++ b/Lib.Web.Mvc/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.4" targetFramework="net46" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.4" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net46" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Hello!
Some developers changing default values of JqGrid in JavaScript. 
Example:
```javascript
$.jqgid.default.cmTemplate = { align: 'center' };
```
And if deleloper wants to set aligment in one column to Left, with you library that doesn't work.
I did so that for every option JavaSctipt generetes only if option was setted. I did it for options in ColumnModel (and it dependensies) and JqGridOptions.

The truth is, there are disadvantages:
- If we set Editable, Searchable or Sortable attributes, JavaScript for this options always generates.
- JqGridHelper constructor with multiple parametres generate more redurant JavaScript code. I mark them as Obsolete. And create new constructor with JqGridOption as parameter.
- I changed behavior of JsonReader and ParameterNames. In static fields they uses only for Requests and Responses (global scope). In JqGridOption uses to set different than global values for Grid. And if we change something in JsonReader/ParametersNames in global scope, we need to change default values for JqGrid in JavaScript.

Other changes:
- Added Bootstrap 4 support and IconSets for it.
- In JqGridOptions added static field DefaultCompatibilityMode. If we use in whole project only Gurido JqGrid we don't need anymore define Compatibility mode for every grid.
- Seeding ColumnModel now in base JqGridOption class with method SetModel. Generic version of JqGridOption leaved for compatibility.
- For attributes Editable, Searchable removed bool parameter in constructors where we set additional fields. I decided if we sets this parameters, that that field is Editable/Searchable. In other constructors for bool value added default value.
- Added new fluent API method ExtendColumnOptions. That method gives us to some options that we can't set in attributes.
- Added support JetBrains.Annotations.

I broke one of the rules of contributing. I did many code refactoring (with support JetBrains Resharper):
- Removed unused usings.
- Changed variable declarations to var. (I like to using var in code)
- Changed code style to C# 7.2
- Changed spaces to tabs